### PR TITLE
feat(pacs): implement DICOM C-MOVE image retrieval

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ target_link_libraries(measurement_service PUBLIC
 add_library(pacs_service STATIC
     src/services/pacs/dicom_echo_scu.cpp
     src/services/pacs/dicom_find_scu.cpp
+    src/services/pacs/dicom_move_scu.cpp
 )
 
 target_include_directories(pacs_service PUBLIC

--- a/include/services/dicom_move_scu.hpp
+++ b/include/services/dicom_move_scu.hpp
@@ -1,0 +1,289 @@
+#pragma once
+
+#include "pacs_config.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <expected>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+// Forward declare PacsErrorInfo from dicom_echo_scu.hpp
+namespace dicom_viewer::services {
+struct PacsErrorInfo;
+enum class QueryRoot;
+}
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Retrieval level for C-MOVE operations
+ */
+enum class RetrieveLevel {
+    Study,   ///< Retrieve entire study
+    Series,  ///< Retrieve specific series
+    Image    ///< Retrieve specific image (instance)
+};
+
+/**
+ * @brief Progress information for C-MOVE operations
+ */
+struct MoveProgress {
+    /// Total number of images to be transferred
+    int32_t totalImages = 0;
+
+    /// Number of images successfully received
+    int32_t receivedImages = 0;
+
+    /// Number of images that failed to transfer
+    int32_t failedImages = 0;
+
+    /// Number of images with warnings
+    int32_t warningImages = 0;
+
+    /// Number of remaining images
+    int32_t remainingImages = 0;
+
+    /// Current Study Instance UID being processed
+    std::string currentStudyUid;
+
+    /// Current Series Instance UID being processed
+    std::string currentSeriesUid;
+
+    /// Timestamp of last progress update
+    std::chrono::steady_clock::time_point lastUpdate;
+
+    /**
+     * @brief Check if transfer is complete
+     */
+    [[nodiscard]] bool isComplete() const noexcept {
+        return remainingImages == 0 && totalImages > 0;
+    }
+
+    /**
+     * @brief Get completion percentage (0-100)
+     */
+    [[nodiscard]] float percentComplete() const noexcept {
+        if (totalImages == 0) return 0.0f;
+        return static_cast<float>(receivedImages + failedImages) /
+               static_cast<float>(totalImages) * 100.0f;
+    }
+};
+
+/**
+ * @brief Result of a C-MOVE retrieval operation
+ */
+struct MoveResult {
+    /// Total operation latency
+    std::chrono::milliseconds latency{0};
+
+    /// Final progress state
+    MoveProgress progress;
+
+    /// Paths to successfully received files
+    std::vector<std::filesystem::path> receivedFiles;
+
+    /// Whether the operation was cancelled
+    bool cancelled = false;
+
+    /**
+     * @brief Check if all images were successfully retrieved
+     */
+    [[nodiscard]] bool isSuccess() const noexcept {
+        return !cancelled &&
+               progress.failedImages == 0 &&
+               progress.receivedImages == progress.totalImages &&
+               progress.totalImages > 0;
+    }
+
+    /**
+     * @brief Check if there were any failures
+     */
+    [[nodiscard]] bool hasFailures() const noexcept {
+        return progress.failedImages > 0;
+    }
+};
+
+/**
+ * @brief Configuration for C-MOVE SCU operations
+ */
+struct MoveConfig {
+    /// Query/Retrieve root (Patient or Study)
+    QueryRoot queryRoot;
+
+    /// Directory to store received files
+    std::filesystem::path storageDirectory;
+
+    /// AE Title for receiving C-STORE (defaults to calling AE title)
+    std::optional<std::string> moveDestinationAeTitle;
+
+    /// Port for C-STORE SCP (0 = use same association for sub-operations)
+    uint16_t storeScpPort = 0;
+
+    /// Maximum concurrent sub-operations
+    int32_t maxConcurrentOperations = 1;
+
+    /// Whether to create subdirectories based on Study/Series UIDs
+    bool createSubdirectories = true;
+
+    /// Whether to use the original SOP Instance UID as filename
+    bool useOriginalFilenames = true;
+};
+
+/**
+ * @brief DICOM C-MOVE Service Class User (SCU)
+ *
+ * Implements the DICOM Query/Retrieve Service Classes for retrieving
+ * images from PACS servers using the C-MOVE protocol.
+ *
+ * Supports:
+ * - Patient Root Query/Retrieve Information Model - MOVE (1.2.840.10008.5.1.4.1.2.1.2)
+ * - Study Root Query/Retrieve Information Model - MOVE (1.2.840.10008.5.1.4.1.2.2.2)
+ *
+ * @note C-MOVE requires a C-STORE SCP to receive images. This implementation
+ *       can either use the same association for sub-operations or start an
+ *       internal C-STORE SCP on the specified port.
+ *
+ * @example
+ * @code
+ * DicomMoveSCU mover;
+ * PacsServerConfig config;
+ * config.hostname = "pacs.hospital.com";
+ * config.port = 104;
+ * config.calledAeTitle = "PACS_SERVER";
+ *
+ * MoveConfig moveConfig;
+ * moveConfig.storageDirectory = "/tmp/dicom";
+ * moveConfig.queryRoot = QueryRoot::StudyRoot;
+ *
+ * auto result = mover.retrieveStudy(config, moveConfig, studyUid,
+ *     [](const MoveProgress& progress) {
+ *         std::cout << "Progress: " << progress.percentComplete() << "%\n";
+ *     });
+ *
+ * if (result) {
+ *     std::cout << "Retrieved " << result->receivedFiles.size() << " files\n";
+ * } else {
+ *     std::cerr << "Retrieval failed: " << result.error().toString() << "\n";
+ * }
+ * @endcode
+ *
+ * @trace SRS-FR-036
+ */
+class DicomMoveSCU {
+public:
+    /// Patient Root Query/Retrieve Information Model - MOVE SOP Class UID
+    static constexpr const char* PATIENT_ROOT_MOVE_SOP_CLASS_UID =
+        "1.2.840.10008.5.1.4.1.2.1.2";
+
+    /// Study Root Query/Retrieve Information Model - MOVE SOP Class UID
+    static constexpr const char* STUDY_ROOT_MOVE_SOP_CLASS_UID =
+        "1.2.840.10008.5.1.4.1.2.2.2";
+
+    /// Progress callback type
+    using ProgressCallback = std::function<void(const MoveProgress&)>;
+
+    DicomMoveSCU();
+    ~DicomMoveSCU();
+
+    // Non-copyable, movable
+    DicomMoveSCU(const DicomMoveSCU&) = delete;
+    DicomMoveSCU& operator=(const DicomMoveSCU&) = delete;
+    DicomMoveSCU(DicomMoveSCU&&) noexcept;
+    DicomMoveSCU& operator=(DicomMoveSCU&&) noexcept;
+
+    /**
+     * @brief Retrieve an entire study from PACS
+     *
+     * Initiates a C-MOVE request to retrieve all images belonging
+     * to the specified study.
+     *
+     * @param config PACS server configuration
+     * @param moveConfig Move operation configuration
+     * @param studyInstanceUid Study Instance UID to retrieve
+     * @param progressCallback Optional callback for progress updates
+     * @return MoveResult on success, PacsErrorInfo on failure
+     */
+    [[nodiscard]] std::expected<MoveResult, PacsErrorInfo>
+    retrieveStudy(
+        const PacsServerConfig& config,
+        const MoveConfig& moveConfig,
+        const std::string& studyInstanceUid,
+        ProgressCallback progressCallback = nullptr
+    );
+
+    /**
+     * @brief Retrieve a specific series from PACS
+     *
+     * Initiates a C-MOVE request to retrieve all images belonging
+     * to the specified series.
+     *
+     * @param config PACS server configuration
+     * @param moveConfig Move operation configuration
+     * @param studyInstanceUid Study Instance UID containing the series
+     * @param seriesInstanceUid Series Instance UID to retrieve
+     * @param progressCallback Optional callback for progress updates
+     * @return MoveResult on success, PacsErrorInfo on failure
+     */
+    [[nodiscard]] std::expected<MoveResult, PacsErrorInfo>
+    retrieveSeries(
+        const PacsServerConfig& config,
+        const MoveConfig& moveConfig,
+        const std::string& studyInstanceUid,
+        const std::string& seriesInstanceUid,
+        ProgressCallback progressCallback = nullptr
+    );
+
+    /**
+     * @brief Retrieve a specific image from PACS
+     *
+     * Initiates a C-MOVE request to retrieve a single image.
+     *
+     * @param config PACS server configuration
+     * @param moveConfig Move operation configuration
+     * @param studyInstanceUid Study Instance UID containing the image
+     * @param seriesInstanceUid Series Instance UID containing the image
+     * @param sopInstanceUid SOP Instance UID of the image to retrieve
+     * @param progressCallback Optional callback for progress updates
+     * @return MoveResult on success, PacsErrorInfo on failure
+     */
+    [[nodiscard]] std::expected<MoveResult, PacsErrorInfo>
+    retrieveImage(
+        const PacsServerConfig& config,
+        const MoveConfig& moveConfig,
+        const std::string& studyInstanceUid,
+        const std::string& seriesInstanceUid,
+        const std::string& sopInstanceUid,
+        ProgressCallback progressCallback = nullptr
+    );
+
+    /**
+     * @brief Cancel any ongoing retrieval operation
+     *
+     * Thread-safe method to abort current operation.
+     * The operation will complete with cancelled=true in the result.
+     */
+    void cancel();
+
+    /**
+     * @brief Check if a retrieval is currently in progress
+     */
+    [[nodiscard]] bool isRetrieving() const;
+
+    /**
+     * @brief Get current progress of ongoing retrieval
+     *
+     * @return Current progress, or nullopt if no retrieval in progress
+     */
+    [[nodiscard]] std::optional<MoveProgress> currentProgress() const;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::services

--- a/src/services/pacs/dicom_move_scu.cpp
+++ b/src/services/pacs/dicom_move_scu.cpp
@@ -1,0 +1,735 @@
+#include "services/dicom_move_scu.hpp"
+#include "services/dicom_echo_scu.hpp"
+#include "services/dicom_find_scu.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <thread>
+
+// DCMTK headers
+#include <dcmtk/config/osconfig.h>
+#include <dcmtk/dcmdata/dcdatset.h>
+#include <dcmtk/dcmdata/dcdict.h>
+#include <dcmtk/dcmdata/dcdeftag.h>
+#include <dcmtk/dcmdata/dcdicent.h>
+#include <dcmtk/dcmdata/dcfilefo.h>
+#include <dcmtk/dcmdata/dcuid.h>
+#include <dcmtk/dcmnet/assoc.h>
+#include <dcmtk/dcmnet/dimse.h>
+#include <dcmtk/dcmnet/diutil.h>
+
+#include <spdlog/spdlog.h>
+
+namespace dicom_viewer::services {
+
+namespace {
+
+/**
+ * @brief Get SOP Class UID for the query root (MOVE variant)
+ */
+const char* getMoveSopClassUid(QueryRoot root) {
+    switch (root) {
+        case QueryRoot::PatientRoot:
+            return DicomMoveSCU::PATIENT_ROOT_MOVE_SOP_CLASS_UID;
+        case QueryRoot::StudyRoot:
+            return DicomMoveSCU::STUDY_ROOT_MOVE_SOP_CLASS_UID;
+    }
+    return DicomMoveSCU::STUDY_ROOT_MOVE_SOP_CLASS_UID;
+}
+
+/**
+ * @brief Convert RetrieveLevel to DICOM string
+ */
+const char* retrieveLevelToString(RetrieveLevel level) {
+    switch (level) {
+        case RetrieveLevel::Study:  return "STUDY";
+        case RetrieveLevel::Series: return "SERIES";
+        case RetrieveLevel::Image:  return "IMAGE";
+    }
+    return "STUDY";
+}
+
+/**
+ * @brief Sanitize UID for use in filesystem paths
+ */
+std::string sanitizeUidForPath(const std::string& uid) {
+    std::string result = uid;
+    // Replace any characters that might cause issues in paths
+    for (char& c : result) {
+        if (c == '/' || c == '\\' || c == ':' || c == '*' ||
+            c == '?' || c == '"' || c == '<' || c == '>' || c == '|') {
+            c = '_';
+        }
+    }
+    return result;
+}
+
+} // anonymous namespace
+
+/**
+ * @brief Context for C-MOVE callback and sub-operations
+ */
+struct MoveCallbackContext {
+    MoveProgress progress;
+    DicomMoveSCU::ProgressCallback progressCallback;
+    std::atomic<bool>* cancelled;
+    std::mutex progressMutex;
+    MoveConfig moveConfig;
+    std::vector<std::filesystem::path> receivedFiles;
+
+    // Current retrieval context
+    std::string studyUid;
+    std::string seriesUid;
+};
+
+/**
+ * @brief Progress callback for receiving dataset
+ *
+ * This callback is invoked to report progress during dataset reception.
+ */
+static void datasetProgressCallback(
+    void* /*callbackData*/,
+    unsigned long bytesReceived
+) {
+    spdlog::trace("Dataset progress: {} bytes received", bytesReceived);
+}
+
+/**
+ * @brief Sub-operation callback for handling incoming C-STORE during C-MOVE
+ *
+ * This function handles the sub-association where PACS sends images
+ * via C-STORE in response to a C-MOVE request.
+ */
+static void moveSubOpCallback(
+    void* callbackData,
+    T_ASC_Network* network,
+    T_ASC_Association** subAssoc
+) {
+    auto* ctx = static_cast<MoveCallbackContext*>(callbackData);
+
+    if (ctx->cancelled->load()) {
+        spdlog::debug("C-MOVE cancelled, aborting sub-association");
+        if (*subAssoc) {
+            ASC_abortAssociation(*subAssoc);
+            ASC_dropAssociation(*subAssoc);
+            ASC_destroyAssociation(subAssoc);
+        }
+        return;
+    }
+
+    // Handle incoming sub-association (C-STORE from PACS)
+    if (*subAssoc == nullptr) {
+        // No more sub-associations expected
+        return;
+    }
+
+    T_ASC_Association* assoc = *subAssoc;
+
+    // Process the sub-association
+    bool finished = false;
+    while (!finished && !ctx->cancelled->load()) {
+        T_DIMSE_Message msg;
+        T_ASC_PresentationContextID presId = 0;
+
+        // Wait for incoming message
+        OFCondition cond = DIMSE_receiveCommand(
+            assoc,
+            DIMSE_BLOCKING,
+            0,
+            &presId,
+            &msg,
+            nullptr,
+            nullptr
+        );
+
+        if (cond.bad()) {
+            if (cond == DUL_PEERREQUESTEDRELEASE ||
+                cond == DUL_PEERABORTEDASSOCIATION) {
+                finished = true;
+                break;
+            }
+            spdlog::error("Failed to receive DIMSE command: {}", cond.text());
+            finished = true;
+            break;
+        }
+
+        // Check for C-STORE request (command field 0x0001)
+        if (msg.CommandField == DIMSE_C_STORE_RQ) {
+            T_DIMSE_C_StoreRQ& storeReq = msg.msg.CStoreRQ;
+            DcmDataset* dataset = nullptr;
+
+            spdlog::debug("Receiving C-STORE: {}", storeReq.AffectedSOPInstanceUID);
+
+            // Receive the dataset
+            cond = DIMSE_receiveDataSetInMemory(
+                assoc,
+                DIMSE_BLOCKING,
+                0,
+                &presId,
+                &dataset,
+                datasetProgressCallback,
+                nullptr
+            );
+
+            Uint16 status = STATUS_Success;
+
+            if (cond.good() && dataset) {
+                // Determine storage path
+                std::filesystem::path filePath = ctx->moveConfig.storageDirectory;
+
+                if (ctx->moveConfig.createSubdirectories) {
+                    filePath /= sanitizeUidForPath(ctx->studyUid);
+                    if (!ctx->seriesUid.empty()) {
+                        filePath /= sanitizeUidForPath(ctx->seriesUid);
+                    }
+                }
+
+                std::filesystem::create_directories(filePath);
+
+                std::string filename;
+                if (ctx->moveConfig.useOriginalFilenames) {
+                    filename = sanitizeUidForPath(storeReq.AffectedSOPInstanceUID) + ".dcm";
+                } else {
+                    std::lock_guard lock(ctx->progressMutex);
+                    filename = std::to_string(ctx->receivedFiles.size() + 1) + ".dcm";
+                }
+                filePath /= filename;
+
+                // Save to file
+                DcmFileFormat fileFormat(dataset);
+                OFCondition saveCond = fileFormat.saveFile(
+                    filePath.string().c_str(),
+                    EXS_LittleEndianExplicit
+                );
+
+                if (saveCond.good()) {
+                    std::lock_guard lock(ctx->progressMutex);
+                    ctx->receivedFiles.push_back(filePath);
+                    spdlog::debug("Saved: {}", filePath.string());
+                } else {
+                    status = STATUS_STORE_Refused_OutOfResources;
+                    spdlog::error("Failed to save file: {}", saveCond.text());
+                }
+            } else {
+                status = STATUS_STORE_Error_DataSetDoesNotMatchSOPClass;
+            }
+
+            // Send C-STORE response
+            T_DIMSE_C_StoreRSP storeRsp;
+            memset(&storeRsp, 0, sizeof(storeRsp));
+            storeRsp.MessageIDBeingRespondedTo = storeReq.MessageID;
+            storeRsp.DimseStatus = status;
+            storeRsp.DataSetType = DIMSE_DATASET_NULL;
+            OFStandard::strlcpy(storeRsp.AffectedSOPClassUID,
+                                storeReq.AffectedSOPClassUID,
+                                sizeof(storeRsp.AffectedSOPClassUID));
+            OFStandard::strlcpy(storeRsp.AffectedSOPInstanceUID,
+                                storeReq.AffectedSOPInstanceUID,
+                                sizeof(storeRsp.AffectedSOPInstanceUID));
+
+            DIMSE_sendStoreResponse(assoc, presId, &storeReq, &storeRsp, nullptr);
+
+            if (dataset) {
+                delete dataset;
+            }
+        } else {
+            // Unknown command, ignore
+            spdlog::warn("Received unexpected command: 0x{:04X}",
+                         static_cast<unsigned int>(msg.CommandField));
+        }
+    }
+
+    // Release the sub-association
+    if (*subAssoc) {
+        ASC_releaseAssociation(*subAssoc);
+        ASC_dropAssociation(*subAssoc);
+        ASC_destroyAssociation(subAssoc);
+    }
+}
+
+/**
+ * @brief Callback for C-MOVE progress updates
+ */
+static void moveProgressCallback(
+    void* callbackData,
+    T_DIMSE_C_MoveRQ* /*request*/,
+    int responseCount,
+    T_DIMSE_C_MoveRSP* response
+) {
+    auto* ctx = static_cast<MoveCallbackContext*>(callbackData);
+
+    if (ctx->cancelled->load()) {
+        spdlog::debug("C-MOVE cancelled at response #{}", responseCount);
+        return;
+    }
+
+    // Update progress from response
+    {
+        std::lock_guard lock(ctx->progressMutex);
+
+        if (response->NumberOfRemainingSubOperations != 0xFFFF) {
+            ctx->progress.remainingImages = response->NumberOfRemainingSubOperations;
+        }
+        if (response->NumberOfCompletedSubOperations != 0xFFFF) {
+            ctx->progress.receivedImages = response->NumberOfCompletedSubOperations;
+        }
+        if (response->NumberOfFailedSubOperations != 0xFFFF) {
+            ctx->progress.failedImages = response->NumberOfFailedSubOperations;
+        }
+        if (response->NumberOfWarningSubOperations != 0xFFFF) {
+            ctx->progress.warningImages = response->NumberOfWarningSubOperations;
+        }
+
+        // Calculate total from first meaningful response
+        if (ctx->progress.totalImages == 0 && ctx->progress.remainingImages > 0) {
+            ctx->progress.totalImages = ctx->progress.remainingImages +
+                                         ctx->progress.receivedImages +
+                                         ctx->progress.failedImages;
+        }
+
+        ctx->progress.lastUpdate = std::chrono::steady_clock::now();
+    }
+
+    spdlog::debug("C-MOVE progress: {}/{} received, {} failed, {} remaining",
+                  ctx->progress.receivedImages,
+                  ctx->progress.totalImages,
+                  ctx->progress.failedImages,
+                  ctx->progress.remainingImages);
+
+    // Notify callback
+    if (ctx->progressCallback) {
+        std::lock_guard lock(ctx->progressMutex);
+        ctx->progressCallback(ctx->progress);
+    }
+}
+
+class DicomMoveSCU::Impl {
+public:
+    Impl() = default;
+    ~Impl() = default;
+
+    std::expected<MoveResult, PacsErrorInfo> retrieveStudy(
+        const PacsServerConfig& config,
+        const MoveConfig& moveConfig,
+        const std::string& studyInstanceUid,
+        ProgressCallback progressCallback
+    ) {
+        return performMove(
+            config,
+            moveConfig,
+            RetrieveLevel::Study,
+            studyInstanceUid,
+            "",  // seriesUid
+            "",  // sopInstanceUid
+            progressCallback
+        );
+    }
+
+    std::expected<MoveResult, PacsErrorInfo> retrieveSeries(
+        const PacsServerConfig& config,
+        const MoveConfig& moveConfig,
+        const std::string& studyInstanceUid,
+        const std::string& seriesInstanceUid,
+        ProgressCallback progressCallback
+    ) {
+        return performMove(
+            config,
+            moveConfig,
+            RetrieveLevel::Series,
+            studyInstanceUid,
+            seriesInstanceUid,
+            "",  // sopInstanceUid
+            progressCallback
+        );
+    }
+
+    std::expected<MoveResult, PacsErrorInfo> retrieveImage(
+        const PacsServerConfig& config,
+        const MoveConfig& moveConfig,
+        const std::string& studyInstanceUid,
+        const std::string& seriesInstanceUid,
+        const std::string& sopInstanceUid,
+        ProgressCallback progressCallback
+    ) {
+        return performMove(
+            config,
+            moveConfig,
+            RetrieveLevel::Image,
+            studyInstanceUid,
+            seriesInstanceUid,
+            sopInstanceUid,
+            progressCallback
+        );
+    }
+
+    void cancel() {
+        cancelled_.store(true);
+    }
+
+    bool isRetrieving() const {
+        return isRetrieving_.load();
+    }
+
+    std::optional<MoveProgress> currentProgress() const {
+        std::lock_guard lock(progressMutex_);
+        if (isRetrieving_.load()) {
+            return currentProgress_;
+        }
+        return std::nullopt;
+    }
+
+private:
+    std::atomic<bool> isRetrieving_{false};
+    std::atomic<bool> cancelled_{false};
+    mutable std::mutex progressMutex_;
+    MoveProgress currentProgress_;
+
+    std::expected<MoveResult, PacsErrorInfo> performMove(
+        const PacsServerConfig& config,
+        const MoveConfig& moveConfig,
+        RetrieveLevel level,
+        const std::string& studyUid,
+        const std::string& seriesUid,
+        const std::string& sopInstanceUid,
+        ProgressCallback progressCallback
+    ) {
+        // Validate configuration
+        if (!config.isValid()) {
+            return std::unexpected(PacsErrorInfo{
+                PacsError::ConfigurationInvalid,
+                "Invalid PACS server configuration"
+            });
+        }
+
+        if (moveConfig.storageDirectory.empty()) {
+            return std::unexpected(PacsErrorInfo{
+                PacsError::ConfigurationInvalid,
+                "Storage directory not specified"
+            });
+        }
+
+        // Check for concurrent operations
+        if (isRetrieving_.exchange(true)) {
+            return std::unexpected(PacsErrorInfo{
+                PacsError::InternalError,
+                "A retrieval is already in progress"
+            });
+        }
+
+        cancelled_.store(false);
+
+        // Create storage directory
+        std::error_code ec;
+        std::filesystem::create_directories(moveConfig.storageDirectory, ec);
+        if (ec) {
+            isRetrieving_.store(false);
+            return std::unexpected(PacsErrorInfo{
+                PacsError::InternalError,
+                "Failed to create storage directory: " + ec.message()
+            });
+        }
+
+        auto startTime = std::chrono::steady_clock::now();
+
+        // Initialize callback context
+        MoveCallbackContext ctx;
+        ctx.cancelled = &cancelled_;
+        ctx.progressCallback = progressCallback;
+        ctx.moveConfig = moveConfig;
+        ctx.studyUid = studyUid;
+        ctx.seriesUid = seriesUid;
+
+        // Initialize network
+        T_ASC_Network* network = nullptr;
+        OFCondition cond = ASC_initializeNetwork(
+            NET_ACCEPTORREQUESTOR,  // Both requestor and acceptor for sub-operations
+            moveConfig.storeScpPort,
+            static_cast<int>(config.connectionTimeout.count()),
+            &network
+        );
+
+        if (cond.bad()) {
+            isRetrieving_.store(false);
+            spdlog::error("Failed to initialize network: {}", cond.text());
+            return std::unexpected(PacsErrorInfo{
+                PacsError::NetworkError,
+                std::string("Failed to initialize network: ") + cond.text()
+            });
+        }
+
+        // Create association parameters
+        T_ASC_Parameters* params = nullptr;
+        cond = ASC_createAssociationParameters(&params, config.maxPduSize);
+        if (cond.bad()) {
+            ASC_dropNetwork(&network);
+            isRetrieving_.store(false);
+            return std::unexpected(PacsErrorInfo{
+                PacsError::InternalError,
+                std::string("Failed to create association parameters: ") + cond.text()
+            });
+        }
+
+        // Set AE titles
+        ASC_setAPTitles(
+            params,
+            config.callingAeTitle.c_str(),
+            config.calledAeTitle.c_str(),
+            nullptr
+        );
+
+        // Set peer address
+        std::string peerAddress = config.hostname + ":" + std::to_string(config.port);
+        ASC_setPresentationAddresses(
+            params,
+            OFStandard::getHostName().c_str(),
+            peerAddress.c_str()
+        );
+
+        // Add presentation context for Query/Retrieve MOVE
+        const char* transferSyntaxes[] = {
+            UID_LittleEndianExplicitTransferSyntax,
+            UID_BigEndianExplicitTransferSyntax,
+            UID_LittleEndianImplicitTransferSyntax
+        };
+
+        const char* moveSopClassUid = getMoveSopClassUid(moveConfig.queryRoot);
+
+        cond = ASC_addPresentationContext(
+            params,
+            1,
+            moveSopClassUid,
+            transferSyntaxes,
+            3
+        );
+
+        if (cond.bad()) {
+            ASC_destroyAssociationParameters(&params);
+            ASC_dropNetwork(&network);
+            isRetrieving_.store(false);
+            return std::unexpected(PacsErrorInfo{
+                PacsError::InternalError,
+                std::string("Failed to add presentation context: ") + cond.text()
+            });
+        }
+
+        // Check for cancellation
+        if (cancelled_.load()) {
+            ASC_destroyAssociationParameters(&params);
+            ASC_dropNetwork(&network);
+            isRetrieving_.store(false);
+            return std::unexpected(PacsErrorInfo{
+                PacsError::NetworkError,
+                "Operation cancelled"
+            });
+        }
+
+        // Request association
+        T_ASC_Association* assoc = nullptr;
+        spdlog::info("Requesting C-MOVE association with {}:{} (AE: {})",
+                     config.hostname, config.port, config.calledAeTitle);
+
+        cond = ASC_requestAssociation(network, params, &assoc);
+        if (cond.bad()) {
+            ASC_destroyAssociationParameters(&params);
+            ASC_dropNetwork(&network);
+            isRetrieving_.store(false);
+
+            if (cond == DUL_ASSOCIATIONREJECTED) {
+                return std::unexpected(PacsErrorInfo{
+                    PacsError::AssociationRejected,
+                    std::string("Association rejected: ") + cond.text()
+                });
+            }
+
+            return std::unexpected(PacsErrorInfo{
+                PacsError::ConnectionFailed,
+                std::string("Failed to request association: ") + cond.text()
+            });
+        }
+
+        // Check if MOVE SOP class was accepted
+        T_ASC_PresentationContextID presId = ASC_findAcceptedPresentationContextID(
+            assoc, moveSopClassUid
+        );
+
+        if (presId == 0) {
+            ASC_releaseAssociation(assoc);
+            ASC_destroyAssociation(&assoc);
+            ASC_dropNetwork(&network);
+            isRetrieving_.store(false);
+            return std::unexpected(PacsErrorInfo{
+                PacsError::AssociationRejected,
+                "Query/Retrieve MOVE SOP Class was not accepted by the server"
+            });
+        }
+
+        // Build move request dataset
+        DcmDataset moveDataset;
+        buildMoveDataset(&moveDataset, level, studyUid, seriesUid, sopInstanceUid);
+
+        // Prepare C-MOVE request
+        T_DIMSE_C_MoveRQ moveRequest;
+        memset(&moveRequest, 0, sizeof(moveRequest));
+        moveRequest.MessageID = assoc->nextMsgID++;
+        strncpy(moveRequest.AffectedSOPClassUID, moveSopClassUid,
+                sizeof(moveRequest.AffectedSOPClassUID) - 1);
+        moveRequest.DataSetType = DIMSE_DATASET_PRESENT;
+        moveRequest.Priority = DIMSE_PRIORITY_MEDIUM;
+
+        // Set move destination (where PACS should send images via C-STORE)
+        std::string moveDestination = moveConfig.moveDestinationAeTitle.value_or(
+            config.callingAeTitle
+        );
+        strncpy(moveRequest.MoveDestination, moveDestination.c_str(),
+                sizeof(moveRequest.MoveDestination) - 1);
+
+        spdlog::info("Sending C-MOVE request (Message ID: {}, Destination: {})",
+                     moveRequest.MessageID, moveDestination);
+
+        T_DIMSE_C_MoveRSP moveResponse;
+        DcmDataset* statusDetail = nullptr;
+        int responseCount = 0;
+
+        // Execute C-MOVE
+        cond = DIMSE_moveUser(
+            assoc,
+            presId,
+            &moveRequest,
+            &moveDataset,
+            moveProgressCallback,
+            &ctx,
+            DIMSE_BLOCKING,
+            static_cast<int>(config.dimseTimeout.count()),
+            network,
+            moveSubOpCallback,
+            &ctx,
+            &moveResponse,
+            &statusDetail,
+            nullptr,  // rspCommandSet
+            OFFalse   // ignoreStore
+        );
+
+        auto endTime = std::chrono::steady_clock::now();
+
+        // Build result
+        MoveResult result;
+        result.latency = std::chrono::duration_cast<std::chrono::milliseconds>(
+            endTime - startTime
+        );
+        result.progress = ctx.progress;
+        result.receivedFiles = std::move(ctx.receivedFiles);
+        result.cancelled = cancelled_.load();
+
+        // Clean up status detail
+        if (statusDetail) {
+            delete statusDetail;
+        }
+
+        // Release association
+        ASC_releaseAssociation(assoc);
+        ASC_destroyAssociation(&assoc);
+        ASC_dropNetwork(&network);
+
+        isRetrieving_.store(false);
+
+        if (cond.bad() && !cancelled_.load()) {
+            if (cond == DIMSE_NODATAAVAILABLE || cond == DIMSE_READPDVFAILED) {
+                return std::unexpected(PacsErrorInfo{
+                    PacsError::Timeout,
+                    std::string("C-MOVE timeout: ") + cond.text()
+                });
+            }
+            return std::unexpected(PacsErrorInfo{
+                PacsError::NetworkError,
+                std::string("C-MOVE failed: ") + cond.text()
+            });
+        }
+
+        spdlog::info("C-MOVE completed: {} files received, {} failed (latency: {}ms)",
+                     result.progress.receivedImages,
+                     result.progress.failedImages,
+                     result.latency.count());
+
+        return result;
+    }
+
+    void buildMoveDataset(
+        DcmDataset* dataset,
+        RetrieveLevel level,
+        const std::string& studyUid,
+        const std::string& seriesUid,
+        const std::string& sopInstanceUid
+    ) {
+        // Set Query/Retrieve Level
+        dataset->putAndInsertString(DCM_QueryRetrieveLevel, retrieveLevelToString(level));
+
+        // Study UID is always required
+        dataset->putAndInsertString(DCM_StudyInstanceUID, studyUid.c_str());
+
+        // Series UID for Series and Image level
+        if (level >= RetrieveLevel::Series && !seriesUid.empty()) {
+            dataset->putAndInsertString(DCM_SeriesInstanceUID, seriesUid.c_str());
+        }
+
+        // SOP Instance UID for Image level
+        if (level == RetrieveLevel::Image && !sopInstanceUid.empty()) {
+            dataset->putAndInsertString(DCM_SOPInstanceUID, sopInstanceUid.c_str());
+        }
+    }
+};
+
+// Public interface implementation
+
+DicomMoveSCU::DicomMoveSCU()
+    : impl_(std::make_unique<Impl>()) {
+}
+
+DicomMoveSCU::~DicomMoveSCU() = default;
+
+DicomMoveSCU::DicomMoveSCU(DicomMoveSCU&&) noexcept = default;
+DicomMoveSCU& DicomMoveSCU::operator=(DicomMoveSCU&&) noexcept = default;
+
+std::expected<MoveResult, PacsErrorInfo> DicomMoveSCU::retrieveStudy(
+    const PacsServerConfig& config,
+    const MoveConfig& moveConfig,
+    const std::string& studyInstanceUid,
+    ProgressCallback progressCallback
+) {
+    return impl_->retrieveStudy(config, moveConfig, studyInstanceUid, progressCallback);
+}
+
+std::expected<MoveResult, PacsErrorInfo> DicomMoveSCU::retrieveSeries(
+    const PacsServerConfig& config,
+    const MoveConfig& moveConfig,
+    const std::string& studyInstanceUid,
+    const std::string& seriesInstanceUid,
+    ProgressCallback progressCallback
+) {
+    return impl_->retrieveSeries(config, moveConfig, studyInstanceUid, seriesInstanceUid, progressCallback);
+}
+
+std::expected<MoveResult, PacsErrorInfo> DicomMoveSCU::retrieveImage(
+    const PacsServerConfig& config,
+    const MoveConfig& moveConfig,
+    const std::string& studyInstanceUid,
+    const std::string& seriesInstanceUid,
+    const std::string& sopInstanceUid,
+    ProgressCallback progressCallback
+) {
+    return impl_->retrieveImage(config, moveConfig, studyInstanceUid, seriesInstanceUid, sopInstanceUid, progressCallback);
+}
+
+void DicomMoveSCU::cancel() {
+    impl_->cancel();
+}
+
+bool DicomMoveSCU::isRetrieving() const {
+    return impl_->isRetrieving();
+}
+
+std::optional<MoveProgress> DicomMoveSCU::currentProgress() const {
+    return impl_->currentProgress();
+}
+
+} // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -155,3 +155,20 @@ gtest_discover_tests(mpr_renderer_test)
 gtest_discover_tests(surface_renderer_test)
 gtest_discover_tests(dicom_echo_scu_test)
 gtest_discover_tests(dicom_find_scu_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for DICOM Move SCU
+add_executable(dicom_move_scu_test
+    unit/dicom_move_scu_test.cpp
+)
+
+target_link_libraries(dicom_move_scu_test PRIVATE
+    pacs_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(dicom_move_scu_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(dicom_move_scu_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/dicom_move_scu_test.cpp
+++ b/tests/unit/dicom_move_scu_test.cpp
@@ -1,0 +1,329 @@
+#include <gtest/gtest.h>
+
+#include "services/dicom_move_scu.hpp"
+#include "services/dicom_echo_scu.hpp"
+#include "services/dicom_find_scu.hpp"
+#include "services/pacs_config.hpp"
+
+#include <filesystem>
+#include <thread>
+
+using namespace dicom_viewer::services;
+
+class DicomMoveSCUTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        moveScu = std::make_unique<DicomMoveSCU>();
+
+        // Create temporary storage directory
+        tempDir = std::filesystem::temp_directory_path() / "dicom_move_test";
+        std::filesystem::create_directories(tempDir);
+    }
+
+    void TearDown() override {
+        moveScu.reset();
+
+        // Clean up temporary directory
+        std::error_code ec;
+        std::filesystem::remove_all(tempDir, ec);
+    }
+
+    std::unique_ptr<DicomMoveSCU> moveScu;
+    std::filesystem::path tempDir;
+};
+
+// Test MoveProgress structure
+TEST(MoveProgressTest, DefaultValues) {
+    MoveProgress progress;
+    EXPECT_EQ(progress.totalImages, 0);
+    EXPECT_EQ(progress.receivedImages, 0);
+    EXPECT_EQ(progress.failedImages, 0);
+    EXPECT_EQ(progress.warningImages, 0);
+    EXPECT_EQ(progress.remainingImages, 0);
+    EXPECT_TRUE(progress.currentStudyUid.empty());
+    EXPECT_TRUE(progress.currentSeriesUid.empty());
+}
+
+TEST(MoveProgressTest, IsCompleteWhenFinished) {
+    MoveProgress progress;
+    progress.totalImages = 10;
+    progress.receivedImages = 10;
+    progress.remainingImages = 0;
+    EXPECT_TRUE(progress.isComplete());
+}
+
+TEST(MoveProgressTest, IsNotCompleteWhenRemaining) {
+    MoveProgress progress;
+    progress.totalImages = 10;
+    progress.receivedImages = 5;
+    progress.remainingImages = 5;
+    EXPECT_FALSE(progress.isComplete());
+}
+
+TEST(MoveProgressTest, IsNotCompleteWhenNoTotal) {
+    MoveProgress progress;
+    progress.remainingImages = 0;
+    EXPECT_FALSE(progress.isComplete());
+}
+
+TEST(MoveProgressTest, PercentComplete) {
+    MoveProgress progress;
+    progress.totalImages = 100;
+    progress.receivedImages = 50;
+    progress.failedImages = 10;
+    EXPECT_FLOAT_EQ(progress.percentComplete(), 60.0f);
+}
+
+TEST(MoveProgressTest, PercentCompleteZeroTotal) {
+    MoveProgress progress;
+    EXPECT_FLOAT_EQ(progress.percentComplete(), 0.0f);
+}
+
+// Test MoveResult structure
+TEST(MoveResultTest, DefaultValues) {
+    MoveResult result;
+    EXPECT_EQ(result.latency.count(), 0);
+    EXPECT_TRUE(result.receivedFiles.empty());
+    EXPECT_FALSE(result.cancelled);
+}
+
+TEST(MoveResultTest, IsSuccessWhenAllReceived) {
+    MoveResult result;
+    result.progress.totalImages = 5;
+    result.progress.receivedImages = 5;
+    result.progress.failedImages = 0;
+    result.cancelled = false;
+    EXPECT_TRUE(result.isSuccess());
+}
+
+TEST(MoveResultTest, IsNotSuccessWhenCancelled) {
+    MoveResult result;
+    result.progress.totalImages = 5;
+    result.progress.receivedImages = 5;
+    result.cancelled = true;
+    EXPECT_FALSE(result.isSuccess());
+}
+
+TEST(MoveResultTest, IsNotSuccessWhenFailed) {
+    MoveResult result;
+    result.progress.totalImages = 5;
+    result.progress.receivedImages = 4;
+    result.progress.failedImages = 1;
+    EXPECT_FALSE(result.isSuccess());
+}
+
+TEST(MoveResultTest, HasFailures) {
+    MoveResult result;
+    result.progress.failedImages = 2;
+    EXPECT_TRUE(result.hasFailures());
+}
+
+TEST(MoveResultTest, NoFailures) {
+    MoveResult result;
+    result.progress.failedImages = 0;
+    EXPECT_FALSE(result.hasFailures());
+}
+
+// Test MoveConfig structure
+TEST(MoveConfigTest, DefaultValues) {
+    MoveConfig config;
+    EXPECT_TRUE(config.storageDirectory.empty());
+    EXPECT_FALSE(config.moveDestinationAeTitle.has_value());
+    EXPECT_EQ(config.storeScpPort, 0);
+    EXPECT_EQ(config.maxConcurrentOperations, 1);
+    EXPECT_TRUE(config.createSubdirectories);
+    EXPECT_TRUE(config.useOriginalFilenames);
+}
+
+// Test RetrieveLevel enum
+TEST(RetrieveLevelTest, EnumValues) {
+    EXPECT_EQ(static_cast<int>(RetrieveLevel::Study), 0);
+    EXPECT_EQ(static_cast<int>(RetrieveLevel::Series), 1);
+    EXPECT_EQ(static_cast<int>(RetrieveLevel::Image), 2);
+}
+
+// Test DicomMoveSCU construction
+TEST_F(DicomMoveSCUTest, DefaultConstruction) {
+    EXPECT_NE(moveScu, nullptr);
+}
+
+TEST_F(DicomMoveSCUTest, MoveConstructor) {
+    DicomMoveSCU moved(std::move(*moveScu));
+    EXPECT_FALSE(moved.isRetrieving());
+}
+
+TEST_F(DicomMoveSCUTest, MoveAssignment) {
+    DicomMoveSCU other;
+    other = std::move(*moveScu);
+    EXPECT_FALSE(other.isRetrieving());
+}
+
+// Test initial state
+TEST_F(DicomMoveSCUTest, InitialStateNotRetrieving) {
+    EXPECT_FALSE(moveScu->isRetrieving());
+}
+
+TEST_F(DicomMoveSCUTest, InitialStateNoProgress) {
+    auto progress = moveScu->currentProgress();
+    EXPECT_FALSE(progress.has_value());
+}
+
+// Test retrieveStudy with invalid config
+TEST_F(DicomMoveSCUTest, RetrieveStudyWithInvalidConfig) {
+    PacsServerConfig config;  // Invalid - empty hostname
+    MoveConfig moveConfig;
+    moveConfig.storageDirectory = tempDir;
+    moveConfig.queryRoot = QueryRoot::StudyRoot;
+
+    auto result = moveScu->retrieveStudy(config, moveConfig, "1.2.3.4.5");
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, PacsError::ConfigurationInvalid);
+}
+
+TEST_F(DicomMoveSCUTest, RetrieveStudyWithEmptyStorageDirectory) {
+    PacsServerConfig config;
+    config.hostname = "localhost";
+    config.calledAeTitle = "PACS_SERVER";
+
+    MoveConfig moveConfig;
+    moveConfig.storageDirectory = "";  // Invalid - empty
+    moveConfig.queryRoot = QueryRoot::StudyRoot;
+
+    auto result = moveScu->retrieveStudy(config, moveConfig, "1.2.3.4.5");
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, PacsError::ConfigurationInvalid);
+}
+
+// Test retrieveSeries with invalid config
+TEST_F(DicomMoveSCUTest, RetrieveSeriesWithInvalidConfig) {
+    PacsServerConfig config;  // Invalid - empty hostname
+    MoveConfig moveConfig;
+    moveConfig.storageDirectory = tempDir;
+    moveConfig.queryRoot = QueryRoot::StudyRoot;
+
+    auto result = moveScu->retrieveSeries(config, moveConfig, "1.2.3.4.5", "1.2.3.4.5.6");
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, PacsError::ConfigurationInvalid);
+}
+
+// Test retrieveImage with invalid config
+TEST_F(DicomMoveSCUTest, RetrieveImageWithInvalidConfig) {
+    PacsServerConfig config;  // Invalid - empty hostname
+    MoveConfig moveConfig;
+    moveConfig.storageDirectory = tempDir;
+    moveConfig.queryRoot = QueryRoot::StudyRoot;
+
+    auto result = moveScu->retrieveImage(config, moveConfig, "1.2.3.4.5", "1.2.3.4.5.6", "1.2.3.4.5.6.7");
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, PacsError::ConfigurationInvalid);
+}
+
+// Test with unreachable server
+TEST_F(DicomMoveSCUTest, RetrieveStudyWithUnreachableServer) {
+    PacsServerConfig config;
+    config.hostname = "192.0.2.1";  // TEST-NET-1, non-routable
+    config.port = 104;
+    config.calledAeTitle = "PACS_SERVER";
+    config.connectionTimeout = std::chrono::seconds(2);  // Short timeout
+
+    MoveConfig moveConfig;
+    moveConfig.storageDirectory = tempDir;
+    moveConfig.queryRoot = QueryRoot::StudyRoot;
+
+    auto result = moveScu->retrieveStudy(config, moveConfig, "1.2.3.4.5");
+    EXPECT_FALSE(result.has_value());
+    EXPECT_TRUE(
+        result.error().code == PacsError::ConnectionFailed ||
+        result.error().code == PacsError::Timeout ||
+        result.error().code == PacsError::NetworkError
+    );
+}
+
+// Test cancel functionality
+TEST_F(DicomMoveSCUTest, CancelDoesNotThrow) {
+    EXPECT_NO_THROW(moveScu->cancel());
+}
+
+// Test SOP Class UID constants
+TEST(DicomMoveSCUConstantsTest, PatientRootMoveSOPClassUID) {
+    EXPECT_STREQ(DicomMoveSCU::PATIENT_ROOT_MOVE_SOP_CLASS_UID,
+                 "1.2.840.10008.5.1.4.1.2.1.2");
+}
+
+TEST(DicomMoveSCUConstantsTest, StudyRootMoveSOPClassUID) {
+    EXPECT_STREQ(DicomMoveSCU::STUDY_ROOT_MOVE_SOP_CLASS_UID,
+                 "1.2.840.10008.5.1.4.1.2.2.2");
+}
+
+// Test MoveConfig with custom values
+TEST(MoveConfigTest, CustomValues) {
+    MoveConfig config;
+    config.queryRoot = QueryRoot::PatientRoot;
+    config.storageDirectory = "/tmp/dicom";
+    config.moveDestinationAeTitle = "RECEIVER";
+    config.storeScpPort = 11112;
+    config.maxConcurrentOperations = 4;
+    config.createSubdirectories = false;
+    config.useOriginalFilenames = false;
+
+    EXPECT_EQ(config.queryRoot, QueryRoot::PatientRoot);
+    EXPECT_EQ(config.storageDirectory, std::filesystem::path("/tmp/dicom"));
+    EXPECT_EQ(config.moveDestinationAeTitle.value(), "RECEIVER");
+    EXPECT_EQ(config.storeScpPort, 11112);
+    EXPECT_EQ(config.maxConcurrentOperations, 4);
+    EXPECT_FALSE(config.createSubdirectories);
+    EXPECT_FALSE(config.useOriginalFilenames);
+}
+
+// Test MoveProgress computation
+TEST(MoveProgressTest, PartialProgress) {
+    MoveProgress progress;
+    progress.totalImages = 100;
+    progress.receivedImages = 45;
+    progress.failedImages = 5;
+    progress.remainingImages = 50;
+
+    EXPECT_FLOAT_EQ(progress.percentComplete(), 50.0f);
+    EXPECT_FALSE(progress.isComplete());
+}
+
+// Test thread safety (basic check)
+TEST_F(DicomMoveSCUTest, ConcurrentCancelSafe) {
+    std::thread t1([this]() {
+        for (int i = 0; i < 100; ++i) {
+            moveScu->cancel();
+        }
+    });
+
+    std::thread t2([this]() {
+        for (int i = 0; i < 100; ++i) {
+            (void)moveScu->isRetrieving();
+        }
+    });
+
+    t1.join();
+    t2.join();
+
+    EXPECT_FALSE(moveScu->isRetrieving());
+}
+
+// Test storage directory creation
+TEST_F(DicomMoveSCUTest, StorageDirectoryCreatedOnError) {
+    PacsServerConfig config;
+    config.hostname = "192.0.2.1";
+    config.port = 104;
+    config.calledAeTitle = "PACS_SERVER";
+    config.connectionTimeout = std::chrono::seconds(1);
+
+    auto nestedDir = tempDir / "nested" / "deep" / "path";
+    MoveConfig moveConfig;
+    moveConfig.storageDirectory = nestedDir;
+    moveConfig.queryRoot = QueryRoot::StudyRoot;
+
+    // Even though the operation will fail, the directory should be created
+    auto result = moveScu->retrieveStudy(config, moveConfig, "1.2.3.4.5");
+    EXPECT_FALSE(result.has_value());
+
+    // Directory should have been created before the connection attempt
+    EXPECT_TRUE(std::filesystem::exists(nestedDir));
+}


### PR DESCRIPTION
## Summary
- Implement `DicomMoveSCU` class for retrieving images from PACS servers using C-MOVE protocol
- Support Study, Series, and Image level retrieval with progress tracking
- Handle sub-operations for receiving C-STORE images from PACS

## Changes
- Add `include/services/dicom_move_scu.hpp` - Public API with MoveProgress, MoveConfig, MoveResult structures
- Add `src/services/pacs/dicom_move_scu.cpp` - DCMTK-based implementation
- Add `tests/unit/dicom_move_scu_test.cpp` - 31 unit tests covering all functionality
- Update CMakeLists.txt to include new source files

## Features
- `retrieveStudy()` - Retrieve all images in a study
- `retrieveSeries()` - Retrieve all images in a series
- `retrieveImage()` - Retrieve a single image
- `cancel()` - Thread-safe cancellation of ongoing operations
- `currentProgress()` - Query current operation progress
- Progress callback for real-time status updates

## Technical Details
- Uses DCMTK `DIMSE_moveUser` for C-MOVE operations
- Implements sub-operation callback for handling incoming C-STORE requests
- Thread-safe progress tracking with mutex protection
- Configurable storage directory with optional subdirectory creation
- Support for both Patient Root and Study Root Query/Retrieve Models

## Test plan
- [x] All 31 unit tests passing
- [x] Build verification on macOS with DCMTK
- [ ] Integration test with real PACS server (manual)

Resolves #20