### PR TITLE
feat(pacs): implement DICOM C-FIND query functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,11 +143,17 @@ target_link_libraries(measurement_service PUBLIC
 
 add_library(pacs_service STATIC
     src/services/pacs/dicom_echo_scu.cpp
+    src/services/pacs/dicom_find_scu.cpp
 )
 
 target_include_directories(pacs_service PUBLIC
     ${CMAKE_SOURCE_DIR}/include
     ${DCMTK_INCLUDE_DIRS}
+)
+
+target_link_directories(pacs_service PUBLIC
+    ${DCMTK_LIBRARY_DIRS}
+    /opt/homebrew/lib
 )
 
 target_link_libraries(pacs_service PUBLIC

--- a/include/services/dicom_find_scu.hpp
+++ b/include/services/dicom_find_scu.hpp
@@ -1,0 +1,295 @@
+#pragma once
+
+#include "pacs_config.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <expected>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+// Forward declare PacsErrorInfo from dicom_echo_scu.hpp
+namespace dicom_viewer::services {
+struct PacsErrorInfo;
+}
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Query/Retrieve Information Model root
+ */
+enum class QueryRoot {
+    PatientRoot,  ///< Patient Root Q/R Information Model
+    StudyRoot     ///< Study Root Q/R Information Model
+};
+
+/**
+ * @brief Query level within the hierarchy
+ */
+enum class QueryLevel {
+    Patient,  ///< Patient level query
+    Study,    ///< Study level query
+    Series,   ///< Series level query
+    Image     ///< Image (Instance) level query
+};
+
+/**
+ * @brief Date range for query filtering
+ */
+struct DateRange {
+    std::optional<std::string> from;  ///< Start date (YYYYMMDD format)
+    std::optional<std::string> to;    ///< End date (YYYYMMDD format)
+
+    /**
+     * @brief Create a single date query
+     */
+    static DateRange singleDate(const std::string& date) {
+        return DateRange{date, date};
+    }
+
+    /**
+     * @brief Create an open-ended date range (from date onwards)
+     */
+    static DateRange fromDate(const std::string& date) {
+        return DateRange{date, std::nullopt};
+    }
+
+    /**
+     * @brief Create a date range up to a specific date
+     */
+    static DateRange toDate(const std::string& date) {
+        return DateRange{std::nullopt, date};
+    }
+
+    /**
+     * @brief Convert to DICOM date range format
+     */
+    [[nodiscard]] std::string toDicomFormat() const;
+};
+
+/**
+ * @brief Query parameters for C-FIND operations
+ *
+ * Supports wildcards (*) for pattern matching in string fields.
+ * Date fields support range queries using DateRange.
+ */
+struct FindQuery {
+    /// Query root (Patient or Study)
+    QueryRoot root = QueryRoot::PatientRoot;
+
+    /// Query level
+    QueryLevel level = QueryLevel::Study;
+
+    /// Patient Name (0010,0010) - supports wildcards
+    std::optional<std::string> patientName;
+
+    /// Patient ID (0010,0020)
+    std::optional<std::string> patientId;
+
+    /// Patient Birth Date (0010,0030)
+    std::optional<DateRange> patientBirthDate;
+
+    /// Study Date (0008,0020)
+    std::optional<DateRange> studyDate;
+
+    /// Study Description (0008,1030)
+    std::optional<std::string> studyDescription;
+
+    /// Study Instance UID (0020,000D)
+    std::optional<std::string> studyInstanceUid;
+
+    /// Accession Number (0008,0050)
+    std::optional<std::string> accessionNumber;
+
+    /// Modality (0008,0060)
+    std::optional<std::string> modality;
+
+    /// Modalities in Study (0008,0061)
+    std::optional<std::string> modalitiesInStudy;
+
+    /// Series Instance UID (0020,000E)
+    std::optional<std::string> seriesInstanceUid;
+
+    /// Series Number (0020,0011)
+    std::optional<int32_t> seriesNumber;
+
+    /// Series Description (0008,103E)
+    std::optional<std::string> seriesDescription;
+
+    /// SOP Instance UID (0008,0018)
+    std::optional<std::string> sopInstanceUid;
+
+    /// Instance Number (0020,0013)
+    std::optional<int32_t> instanceNumber;
+};
+
+/**
+ * @brief Patient-level query result
+ */
+struct PatientResult {
+    std::string patientId;        ///< Patient ID (0010,0020)
+    std::string patientName;      ///< Patient Name (0010,0010)
+    std::string patientBirthDate; ///< Birth Date (0010,0030)
+    std::string patientSex;       ///< Patient Sex (0010,0040)
+    int32_t numberOfStudies = 0;  ///< Number of Patient Related Studies (0020,1200)
+};
+
+/**
+ * @brief Study-level query result
+ */
+struct StudyResult {
+    std::string studyInstanceUid;  ///< Study Instance UID (0020,000D)
+    std::string studyDate;         ///< Study Date (0008,0020)
+    std::string studyTime;         ///< Study Time (0008,0030)
+    std::string studyDescription;  ///< Study Description (0008,1030)
+    std::string accessionNumber;   ///< Accession Number (0008,0050)
+    std::string referringPhysician;///< Referring Physician's Name (0008,0090)
+    std::string patientId;         ///< Patient ID (0010,0020)
+    std::string patientName;       ///< Patient Name (0010,0010)
+    std::string modalitiesInStudy; ///< Modalities in Study (0008,0061)
+    int32_t numberOfSeries = 0;    ///< Number of Study Related Series (0020,1206)
+    int32_t numberOfInstances = 0; ///< Number of Study Related Instances (0020,1208)
+};
+
+/**
+ * @brief Series-level query result
+ */
+struct SeriesResult {
+    std::string seriesInstanceUid; ///< Series Instance UID (0020,000E)
+    std::string studyInstanceUid;  ///< Study Instance UID (0020,000D)
+    std::string modality;          ///< Modality (0008,0060)
+    int32_t seriesNumber = 0;      ///< Series Number (0020,0011)
+    std::string seriesDescription; ///< Series Description (0008,103E)
+    std::string seriesDate;        ///< Series Date (0008,0021)
+    std::string seriesTime;        ///< Series Time (0008,0031)
+    std::string bodyPartExamined;  ///< Body Part Examined (0018,0015)
+    int32_t numberOfInstances = 0; ///< Number of Series Related Instances (0020,1209)
+};
+
+/**
+ * @brief Image (Instance) level query result
+ */
+struct ImageResult {
+    std::string sopInstanceUid;    ///< SOP Instance UID (0008,0018)
+    std::string sopClassUid;       ///< SOP Class UID (0008,0016)
+    std::string seriesInstanceUid; ///< Series Instance UID (0020,000E)
+    int32_t instanceNumber = 0;    ///< Instance Number (0020,0013)
+    std::string contentDate;       ///< Content Date (0008,0023)
+    std::string contentTime;       ///< Content Time (0008,0033)
+};
+
+/**
+ * @brief Result of a C-FIND query operation
+ */
+struct FindResult {
+    /// Query latency
+    std::chrono::milliseconds latency{0};
+
+    /// Patient-level results (when query level is Patient)
+    std::vector<PatientResult> patients;
+
+    /// Study-level results (when query level is Study)
+    std::vector<StudyResult> studies;
+
+    /// Series-level results (when query level is Series)
+    std::vector<SeriesResult> series;
+
+    /// Image-level results (when query level is Image)
+    std::vector<ImageResult> images;
+
+    /**
+     * @brief Get total number of results across all levels
+     */
+    [[nodiscard]] size_t totalCount() const {
+        return patients.size() + studies.size() + series.size() + images.size();
+    }
+};
+
+/**
+ * @brief DICOM C-FIND Service Class User (SCU)
+ *
+ * Implements the DICOM Query/Retrieve Service Classes for searching
+ * patient/study/series/image data on PACS servers.
+ *
+ * Supports:
+ * - Patient Root Query/Retrieve Information Model - FIND (1.2.840.10008.5.1.4.1.2.1.1)
+ * - Study Root Query/Retrieve Information Model - FIND (1.2.840.10008.5.1.4.1.2.2.1)
+ *
+ * @example
+ * @code
+ * DicomFindSCU finder;
+ * PacsServerConfig config;
+ * config.hostname = "pacs.hospital.com";
+ * config.port = 104;
+ * config.calledAeTitle = "PACS_SERVER";
+ *
+ * FindQuery query;
+ * query.root = QueryRoot::StudyRoot;
+ * query.level = QueryLevel::Study;
+ * query.patientName = "SMITH*";
+ * query.studyDate = DateRange::fromDate("20240101");
+ *
+ * auto result = finder.find(config, query);
+ * if (result) {
+ *     for (const auto& study : result->studies) {
+ *         std::cout << "Study: " << study.studyDescription << "\n";
+ *     }
+ * } else {
+ *     std::cerr << "Query failed: " << result.error().toString() << "\n";
+ * }
+ * @endcode
+ *
+ * @trace SRS-FR-035
+ */
+class DicomFindSCU {
+public:
+    /// Patient Root Query/Retrieve Information Model - FIND SOP Class UID
+    static constexpr const char* PATIENT_ROOT_FIND_SOP_CLASS_UID =
+        "1.2.840.10008.5.1.4.1.2.1.1";
+
+    /// Study Root Query/Retrieve Information Model - FIND SOP Class UID
+    static constexpr const char* STUDY_ROOT_FIND_SOP_CLASS_UID =
+        "1.2.840.10008.5.1.4.1.2.2.1";
+
+    DicomFindSCU();
+    ~DicomFindSCU();
+
+    // Non-copyable, movable
+    DicomFindSCU(const DicomFindSCU&) = delete;
+    DicomFindSCU& operator=(const DicomFindSCU&) = delete;
+    DicomFindSCU(DicomFindSCU&&) noexcept;
+    DicomFindSCU& operator=(DicomFindSCU&&) noexcept;
+
+    /**
+     * @brief Execute a C-FIND query against a PACS server
+     *
+     * Establishes a DICOM association with the server and sends
+     * a C-FIND request with the specified query parameters.
+     *
+     * @param config Server configuration
+     * @param query Query parameters
+     * @return FindResult on success, PacsErrorInfo on failure
+     */
+    [[nodiscard]] std::expected<FindResult, PacsErrorInfo>
+    find(const PacsServerConfig& config, const FindQuery& query);
+
+    /**
+     * @brief Cancel any ongoing query operation
+     *
+     * Thread-safe method to abort current operation.
+     */
+    void cancel();
+
+    /**
+     * @brief Check if a query is currently in progress
+     */
+    [[nodiscard]] bool isQuerying() const;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::services

--- a/src/services/pacs/dicom_find_scu.cpp
+++ b/src/services/pacs/dicom_find_scu.cpp
@@ -1,0 +1,591 @@
+#include "services/dicom_find_scu.hpp"
+#include "services/dicom_echo_scu.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+
+// DCMTK headers
+#include <dcmtk/config/osconfig.h>
+#include <dcmtk/dcmdata/dcdatset.h>
+#include <dcmtk/dcmdata/dcdict.h>
+#include <dcmtk/dcmdata/dcdeftag.h>
+#include <dcmtk/dcmdata/dcdicent.h>
+#include <dcmtk/dcmnet/assoc.h>
+#include <dcmtk/dcmnet/dimse.h>
+#include <dcmtk/dcmnet/diutil.h>
+
+#include <spdlog/spdlog.h>
+
+namespace dicom_viewer::services {
+
+std::string DateRange::toDicomFormat() const {
+    if (from && to) {
+        if (*from == *to) {
+            return *from;
+        }
+        return *from + "-" + *to;
+    } else if (from) {
+        return *from + "-";
+    } else if (to) {
+        return "-" + *to;
+    }
+    return "";
+}
+
+namespace {
+
+/**
+ * @brief Convert QueryLevel to DICOM string representation
+ */
+const char* queryLevelToString(QueryLevel level) {
+    switch (level) {
+        case QueryLevel::Patient: return "PATIENT";
+        case QueryLevel::Study:   return "STUDY";
+        case QueryLevel::Series:  return "SERIES";
+        case QueryLevel::Image:   return "IMAGE";
+    }
+    return "STUDY";
+}
+
+/**
+ * @brief Get SOP Class UID for the query root
+ */
+const char* getSopClassUid(QueryRoot root) {
+    switch (root) {
+        case QueryRoot::PatientRoot:
+            return DicomFindSCU::PATIENT_ROOT_FIND_SOP_CLASS_UID;
+        case QueryRoot::StudyRoot:
+            return DicomFindSCU::STUDY_ROOT_FIND_SOP_CLASS_UID;
+    }
+    return DicomFindSCU::STUDY_ROOT_FIND_SOP_CLASS_UID;
+}
+
+/**
+ * @brief Helper to safely get string from dataset
+ */
+std::string getStringFromDataset(DcmDataset* dataset, const DcmTagKey& tag) {
+    if (!dataset) return "";
+
+    OFString value;
+    if (dataset->findAndGetOFString(tag, value).good()) {
+        return std::string(value.c_str());
+    }
+    return "";
+}
+
+/**
+ * @brief Helper to safely get integer from dataset
+ */
+int32_t getIntFromDataset(DcmDataset* dataset, const DcmTagKey& tag) {
+    if (!dataset) return 0;
+
+    Sint32 value = 0;
+    if (dataset->findAndGetSint32(tag, value).good()) {
+        return static_cast<int32_t>(value);
+    }
+
+    // Try as string and convert
+    OFString strValue;
+    if (dataset->findAndGetOFString(tag, strValue).good() && !strValue.empty()) {
+        try {
+            return std::stoi(strValue.c_str());
+        } catch (...) {
+            return 0;
+        }
+    }
+    return 0;
+}
+
+/**
+ * @brief Parse a patient result from dataset
+ */
+PatientResult parsePatientResult(DcmDataset* dataset) {
+    PatientResult result;
+    result.patientId = getStringFromDataset(dataset, DCM_PatientID);
+    result.patientName = getStringFromDataset(dataset, DCM_PatientName);
+    result.patientBirthDate = getStringFromDataset(dataset, DCM_PatientBirthDate);
+    result.patientSex = getStringFromDataset(dataset, DCM_PatientSex);
+    result.numberOfStudies = getIntFromDataset(dataset, DCM_NumberOfPatientRelatedStudies);
+    return result;
+}
+
+/**
+ * @brief Parse a study result from dataset
+ */
+StudyResult parseStudyResult(DcmDataset* dataset) {
+    StudyResult result;
+    result.studyInstanceUid = getStringFromDataset(dataset, DCM_StudyInstanceUID);
+    result.studyDate = getStringFromDataset(dataset, DCM_StudyDate);
+    result.studyTime = getStringFromDataset(dataset, DCM_StudyTime);
+    result.studyDescription = getStringFromDataset(dataset, DCM_StudyDescription);
+    result.accessionNumber = getStringFromDataset(dataset, DCM_AccessionNumber);
+    result.referringPhysician = getStringFromDataset(dataset, DCM_ReferringPhysicianName);
+    result.patientId = getStringFromDataset(dataset, DCM_PatientID);
+    result.patientName = getStringFromDataset(dataset, DCM_PatientName);
+    result.modalitiesInStudy = getStringFromDataset(dataset, DCM_ModalitiesInStudy);
+    result.numberOfSeries = getIntFromDataset(dataset, DCM_NumberOfStudyRelatedSeries);
+    result.numberOfInstances = getIntFromDataset(dataset, DCM_NumberOfStudyRelatedInstances);
+    return result;
+}
+
+/**
+ * @brief Parse a series result from dataset
+ */
+SeriesResult parseSeriesResult(DcmDataset* dataset) {
+    SeriesResult result;
+    result.seriesInstanceUid = getStringFromDataset(dataset, DCM_SeriesInstanceUID);
+    result.studyInstanceUid = getStringFromDataset(dataset, DCM_StudyInstanceUID);
+    result.modality = getStringFromDataset(dataset, DCM_Modality);
+    result.seriesNumber = getIntFromDataset(dataset, DCM_SeriesNumber);
+    result.seriesDescription = getStringFromDataset(dataset, DCM_SeriesDescription);
+    result.seriesDate = getStringFromDataset(dataset, DCM_SeriesDate);
+    result.seriesTime = getStringFromDataset(dataset, DCM_SeriesTime);
+    result.bodyPartExamined = getStringFromDataset(dataset, DCM_BodyPartExamined);
+    result.numberOfInstances = getIntFromDataset(dataset, DCM_NumberOfSeriesRelatedInstances);
+    return result;
+}
+
+/**
+ * @brief Parse an image result from dataset
+ */
+ImageResult parseImageResult(DcmDataset* dataset) {
+    ImageResult result;
+    result.sopInstanceUid = getStringFromDataset(dataset, DCM_SOPInstanceUID);
+    result.sopClassUid = getStringFromDataset(dataset, DCM_SOPClassUID);
+    result.seriesInstanceUid = getStringFromDataset(dataset, DCM_SeriesInstanceUID);
+    result.instanceNumber = getIntFromDataset(dataset, DCM_InstanceNumber);
+    result.contentDate = getStringFromDataset(dataset, DCM_ContentDate);
+    result.contentTime = getStringFromDataset(dataset, DCM_ContentTime);
+    return result;
+}
+
+} // anonymous namespace
+
+/**
+ * @brief Callback context for storing C-FIND results
+ */
+struct FindCallbackContext {
+    QueryLevel level;
+    FindResult* result;
+    std::atomic<bool>* cancelled;
+};
+
+/**
+ * @brief Callback function for processing C-FIND responses
+ */
+static void findCallback(
+    void* callbackData,
+    T_DIMSE_C_FindRQ* /*request*/,
+    int responseCount,
+    T_DIMSE_C_FindRSP* response,
+    DcmDataset* responseIdentifiers
+) {
+    auto* ctx = static_cast<FindCallbackContext*>(callbackData);
+
+    if (ctx->cancelled->load()) {
+        spdlog::debug("C-FIND cancelled, ignoring response #{}", responseCount);
+        return;
+    }
+
+    if (response->DimseStatus == STATUS_Pending ||
+        response->DimseStatus == STATUS_FIND_Pending_WarningUnsupportedOptionalKeys) {
+
+        if (!responseIdentifiers) {
+            spdlog::warn("C-FIND response #{} has no identifiers", responseCount);
+            return;
+        }
+
+        spdlog::debug("Processing C-FIND response #{}", responseCount);
+
+        switch (ctx->level) {
+            case QueryLevel::Patient:
+                ctx->result->patients.push_back(parsePatientResult(responseIdentifiers));
+                break;
+            case QueryLevel::Study:
+                ctx->result->studies.push_back(parseStudyResult(responseIdentifiers));
+                break;
+            case QueryLevel::Series:
+                ctx->result->series.push_back(parseSeriesResult(responseIdentifiers));
+                break;
+            case QueryLevel::Image:
+                ctx->result->images.push_back(parseImageResult(responseIdentifiers));
+                break;
+        }
+    }
+}
+
+class DicomFindSCU::Impl {
+public:
+    Impl() = default;
+    ~Impl() = default;
+
+    std::expected<FindResult, PacsErrorInfo> find(
+        const PacsServerConfig& config,
+        const FindQuery& query
+    ) {
+        if (!config.isValid()) {
+            return std::unexpected(PacsErrorInfo{
+                PacsError::ConfigurationInvalid,
+                "Invalid PACS server configuration"
+            });
+        }
+
+        if (isQuerying_.exchange(true)) {
+            return std::unexpected(PacsErrorInfo{
+                PacsError::InternalError,
+                "A query is already in progress"
+            });
+        }
+
+        cancelled_.store(false);
+        auto result = performFind(config, query);
+        isQuerying_.store(false);
+
+        return result;
+    }
+
+    void cancel() {
+        cancelled_.store(true);
+    }
+
+    bool isQuerying() const {
+        return isQuerying_.load();
+    }
+
+private:
+    std::atomic<bool> isQuerying_{false};
+    std::atomic<bool> cancelled_{false};
+
+    std::expected<FindResult, PacsErrorInfo> performFind(
+        const PacsServerConfig& config,
+        const FindQuery& query
+    ) {
+        auto startTime = std::chrono::steady_clock::now();
+        FindResult findResult;
+
+        // Initialize network
+        T_ASC_Network* network = nullptr;
+        OFCondition cond = ASC_initializeNetwork(
+            NET_REQUESTOR,
+            0,
+            static_cast<int>(config.connectionTimeout.count()),
+            &network
+        );
+
+        if (cond.bad()) {
+            spdlog::error("Failed to initialize network: {}", cond.text());
+            return std::unexpected(PacsErrorInfo{
+                PacsError::NetworkError,
+                std::string("Failed to initialize network: ") + cond.text()
+            });
+        }
+
+        // Create association parameters
+        T_ASC_Parameters* params = nullptr;
+        cond = ASC_createAssociationParameters(&params, config.maxPduSize);
+        if (cond.bad()) {
+            ASC_dropNetwork(&network);
+            return std::unexpected(PacsErrorInfo{
+                PacsError::InternalError,
+                std::string("Failed to create association parameters: ") + cond.text()
+            });
+        }
+
+        // Set AE titles
+        ASC_setAPTitles(
+            params,
+            config.callingAeTitle.c_str(),
+            config.calledAeTitle.c_str(),
+            nullptr
+        );
+
+        // Set peer address
+        std::string peerAddress = config.hostname + ":" + std::to_string(config.port);
+        ASC_setPresentationAddresses(
+            params,
+            OFStandard::getHostName().c_str(),
+            peerAddress.c_str()
+        );
+
+        // Add presentation context for Query/Retrieve FIND
+        const char* transferSyntaxes[] = {
+            UID_LittleEndianExplicitTransferSyntax,
+            UID_BigEndianExplicitTransferSyntax,
+            UID_LittleEndianImplicitTransferSyntax
+        };
+
+        const char* sopClassUid = getSopClassUid(query.root);
+
+        cond = ASC_addPresentationContext(
+            params,
+            1,
+            sopClassUid,
+            transferSyntaxes,
+            3
+        );
+
+        if (cond.bad()) {
+            ASC_destroyAssociationParameters(&params);
+            ASC_dropNetwork(&network);
+            return std::unexpected(PacsErrorInfo{
+                PacsError::InternalError,
+                std::string("Failed to add presentation context: ") + cond.text()
+            });
+        }
+
+        // Check for cancellation
+        if (cancelled_.load()) {
+            ASC_destroyAssociationParameters(&params);
+            ASC_dropNetwork(&network);
+            return std::unexpected(PacsErrorInfo{
+                PacsError::NetworkError,
+                "Operation cancelled"
+            });
+        }
+
+        // Create association
+        T_ASC_Association* assoc = nullptr;
+        spdlog::info("Requesting C-FIND association with {}:{} (AE: {})",
+                     config.hostname, config.port, config.calledAeTitle);
+
+        cond = ASC_requestAssociation(network, params, &assoc);
+        if (cond.bad()) {
+            ASC_destroyAssociationParameters(&params);
+            ASC_dropNetwork(&network);
+
+            if (cond == DUL_ASSOCIATIONREJECTED) {
+                return std::unexpected(PacsErrorInfo{
+                    PacsError::AssociationRejected,
+                    std::string("Association rejected: ") + cond.text()
+                });
+            }
+
+            return std::unexpected(PacsErrorInfo{
+                PacsError::ConnectionFailed,
+                std::string("Failed to request association: ") + cond.text()
+            });
+        }
+
+        // Check if SOP class was accepted
+        T_ASC_PresentationContextID presId = ASC_findAcceptedPresentationContextID(
+            assoc, sopClassUid
+        );
+
+        if (presId == 0) {
+            ASC_releaseAssociation(assoc);
+            ASC_destroyAssociation(&assoc);
+            ASC_dropNetwork(&network);
+            return std::unexpected(PacsErrorInfo{
+                PacsError::AssociationRejected,
+                "Query/Retrieve FIND SOP Class was not accepted by the server"
+            });
+        }
+
+        // Build query dataset
+        DcmDataset queryDataset;
+        buildQueryDataset(&queryDataset, query);
+
+        // Prepare C-FIND request
+        T_DIMSE_C_FindRQ findRequest;
+        memset(&findRequest, 0, sizeof(findRequest));
+        findRequest.MessageID = assoc->nextMsgID++;
+        strncpy(findRequest.AffectedSOPClassUID, sopClassUid,
+                sizeof(findRequest.AffectedSOPClassUID) - 1);
+        findRequest.DataSetType = DIMSE_DATASET_PRESENT;
+        findRequest.Priority = DIMSE_PRIORITY_MEDIUM;
+
+        // Prepare callback context
+        FindCallbackContext callbackCtx;
+        callbackCtx.level = query.level;
+        callbackCtx.result = &findResult;
+        callbackCtx.cancelled = &cancelled_;
+
+        T_DIMSE_C_FindRSP findResponse;
+        DcmDataset* statusDetail = nullptr;
+        int responseCount = 0;
+
+        spdlog::debug("Sending C-FIND request (Message ID: {})", findRequest.MessageID);
+
+        // Execute C-FIND
+        cond = DIMSE_findUser(
+            assoc,
+            presId,
+            &findRequest,
+            &queryDataset,
+            responseCount,
+            findCallback,
+            &callbackCtx,
+            DIMSE_BLOCKING,
+            static_cast<int>(config.dimseTimeout.count()),
+            &findResponse,
+            &statusDetail
+        );
+
+        auto endTime = std::chrono::steady_clock::now();
+        findResult.latency = std::chrono::duration_cast<std::chrono::milliseconds>(
+            endTime - startTime
+        );
+
+        // Clean up status detail
+        if (statusDetail) {
+            delete statusDetail;
+        }
+
+        // Release association
+        ASC_releaseAssociation(assoc);
+        ASC_destroyAssociation(&assoc);
+        ASC_dropNetwork(&network);
+
+        if (cond.bad()) {
+            if (cancelled_.load()) {
+                return std::unexpected(PacsErrorInfo{
+                    PacsError::NetworkError,
+                    "Operation cancelled"
+                });
+            }
+            if (cond == DIMSE_NODATAAVAILABLE || cond == DIMSE_READPDVFAILED) {
+                return std::unexpected(PacsErrorInfo{
+                    PacsError::Timeout,
+                    std::string("C-FIND timeout: ") + cond.text()
+                });
+            }
+            return std::unexpected(PacsErrorInfo{
+                PacsError::NetworkError,
+                std::string("C-FIND failed: ") + cond.text()
+            });
+        }
+
+        // Check DIMSE status
+        if (findResponse.DimseStatus != STATUS_Success &&
+            findResponse.DimseStatus != STATUS_FIND_Cancel) {
+            // Non-fatal statuses are acceptable
+            spdlog::debug("C-FIND completed with status: 0x{:04X}",
+                          findResponse.DimseStatus);
+        }
+
+        spdlog::info("C-FIND completed: {} results (latency: {}ms)",
+                     findResult.totalCount(), findResult.latency.count());
+
+        return findResult;
+    }
+
+    void buildQueryDataset(DcmDataset* dataset, const FindQuery& query) {
+        // Set Query/Retrieve Level
+        dataset->putAndInsertString(DCM_QueryRetrieveLevel, queryLevelToString(query.level));
+
+        // Patient level attributes
+        if (query.level >= QueryLevel::Patient) {
+            dataset->putAndInsertString(DCM_PatientID,
+                query.patientId.value_or("").c_str());
+            dataset->putAndInsertString(DCM_PatientName,
+                query.patientName.value_or("").c_str());
+
+            if (query.patientBirthDate) {
+                dataset->putAndInsertString(DCM_PatientBirthDate,
+                    query.patientBirthDate->toDicomFormat().c_str());
+            } else {
+                dataset->putAndInsertString(DCM_PatientBirthDate, "");
+            }
+            dataset->putAndInsertString(DCM_PatientSex, "");
+
+            if (query.level == QueryLevel::Patient) {
+                dataset->putAndInsertString(DCM_NumberOfPatientRelatedStudies, "");
+            }
+        }
+
+        // Study level attributes
+        if (query.level >= QueryLevel::Study || query.root == QueryRoot::StudyRoot) {
+            dataset->putAndInsertString(DCM_StudyInstanceUID,
+                query.studyInstanceUid.value_or("").c_str());
+
+            if (query.studyDate) {
+                dataset->putAndInsertString(DCM_StudyDate,
+                    query.studyDate->toDicomFormat().c_str());
+            } else {
+                dataset->putAndInsertString(DCM_StudyDate, "");
+            }
+            dataset->putAndInsertString(DCM_StudyTime, "");
+            dataset->putAndInsertString(DCM_StudyDescription,
+                query.studyDescription.value_or("").c_str());
+            dataset->putAndInsertString(DCM_AccessionNumber,
+                query.accessionNumber.value_or("").c_str());
+            dataset->putAndInsertString(DCM_ReferringPhysicianName, "");
+            dataset->putAndInsertString(DCM_ModalitiesInStudy,
+                query.modalitiesInStudy.value_or("").c_str());
+
+            if (query.level == QueryLevel::Study) {
+                dataset->putAndInsertString(DCM_NumberOfStudyRelatedSeries, "");
+                dataset->putAndInsertString(DCM_NumberOfStudyRelatedInstances, "");
+            }
+        }
+
+        // Series level attributes
+        if (query.level >= QueryLevel::Series) {
+            dataset->putAndInsertString(DCM_SeriesInstanceUID,
+                query.seriesInstanceUid.value_or("").c_str());
+            dataset->putAndInsertString(DCM_Modality,
+                query.modality.value_or("").c_str());
+
+            if (query.seriesNumber) {
+                dataset->putAndInsertString(DCM_SeriesNumber,
+                    std::to_string(*query.seriesNumber).c_str());
+            } else {
+                dataset->putAndInsertString(DCM_SeriesNumber, "");
+            }
+            dataset->putAndInsertString(DCM_SeriesDescription,
+                query.seriesDescription.value_or("").c_str());
+            dataset->putAndInsertString(DCM_SeriesDate, "");
+            dataset->putAndInsertString(DCM_SeriesTime, "");
+            dataset->putAndInsertString(DCM_BodyPartExamined, "");
+
+            if (query.level == QueryLevel::Series) {
+                dataset->putAndInsertString(DCM_NumberOfSeriesRelatedInstances, "");
+            }
+        }
+
+        // Image level attributes
+        if (query.level == QueryLevel::Image) {
+            dataset->putAndInsertString(DCM_SOPInstanceUID,
+                query.sopInstanceUid.value_or("").c_str());
+            dataset->putAndInsertString(DCM_SOPClassUID, "");
+
+            if (query.instanceNumber) {
+                dataset->putAndInsertString(DCM_InstanceNumber,
+                    std::to_string(*query.instanceNumber).c_str());
+            } else {
+                dataset->putAndInsertString(DCM_InstanceNumber, "");
+            }
+            dataset->putAndInsertString(DCM_ContentDate, "");
+            dataset->putAndInsertString(DCM_ContentTime, "");
+        }
+    }
+};
+
+// Public interface implementation
+
+DicomFindSCU::DicomFindSCU()
+    : impl_(std::make_unique<Impl>()) {
+}
+
+DicomFindSCU::~DicomFindSCU() = default;
+
+DicomFindSCU::DicomFindSCU(DicomFindSCU&&) noexcept = default;
+DicomFindSCU& DicomFindSCU::operator=(DicomFindSCU&&) noexcept = default;
+
+std::expected<FindResult, PacsErrorInfo> DicomFindSCU::find(
+    const PacsServerConfig& config,
+    const FindQuery& query
+) {
+    return impl_->find(config, query);
+}
+
+void DicomFindSCU::cancel() {
+    impl_->cancel();
+}
+
+bool DicomFindSCU::isQuerying() const {
+    return impl_->isQuerying();
+}
+
+} // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -123,6 +123,21 @@ target_include_directories(dicom_echo_scu_test PRIVATE
     ${CMAKE_SOURCE_DIR}/include
 )
 
+# Unit tests for DICOM Find SCU
+add_executable(dicom_find_scu_test
+    unit/dicom_find_scu_test.cpp
+)
+
+target_link_libraries(dicom_find_scu_test PRIVATE
+    pacs_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(dicom_find_scu_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
 # VTK module autoinit for tests
 vtk_module_autoinit(
     TARGETS volume_renderer_test transfer_function_manager_test mpr_renderer_test surface_renderer_test
@@ -139,3 +154,4 @@ gtest_discover_tests(transfer_function_manager_test)
 gtest_discover_tests(mpr_renderer_test)
 gtest_discover_tests(surface_renderer_test)
 gtest_discover_tests(dicom_echo_scu_test)
+gtest_discover_tests(dicom_find_scu_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/dicom_find_scu_test.cpp
+++ b/tests/unit/dicom_find_scu_test.cpp
@@ -1,0 +1,244 @@
+#include <gtest/gtest.h>
+
+#include "services/dicom_find_scu.hpp"
+#include "services/dicom_echo_scu.hpp"
+#include "services/pacs_config.hpp"
+
+using namespace dicom_viewer::services;
+
+class DicomFindSCUTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        findScu = std::make_unique<DicomFindSCU>();
+    }
+
+    void TearDown() override {
+        findScu.reset();
+    }
+
+    std::unique_ptr<DicomFindSCU> findScu;
+};
+
+// Test DateRange functionality
+TEST(DateRangeTest, SingleDate) {
+    auto range = DateRange::singleDate("20240115");
+    EXPECT_EQ(range.toDicomFormat(), "20240115");
+}
+
+TEST(DateRangeTest, FromDate) {
+    auto range = DateRange::fromDate("20240101");
+    EXPECT_EQ(range.toDicomFormat(), "20240101-");
+}
+
+TEST(DateRangeTest, ToDate) {
+    auto range = DateRange::toDate("20241231");
+    EXPECT_EQ(range.toDicomFormat(), "-20241231");
+}
+
+TEST(DateRangeTest, FullRange) {
+    DateRange range;
+    range.from = "20240101";
+    range.to = "20241231";
+    EXPECT_EQ(range.toDicomFormat(), "20240101-20241231");
+}
+
+TEST(DateRangeTest, EmptyRange) {
+    DateRange range;
+    EXPECT_EQ(range.toDicomFormat(), "");
+}
+
+// Test FindQuery default values
+TEST(FindQueryTest, DefaultValues) {
+    FindQuery query;
+    EXPECT_EQ(query.root, QueryRoot::PatientRoot);
+    EXPECT_EQ(query.level, QueryLevel::Study);
+    EXPECT_FALSE(query.patientName.has_value());
+    EXPECT_FALSE(query.patientId.has_value());
+    EXPECT_FALSE(query.studyDate.has_value());
+    EXPECT_FALSE(query.modality.has_value());
+    EXPECT_FALSE(query.accessionNumber.has_value());
+}
+
+// Test FindResult structure
+TEST(FindResultTest, DefaultValues) {
+    FindResult result;
+    EXPECT_EQ(result.latency.count(), 0);
+    EXPECT_TRUE(result.patients.empty());
+    EXPECT_TRUE(result.studies.empty());
+    EXPECT_TRUE(result.series.empty());
+    EXPECT_TRUE(result.images.empty());
+}
+
+TEST(FindResultTest, TotalCount) {
+    FindResult result;
+    result.patients.push_back(PatientResult{});
+    result.patients.push_back(PatientResult{});
+    result.studies.push_back(StudyResult{});
+    EXPECT_EQ(result.totalCount(), 3);
+}
+
+// Test PatientResult default values
+TEST(PatientResultTest, DefaultValues) {
+    PatientResult result;
+    EXPECT_TRUE(result.patientId.empty());
+    EXPECT_TRUE(result.patientName.empty());
+    EXPECT_TRUE(result.patientBirthDate.empty());
+    EXPECT_TRUE(result.patientSex.empty());
+    EXPECT_EQ(result.numberOfStudies, 0);
+}
+
+// Test StudyResult default values
+TEST(StudyResultTest, DefaultValues) {
+    StudyResult result;
+    EXPECT_TRUE(result.studyInstanceUid.empty());
+    EXPECT_TRUE(result.studyDate.empty());
+    EXPECT_TRUE(result.studyTime.empty());
+    EXPECT_TRUE(result.studyDescription.empty());
+    EXPECT_TRUE(result.accessionNumber.empty());
+    EXPECT_TRUE(result.referringPhysician.empty());
+    EXPECT_TRUE(result.patientId.empty());
+    EXPECT_TRUE(result.patientName.empty());
+    EXPECT_TRUE(result.modalitiesInStudy.empty());
+    EXPECT_EQ(result.numberOfSeries, 0);
+    EXPECT_EQ(result.numberOfInstances, 0);
+}
+
+// Test SeriesResult default values
+TEST(SeriesResultTest, DefaultValues) {
+    SeriesResult result;
+    EXPECT_TRUE(result.seriesInstanceUid.empty());
+    EXPECT_TRUE(result.studyInstanceUid.empty());
+    EXPECT_TRUE(result.modality.empty());
+    EXPECT_EQ(result.seriesNumber, 0);
+    EXPECT_TRUE(result.seriesDescription.empty());
+    EXPECT_TRUE(result.seriesDate.empty());
+    EXPECT_TRUE(result.seriesTime.empty());
+    EXPECT_TRUE(result.bodyPartExamined.empty());
+    EXPECT_EQ(result.numberOfInstances, 0);
+}
+
+// Test ImageResult default values
+TEST(ImageResultTest, DefaultValues) {
+    ImageResult result;
+    EXPECT_TRUE(result.sopInstanceUid.empty());
+    EXPECT_TRUE(result.sopClassUid.empty());
+    EXPECT_TRUE(result.seriesInstanceUid.empty());
+    EXPECT_EQ(result.instanceNumber, 0);
+    EXPECT_TRUE(result.contentDate.empty());
+    EXPECT_TRUE(result.contentTime.empty());
+}
+
+// Test DicomFindSCU construction
+TEST_F(DicomFindSCUTest, DefaultConstruction) {
+    EXPECT_NE(findScu, nullptr);
+}
+
+TEST_F(DicomFindSCUTest, MoveConstructor) {
+    DicomFindSCU moved(std::move(*findScu));
+    EXPECT_FALSE(moved.isQuerying());
+}
+
+TEST_F(DicomFindSCUTest, MoveAssignment) {
+    DicomFindSCU other;
+    other = std::move(*findScu);
+    EXPECT_FALSE(other.isQuerying());
+}
+
+// Test initial state
+TEST_F(DicomFindSCUTest, InitialStateNotQuerying) {
+    EXPECT_FALSE(findScu->isQuerying());
+}
+
+// Test find with invalid config
+TEST_F(DicomFindSCUTest, FindWithInvalidConfig) {
+    PacsServerConfig config;  // Invalid - empty hostname
+    FindQuery query;
+    auto result = findScu->find(config, query);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, PacsError::ConfigurationInvalid);
+}
+
+TEST_F(DicomFindSCUTest, FindWithEmptyHostname) {
+    PacsServerConfig config;
+    config.hostname = "";
+    config.calledAeTitle = "PACS_SERVER";
+    FindQuery query;
+    auto result = findScu->find(config, query);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, PacsError::ConfigurationInvalid);
+}
+
+// Test find with unreachable server (will fail to connect)
+TEST_F(DicomFindSCUTest, FindWithUnreachableServer) {
+    PacsServerConfig config;
+    config.hostname = "192.0.2.1";  // TEST-NET-1, non-routable
+    config.port = 104;
+    config.calledAeTitle = "PACS_SERVER";
+    config.connectionTimeout = std::chrono::seconds(2);  // Short timeout
+
+    FindQuery query;
+    query.patientName = "SMITH*";
+
+    auto result = findScu->find(config, query);
+    EXPECT_FALSE(result.has_value());
+    // Should fail with connection error or timeout
+    EXPECT_TRUE(
+        result.error().code == PacsError::ConnectionFailed ||
+        result.error().code == PacsError::Timeout ||
+        result.error().code == PacsError::NetworkError
+    );
+}
+
+// Test cancel functionality
+TEST_F(DicomFindSCUTest, CancelDoesNotThrow) {
+    EXPECT_NO_THROW(findScu->cancel());
+}
+
+// Test SOP Class UID constants
+TEST(DicomFindSCUConstantsTest, PatientRootFindSOPClassUID) {
+    EXPECT_STREQ(DicomFindSCU::PATIENT_ROOT_FIND_SOP_CLASS_UID,
+                 "1.2.840.10008.5.1.4.1.2.1.1");
+}
+
+TEST(DicomFindSCUConstantsTest, StudyRootFindSOPClassUID) {
+    EXPECT_STREQ(DicomFindSCU::STUDY_ROOT_FIND_SOP_CLASS_UID,
+                 "1.2.840.10008.5.1.4.1.2.2.1");
+}
+
+// Test query level enum
+TEST(QueryLevelTest, EnumValues) {
+    EXPECT_EQ(static_cast<int>(QueryLevel::Patient), 0);
+    EXPECT_EQ(static_cast<int>(QueryLevel::Study), 1);
+    EXPECT_EQ(static_cast<int>(QueryLevel::Series), 2);
+    EXPECT_EQ(static_cast<int>(QueryLevel::Image), 3);
+}
+
+// Test query root enum
+TEST(QueryRootTest, EnumValues) {
+    EXPECT_EQ(static_cast<int>(QueryRoot::PatientRoot), 0);
+    EXPECT_EQ(static_cast<int>(QueryRoot::StudyRoot), 1);
+}
+
+// Test FindQuery with all fields
+TEST(FindQueryTest, AllFieldsSet) {
+    FindQuery query;
+    query.root = QueryRoot::StudyRoot;
+    query.level = QueryLevel::Series;
+    query.patientName = "DOE^JOHN";
+    query.patientId = "12345";
+    query.studyDate = DateRange::singleDate("20240101");
+    query.modality = "CT";
+    query.accessionNumber = "ACC001";
+    query.studyInstanceUid = "1.2.3.4.5";
+    query.seriesNumber = 1;
+
+    EXPECT_EQ(query.root, QueryRoot::StudyRoot);
+    EXPECT_EQ(query.level, QueryLevel::Series);
+    EXPECT_EQ(query.patientName.value(), "DOE^JOHN");
+    EXPECT_EQ(query.patientId.value(), "12345");
+    EXPECT_EQ(query.studyDate->toDicomFormat(), "20240101");
+    EXPECT_EQ(query.modality.value(), "CT");
+    EXPECT_EQ(query.accessionNumber.value(), "ACC001");
+    EXPECT_EQ(query.studyInstanceUid.value(), "1.2.3.4.5");
+    EXPECT_EQ(query.seriesNumber.value(), 1);
+}


### PR DESCRIPTION
## Summary

- Implement DICOM C-FIND SCU for querying PACS servers
- Support Patient Root and Study Root Query/Retrieve Information Models
- Add query support for Patient, Study, Series, and Image levels
- Support wildcard searches and date range queries

## Changes

- Add `dicom_find_scu.hpp` with query structures and SCU class
- Add `dicom_find_scu.cpp` with DCMTK-based implementation
- Add unit tests for C-FIND functionality
- Update CMakeLists.txt to include new source files

## Test plan

- [x] Unit tests pass (25 tests)
- [x] Build succeeds with DCMTK 3.7.0
- [ ] Integration test with real PACS server

Closes #19