### PR TITLE
feat(segmentation): implement threshold-based segmentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,15 @@ target_link_libraries(measurement_service PUBLIC
     ${ITK_LIBRARIES}
 )
 
+add_library(segmentation_service STATIC
+    src/services/segmentation/threshold_segmenter.cpp
+)
+
+target_link_libraries(segmentation_service PUBLIC
+    dicom_viewer_core
+    ${ITK_LIBRARIES}
+)
+
 add_library(pacs_service STATIC
     src/services/pacs/dicom_echo_scu.cpp
     src/services/pacs/dicom_find_scu.cpp
@@ -181,6 +190,7 @@ target_link_libraries(dicom_viewer_controller PUBLIC
     image_service
     render_service
     measurement_service
+    segmentation_service
     pacs_service
 )
 

--- a/include/services/segmentation/threshold_segmenter.hpp
+++ b/include/services/segmentation/threshold_segmenter.hpp
@@ -1,0 +1,282 @@
+#pragma once
+
+#include <expected>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <itkImage.h>
+#include <itkSmartPointer.h>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Error information for segmentation operations
+ */
+struct SegmentationError {
+    enum class Code {
+        Success,
+        InvalidInput,
+        InvalidParameters,
+        ProcessingFailed,
+        InternalError
+    };
+
+    Code code = Code::Success;
+    std::string message;
+
+    [[nodiscard]] bool isSuccess() const noexcept {
+        return code == Code::Success;
+    }
+
+    [[nodiscard]] std::string toString() const {
+        switch (code) {
+            case Code::Success: return "Success";
+            case Code::InvalidInput: return "Invalid input: " + message;
+            case Code::InvalidParameters: return "Invalid parameters: " + message;
+            case Code::ProcessingFailed: return "Processing failed: " + message;
+            case Code::InternalError: return "Internal error: " + message;
+        }
+        return "Unknown error";
+    }
+};
+
+/**
+ * @brief Result of Otsu threshold calculation
+ */
+struct OtsuThresholdResult {
+    /// Calculated threshold value
+    double threshold;
+
+    /// Binary mask from thresholding
+    using BinaryMaskType = itk::Image<unsigned char, 3>;
+    BinaryMaskType::Pointer mask;
+};
+
+/**
+ * @brief Result of multi-threshold Otsu calculation
+ */
+struct OtsuMultiThresholdResult {
+    /// Calculated threshold values (sorted ascending)
+    std::vector<double> thresholds;
+
+    /// Label map with regions (0 = below first threshold, 1..N = between thresholds)
+    using LabelMapType = itk::Image<unsigned char, 3>;
+    LabelMapType::Pointer labelMap;
+};
+
+/**
+ * @brief Threshold-based segmentation using ITK filters
+ *
+ * Provides manual and automatic threshold segmentation capabilities
+ * for CT/MRI medical images based on HU or signal intensity values.
+ *
+ * Supported algorithms:
+ * - Manual binary threshold (user-defined lower/upper bounds)
+ * - Otsu automatic threshold
+ * - Multi-class Otsu threshold
+ *
+ * @example
+ * @code
+ * ThresholdSegmenter segmenter;
+ *
+ * // Manual thresholding for bone segmentation
+ * auto result = segmenter.manualThreshold(ctImage, 200.0, 3000.0);
+ * if (result) {
+ *     auto boneMask = result.value();
+ * }
+ *
+ * // Automatic Otsu thresholding
+ * auto otsuResult = segmenter.otsuThreshold(mrImage);
+ * if (otsuResult) {
+ *     double threshold = otsuResult->threshold;
+ *     auto mask = otsuResult->mask;
+ * }
+ * @endcode
+ *
+ * @trace SRS-FR-020
+ */
+class ThresholdSegmenter {
+public:
+    /// Input image type (typically CT or MRI)
+    using ImageType = itk::Image<short, 3>;
+
+    /// Binary mask output type
+    using BinaryMaskType = itk::Image<unsigned char, 3>;
+
+    /// Label map type for multi-threshold
+    using LabelMapType = itk::Image<unsigned char, 3>;
+
+    /// Progress callback (0.0 to 1.0)
+    using ProgressCallback = std::function<void(double progress)>;
+
+    /**
+     * @brief Parameters for manual threshold segmentation
+     */
+    struct ThresholdParameters {
+        /// Lower threshold value (inclusive)
+        double lowerThreshold = 0.0;
+
+        /// Upper threshold value (inclusive)
+        double upperThreshold = 3000.0;
+
+        /// Value for pixels inside the threshold range
+        unsigned char insideValue = 1;
+
+        /// Value for pixels outside the threshold range
+        unsigned char outsideValue = 0;
+
+        /**
+         * @brief Validate parameters
+         * @return true if parameters are valid
+         */
+        [[nodiscard]] bool isValid() const noexcept {
+            return lowerThreshold <= upperThreshold;
+        }
+    };
+
+    /**
+     * @brief Parameters for Otsu threshold
+     */
+    struct OtsuParameters {
+        /// Number of histogram bins (default 256)
+        unsigned int numberOfHistogramBins = 256;
+
+        /// For multi-threshold: number of thresholds (2-255)
+        unsigned int numberOfThresholds = 1;
+
+        /// Value spread across thresholds (for multi-threshold)
+        bool valleyEmphasis = false;
+    };
+
+    ThresholdSegmenter() = default;
+    ~ThresholdSegmenter() = default;
+
+    // Copyable and movable
+    ThresholdSegmenter(const ThresholdSegmenter&) = default;
+    ThresholdSegmenter& operator=(const ThresholdSegmenter&) = default;
+    ThresholdSegmenter(ThresholdSegmenter&&) noexcept = default;
+    ThresholdSegmenter& operator=(ThresholdSegmenter&&) noexcept = default;
+
+    /**
+     * @brief Apply manual binary threshold segmentation
+     *
+     * Segments the image using user-defined lower and upper threshold values.
+     * Pixels within [lower, upper] are set to insideValue, others to outsideValue.
+     *
+     * @param input Input 3D image
+     * @param lowerThreshold Lower threshold (HU value for CT)
+     * @param upperThreshold Upper threshold (HU value for CT)
+     * @return Binary mask on success, error on failure
+     */
+    [[nodiscard]] std::expected<BinaryMaskType::Pointer, SegmentationError>
+    manualThreshold(
+        ImageType::Pointer input,
+        double lowerThreshold,
+        double upperThreshold
+    ) const;
+
+    /**
+     * @brief Apply manual binary threshold with detailed parameters
+     *
+     * @param input Input 3D image
+     * @param params Threshold parameters
+     * @return Binary mask on success, error on failure
+     */
+    [[nodiscard]] std::expected<BinaryMaskType::Pointer, SegmentationError>
+    manualThreshold(
+        ImageType::Pointer input,
+        const ThresholdParameters& params
+    ) const;
+
+    /**
+     * @brief Apply Otsu automatic threshold segmentation with default parameters
+     *
+     * Automatically calculates optimal threshold using Otsu's method
+     * to maximize between-class variance.
+     *
+     * @param input Input 3D image
+     * @return Threshold result with calculated value and mask
+     */
+    [[nodiscard]] std::expected<OtsuThresholdResult, SegmentationError>
+    otsuThreshold(ImageType::Pointer input) const;
+
+    /**
+     * @brief Apply Otsu automatic threshold segmentation
+     *
+     * Automatically calculates optimal threshold using Otsu's method
+     * to maximize between-class variance.
+     *
+     * @param input Input 3D image
+     * @param params Otsu parameters
+     * @return Threshold result with calculated value and mask
+     */
+    [[nodiscard]] std::expected<OtsuThresholdResult, SegmentationError>
+    otsuThreshold(
+        ImageType::Pointer input,
+        const OtsuParameters& params
+    ) const;
+
+    /**
+     * @brief Apply multi-class Otsu threshold segmentation with default parameters
+     *
+     * Segments image into multiple classes using multiple thresholds.
+     * Results in N+1 regions for N thresholds.
+     *
+     * @param input Input 3D image
+     * @param numThresholds Number of thresholds (2-255, creates numThresholds+1 regions)
+     * @return Multi-threshold result with thresholds and label map
+     */
+    [[nodiscard]] std::expected<OtsuMultiThresholdResult, SegmentationError>
+    otsuMultiThreshold(
+        ImageType::Pointer input,
+        unsigned int numThresholds
+    ) const;
+
+    /**
+     * @brief Apply multi-class Otsu threshold segmentation
+     *
+     * Segments image into multiple classes using multiple thresholds.
+     * Results in N+1 regions for N thresholds.
+     *
+     * @param input Input 3D image
+     * @param numThresholds Number of thresholds (2-255, creates numThresholds+1 regions)
+     * @param params Otsu parameters
+     * @return Multi-threshold result with thresholds and label map
+     */
+    [[nodiscard]] std::expected<OtsuMultiThresholdResult, SegmentationError>
+    otsuMultiThreshold(
+        ImageType::Pointer input,
+        unsigned int numThresholds,
+        const OtsuParameters& params
+    ) const;
+
+    /**
+     * @brief Apply threshold to a single 2D slice (for preview)
+     *
+     * @param input Input 3D image
+     * @param sliceIndex Slice index (along Z axis)
+     * @param lowerThreshold Lower threshold
+     * @param upperThreshold Upper threshold
+     * @return 2D binary mask for the specified slice
+     */
+    [[nodiscard]] std::expected<itk::Image<unsigned char, 2>::Pointer, SegmentationError>
+    thresholdSlice(
+        ImageType::Pointer input,
+        unsigned int sliceIndex,
+        double lowerThreshold,
+        double upperThreshold
+    ) const;
+
+    /**
+     * @brief Set progress callback for long operations
+     * @param callback Progress callback function
+     */
+    void setProgressCallback(ProgressCallback callback);
+
+private:
+    ProgressCallback progressCallback_;
+};
+
+} // namespace dicom_viewer::services

--- a/src/services/segmentation/threshold_segmenter.cpp
+++ b/src/services/segmentation/threshold_segmenter.cpp
@@ -1,0 +1,328 @@
+#include "services/segmentation/threshold_segmenter.hpp"
+
+#include <itkBinaryThresholdImageFilter.h>
+#include <itkOtsuThresholdImageFilter.h>
+#include <itkOtsuMultipleThresholdsImageFilter.h>
+#include <itkExtractImageFilter.h>
+#include <itkCommand.h>
+
+namespace dicom_viewer::services {
+
+namespace {
+
+/**
+ * @brief ITK progress observer for callback integration
+ */
+class ProgressObserver : public itk::Command {
+public:
+    using Self = ProgressObserver;
+    using Superclass = itk::Command;
+    using Pointer = itk::SmartPointer<Self>;
+
+    itkNewMacro(Self);
+
+    void setCallback(ThresholdSegmenter::ProgressCallback callback) {
+        callback_ = std::move(callback);
+    }
+
+    void Execute(itk::Object* caller, const itk::EventObject& event) override {
+        Execute(static_cast<const itk::Object*>(caller), event);
+    }
+
+    void Execute(const itk::Object* caller, const itk::EventObject& event) override {
+        if (!callback_) return;
+
+        if (itk::ProgressEvent().CheckEvent(&event)) {
+            const auto* process = dynamic_cast<const itk::ProcessObject*>(caller);
+            if (process) {
+                callback_(process->GetProgress());
+            }
+        }
+    }
+
+private:
+    ThresholdSegmenter::ProgressCallback callback_;
+};
+
+} // anonymous namespace
+
+std::expected<ThresholdSegmenter::BinaryMaskType::Pointer, SegmentationError>
+ThresholdSegmenter::manualThreshold(
+    ImageType::Pointer input,
+    double lowerThreshold,
+    double upperThreshold
+) const {
+    ThresholdParameters params;
+    params.lowerThreshold = lowerThreshold;
+    params.upperThreshold = upperThreshold;
+    return manualThreshold(input, params);
+}
+
+std::expected<ThresholdSegmenter::BinaryMaskType::Pointer, SegmentationError>
+ThresholdSegmenter::manualThreshold(
+    ImageType::Pointer input,
+    const ThresholdParameters& params
+) const {
+    // Validate input
+    if (!input) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Input image is null"
+        });
+    }
+
+    // Validate parameters
+    if (!params.isValid()) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidParameters,
+            "Lower threshold must be <= upper threshold"
+        });
+    }
+
+    try {
+        using FilterType = itk::BinaryThresholdImageFilter<ImageType, BinaryMaskType>;
+        auto filter = FilterType::New();
+
+        filter->SetInput(input);
+        filter->SetLowerThreshold(static_cast<ImageType::PixelType>(params.lowerThreshold));
+        filter->SetUpperThreshold(static_cast<ImageType::PixelType>(params.upperThreshold));
+        filter->SetInsideValue(params.insideValue);
+        filter->SetOutsideValue(params.outsideValue);
+
+        // Attach progress observer if callback is set
+        if (progressCallback_) {
+            auto observer = ProgressObserver::New();
+            observer->setCallback(progressCallback_);
+            filter->AddObserver(itk::ProgressEvent(), observer);
+        }
+
+        filter->Update();
+
+        return filter->GetOutput();
+    }
+    catch (const itk::ExceptionObject& e) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::ProcessingFailed,
+            std::string("ITK exception: ") + e.GetDescription()
+        });
+    }
+    catch (const std::exception& e) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InternalError,
+            std::string("Standard exception: ") + e.what()
+        });
+    }
+}
+
+std::expected<OtsuThresholdResult, SegmentationError>
+ThresholdSegmenter::otsuThreshold(ImageType::Pointer input) const {
+    return otsuThreshold(input, OtsuParameters{});
+}
+
+std::expected<OtsuThresholdResult, SegmentationError>
+ThresholdSegmenter::otsuThreshold(
+    ImageType::Pointer input,
+    const OtsuParameters& params
+) const {
+    // Validate input
+    if (!input) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Input image is null"
+        });
+    }
+
+    try {
+        using FilterType = itk::OtsuThresholdImageFilter<ImageType, BinaryMaskType>;
+        auto filter = FilterType::New();
+
+        filter->SetInput(input);
+        filter->SetNumberOfHistogramBins(params.numberOfHistogramBins);
+        filter->SetInsideValue(1);
+        filter->SetOutsideValue(0);
+
+        // Attach progress observer if callback is set
+        if (progressCallback_) {
+            auto observer = ProgressObserver::New();
+            observer->setCallback(progressCallback_);
+            filter->AddObserver(itk::ProgressEvent(), observer);
+        }
+
+        filter->Update();
+
+        OtsuThresholdResult result;
+        result.threshold = static_cast<double>(filter->GetThreshold());
+        result.mask = filter->GetOutput();
+
+        return result;
+    }
+    catch (const itk::ExceptionObject& e) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::ProcessingFailed,
+            std::string("ITK exception: ") + e.GetDescription()
+        });
+    }
+    catch (const std::exception& e) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InternalError,
+            std::string("Standard exception: ") + e.what()
+        });
+    }
+}
+
+std::expected<OtsuMultiThresholdResult, SegmentationError>
+ThresholdSegmenter::otsuMultiThreshold(
+    ImageType::Pointer input,
+    unsigned int numThresholds
+) const {
+    return otsuMultiThreshold(input, numThresholds, OtsuParameters{});
+}
+
+std::expected<OtsuMultiThresholdResult, SegmentationError>
+ThresholdSegmenter::otsuMultiThreshold(
+    ImageType::Pointer input,
+    unsigned int numThresholds,
+    const OtsuParameters& params
+) const {
+    // Validate input
+    if (!input) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Input image is null"
+        });
+    }
+
+    // Validate number of thresholds
+    if (numThresholds < 1 || numThresholds > 255) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidParameters,
+            "Number of thresholds must be between 1 and 255"
+        });
+    }
+
+    try {
+        using FilterType = itk::OtsuMultipleThresholdsImageFilter<ImageType, LabelMapType>;
+        auto filter = FilterType::New();
+
+        filter->SetInput(input);
+        filter->SetNumberOfThresholds(numThresholds);
+        filter->SetNumberOfHistogramBins(params.numberOfHistogramBins);
+        filter->SetValleyEmphasis(params.valleyEmphasis);
+
+        // Attach progress observer if callback is set
+        if (progressCallback_) {
+            auto observer = ProgressObserver::New();
+            observer->setCallback(progressCallback_);
+            filter->AddObserver(itk::ProgressEvent(), observer);
+        }
+
+        filter->Update();
+
+        OtsuMultiThresholdResult result;
+
+        // Copy thresholds
+        const auto& thresholds = filter->GetThresholds();
+        result.thresholds.reserve(thresholds.size());
+        for (const auto& t : thresholds) {
+            result.thresholds.push_back(static_cast<double>(t));
+        }
+
+        result.labelMap = filter->GetOutput();
+
+        return result;
+    }
+    catch (const itk::ExceptionObject& e) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::ProcessingFailed,
+            std::string("ITK exception: ") + e.GetDescription()
+        });
+    }
+    catch (const std::exception& e) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InternalError,
+            std::string("Standard exception: ") + e.what()
+        });
+    }
+}
+
+std::expected<itk::Image<unsigned char, 2>::Pointer, SegmentationError>
+ThresholdSegmenter::thresholdSlice(
+    ImageType::Pointer input,
+    unsigned int sliceIndex,
+    double lowerThreshold,
+    double upperThreshold
+) const {
+    // Validate input
+    if (!input) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Input image is null"
+        });
+    }
+
+    // Validate parameters
+    if (lowerThreshold > upperThreshold) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidParameters,
+            "Lower threshold must be <= upper threshold"
+        });
+    }
+
+    // Validate slice index
+    auto region = input->GetLargestPossibleRegion();
+    auto size = region.GetSize();
+    if (sliceIndex >= size[2]) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidParameters,
+            "Slice index out of range"
+        });
+    }
+
+    try {
+        // Extract 2D slice
+        using ExtractFilterType = itk::ExtractImageFilter<ImageType, itk::Image<short, 2>>;
+        auto extractFilter = ExtractFilterType::New();
+        extractFilter->SetDirectionCollapseToSubmatrix();
+
+        ImageType::RegionType extractRegion = region;
+        extractRegion.SetSize(2, 0);  // Collapse Z dimension
+        extractRegion.SetIndex(2, sliceIndex);
+
+        extractFilter->SetExtractionRegion(extractRegion);
+        extractFilter->SetInput(input);
+
+        // Apply threshold to 2D slice
+        using Image2DType = itk::Image<short, 2>;
+        using Mask2DType = itk::Image<unsigned char, 2>;
+        using ThresholdFilterType = itk::BinaryThresholdImageFilter<Image2DType, Mask2DType>;
+        auto thresholdFilter = ThresholdFilterType::New();
+
+        thresholdFilter->SetInput(extractFilter->GetOutput());
+        thresholdFilter->SetLowerThreshold(static_cast<short>(lowerThreshold));
+        thresholdFilter->SetUpperThreshold(static_cast<short>(upperThreshold));
+        thresholdFilter->SetInsideValue(1);
+        thresholdFilter->SetOutsideValue(0);
+
+        thresholdFilter->Update();
+
+        return thresholdFilter->GetOutput();
+    }
+    catch (const itk::ExceptionObject& e) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::ProcessingFailed,
+            std::string("ITK exception: ") + e.GetDescription()
+        });
+    }
+    catch (const std::exception& e) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InternalError,
+            std::string("Standard exception: ") + e.what()
+        });
+    }
+}
+
+void ThresholdSegmenter::setProgressCallback(ProgressCallback callback) {
+    progressCallback_ = std::move(callback);
+}
+
+} // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -208,3 +208,20 @@ target_include_directories(dicom_store_scp_test PRIVATE
 )
 
 gtest_discover_tests(dicom_store_scp_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for Threshold Segmenter
+add_executable(threshold_segmenter_test
+    unit/threshold_segmenter_test.cpp
+)
+
+target_link_libraries(threshold_segmenter_test PRIVATE
+    segmentation_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(threshold_segmenter_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(threshold_segmenter_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/threshold_segmenter_test.cpp
+++ b/tests/unit/threshold_segmenter_test.cpp
@@ -1,0 +1,328 @@
+#include <gtest/gtest.h>
+
+#include "services/segmentation/threshold_segmenter.hpp"
+
+#include <itkImageRegionIterator.h>
+
+using namespace dicom_viewer::services;
+
+class ThresholdSegmenterTest : public ::testing::Test {
+protected:
+    using ImageType = ThresholdSegmenter::ImageType;
+    using BinaryMaskType = ThresholdSegmenter::BinaryMaskType;
+
+    void SetUp() override {
+        segmenter_ = std::make_unique<ThresholdSegmenter>();
+    }
+
+    /**
+     * @brief Create a test image with known pixel values
+     *
+     * Creates a 10x10x10 image where pixel value = x + y * 10 + z * 100
+     * This gives values from 0 to 999
+     */
+    ImageType::Pointer createTestImage(
+        unsigned int sizeX = 10,
+        unsigned int sizeY = 10,
+        unsigned int sizeZ = 10
+    ) {
+        auto image = ImageType::New();
+
+        ImageType::SizeType size;
+        size[0] = sizeX;
+        size[1] = sizeY;
+        size[2] = sizeZ;
+
+        ImageType::IndexType start;
+        start.Fill(0);
+
+        ImageType::RegionType region;
+        region.SetSize(size);
+        region.SetIndex(start);
+
+        image->SetRegions(region);
+        image->Allocate();
+
+        // Fill with predictable values
+        itk::ImageRegionIterator<ImageType> it(image, region);
+        for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+            auto idx = it.GetIndex();
+            it.Set(static_cast<short>(idx[0] + idx[1] * 10 + idx[2] * 100));
+        }
+
+        return image;
+    }
+
+    /**
+     * @brief Count non-zero pixels in binary mask
+     */
+    int countNonZeroPixels(BinaryMaskType::Pointer mask) {
+        int count = 0;
+        itk::ImageRegionIterator<BinaryMaskType> it(
+            mask, mask->GetLargestPossibleRegion()
+        );
+        for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+            if (it.Get() != 0) {
+                ++count;
+            }
+        }
+        return count;
+    }
+
+    std::unique_ptr<ThresholdSegmenter> segmenter_;
+};
+
+// Basic functionality tests
+TEST_F(ThresholdSegmenterTest, ManualThresholdReturnsValidMask) {
+    auto image = createTestImage();
+    auto result = segmenter_->manualThreshold(image, 0.0, 100.0);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NE(result.value(), nullptr);
+}
+
+TEST_F(ThresholdSegmenterTest, ManualThresholdHandlesNullInput) {
+    auto result = segmenter_->manualThreshold(nullptr, 0.0, 100.0);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+TEST_F(ThresholdSegmenterTest, ManualThresholdRejectsInvalidRange) {
+    auto image = createTestImage();
+    // Upper < Lower
+    auto result = segmenter_->manualThreshold(image, 100.0, 50.0);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidParameters);
+}
+
+TEST_F(ThresholdSegmenterTest, ManualThresholdSegmentsCorrectPixels) {
+    auto image = createTestImage();
+    // Only first two Z slices have values < 200
+    auto result = segmenter_->manualThreshold(image, 0.0, 199.0);
+
+    ASSERT_TRUE(result.has_value());
+
+    // First two slices (z=0, z=1) have values 0-109 and 100-209
+    // Values in range [0, 199] should be marked
+    int nonZeroCount = countNonZeroPixels(result.value());
+    EXPECT_GT(nonZeroCount, 0);
+    EXPECT_LT(nonZeroCount, 1000);  // Not all pixels
+}
+
+TEST_F(ThresholdSegmenterTest, ManualThresholdWithParametersStruct) {
+    auto image = createTestImage();
+
+    ThresholdSegmenter::ThresholdParameters params;
+    params.lowerThreshold = 100.0;
+    params.upperThreshold = 300.0;
+    params.insideValue = 255;
+    params.outsideValue = 0;
+
+    auto result = segmenter_->manualThreshold(image, params);
+
+    ASSERT_TRUE(result.has_value());
+
+    // Check that inside value is 255
+    itk::ImageRegionIterator<BinaryMaskType> it(
+        result.value(), result.value()->GetLargestPossibleRegion()
+    );
+    bool found255 = false;
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        if (it.Get() == 255) {
+            found255 = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found255);
+}
+
+// Otsu threshold tests
+TEST_F(ThresholdSegmenterTest, OtsuThresholdReturnsValidResult) {
+    auto image = createTestImage();
+    auto result = segmenter_->otsuThreshold(image);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NE(result->mask, nullptr);
+    // Threshold should be somewhere in the middle of the value range
+    EXPECT_GT(result->threshold, 0.0);
+    EXPECT_LT(result->threshold, 1000.0);
+}
+
+TEST_F(ThresholdSegmenterTest, OtsuThresholdHandlesNullInput) {
+    auto result = segmenter_->otsuThreshold(nullptr);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+TEST_F(ThresholdSegmenterTest, OtsuThresholdWithCustomBins) {
+    auto image = createTestImage();
+
+    ThresholdSegmenter::OtsuParameters params;
+    params.numberOfHistogramBins = 128;
+
+    auto result = segmenter_->otsuThreshold(image, params);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NE(result->mask, nullptr);
+}
+
+// Multi-threshold Otsu tests
+TEST_F(ThresholdSegmenterTest, OtsuMultiThresholdReturnsValidResult) {
+    auto image = createTestImage();
+    auto result = segmenter_->otsuMultiThreshold(image, 2);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NE(result->labelMap, nullptr);
+    EXPECT_EQ(result->thresholds.size(), 2u);
+    // Thresholds should be sorted
+    EXPECT_LT(result->thresholds[0], result->thresholds[1]);
+}
+
+TEST_F(ThresholdSegmenterTest, OtsuMultiThresholdHandlesNullInput) {
+    auto result = segmenter_->otsuMultiThreshold(nullptr, 2);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+TEST_F(ThresholdSegmenterTest, OtsuMultiThresholdRejectsInvalidCount) {
+    auto image = createTestImage();
+
+    // Zero thresholds
+    auto result = segmenter_->otsuMultiThreshold(image, 0);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidParameters);
+}
+
+TEST_F(ThresholdSegmenterTest, OtsuMultiThresholdCreatesMultipleRegions) {
+    auto image = createTestImage();
+    auto result = segmenter_->otsuMultiThreshold(image, 3);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->thresholds.size(), 3u);
+
+    // Should have labels 0, 1, 2, 3 (4 regions for 3 thresholds)
+    std::set<unsigned char> labels;
+    itk::ImageRegionIterator<ThresholdSegmenter::LabelMapType> it(
+        result->labelMap, result->labelMap->GetLargestPossibleRegion()
+    );
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        labels.insert(it.Get());
+    }
+    EXPECT_GE(labels.size(), 2u);  // At least 2 different labels
+}
+
+// Slice threshold tests
+TEST_F(ThresholdSegmenterTest, ThresholdSliceReturns2DMask) {
+    auto image = createTestImage();
+    auto result = segmenter_->thresholdSlice(image, 0, 0.0, 50.0);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NE(result.value(), nullptr);
+
+    // Check output is 2D
+    auto region = result.value()->GetLargestPossibleRegion();
+    EXPECT_EQ(region.GetSize()[0], 10u);
+    EXPECT_EQ(region.GetSize()[1], 10u);
+}
+
+TEST_F(ThresholdSegmenterTest, ThresholdSliceHandlesNullInput) {
+    auto result = segmenter_->thresholdSlice(nullptr, 0, 0.0, 50.0);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+TEST_F(ThresholdSegmenterTest, ThresholdSliceRejectsInvalidSliceIndex) {
+    auto image = createTestImage();
+    auto result = segmenter_->thresholdSlice(image, 100, 0.0, 50.0);  // Out of range
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidParameters);
+}
+
+TEST_F(ThresholdSegmenterTest, ThresholdSliceRejectsInvalidThresholdRange) {
+    auto image = createTestImage();
+    auto result = segmenter_->thresholdSlice(image, 0, 100.0, 50.0);  // Lower > Upper
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidParameters);
+}
+
+// Parameter validation tests
+TEST_F(ThresholdSegmenterTest, ThresholdParametersValidationWorks) {
+    ThresholdSegmenter::ThresholdParameters valid;
+    valid.lowerThreshold = 0.0;
+    valid.upperThreshold = 100.0;
+    EXPECT_TRUE(valid.isValid());
+
+    ThresholdSegmenter::ThresholdParameters equal;
+    equal.lowerThreshold = 50.0;
+    equal.upperThreshold = 50.0;
+    EXPECT_TRUE(equal.isValid());
+
+    ThresholdSegmenter::ThresholdParameters invalid;
+    invalid.lowerThreshold = 100.0;
+    invalid.upperThreshold = 50.0;
+    EXPECT_FALSE(invalid.isValid());
+}
+
+// Progress callback tests
+TEST_F(ThresholdSegmenterTest, ProgressCallbackIsCalled) {
+    auto image = createTestImage();
+
+    bool callbackCalled = false;
+    segmenter_->setProgressCallback([&callbackCalled](double /*progress*/) {
+        callbackCalled = true;
+    });
+
+    auto result = segmenter_->manualThreshold(image, 0.0, 500.0);
+
+    ASSERT_TRUE(result.has_value());
+    // Note: Progress callback may not be called for very fast operations
+    // This test just ensures no crash occurs
+}
+
+// Error message tests
+TEST_F(ThresholdSegmenterTest, SegmentationErrorToStringWorks) {
+    SegmentationError success{SegmentationError::Code::Success, ""};
+    EXPECT_EQ(success.toString(), "Success");
+
+    SegmentationError invalidInput{SegmentationError::Code::InvalidInput, "null pointer"};
+    EXPECT_TRUE(invalidInput.toString().find("Invalid input") != std::string::npos);
+
+    SegmentationError invalidParams{SegmentationError::Code::InvalidParameters, "bad range"};
+    EXPECT_TRUE(invalidParams.toString().find("Invalid parameters") != std::string::npos);
+}
+
+TEST_F(ThresholdSegmenterTest, SegmentationErrorIsSuccessWorks) {
+    SegmentationError success{SegmentationError::Code::Success, ""};
+    EXPECT_TRUE(success.isSuccess());
+
+    SegmentationError failure{SegmentationError::Code::InvalidInput, "error"};
+    EXPECT_FALSE(failure.isSuccess());
+}
+
+// Edge case tests
+TEST_F(ThresholdSegmenterTest, ManualThresholdHandlesEntireRange) {
+    auto image = createTestImage();
+    // All pixels should be selected
+    auto result = segmenter_->manualThreshold(image, -32768.0, 32767.0);
+
+    ASSERT_TRUE(result.has_value());
+    int nonZeroCount = countNonZeroPixels(result.value());
+    EXPECT_EQ(nonZeroCount, 1000);  // All 10x10x10 pixels
+}
+
+TEST_F(ThresholdSegmenterTest, ManualThresholdHandlesEmptyRange) {
+    auto image = createTestImage();
+    // No pixels should match (values are 0-999, threshold is > 1000)
+    auto result = segmenter_->manualThreshold(image, 1000.0, 2000.0);
+
+    ASSERT_TRUE(result.has_value());
+    int nonZeroCount = countNonZeroPixels(result.value());
+    EXPECT_EQ(nonZeroCount, 0);
+}


### PR DESCRIPTION
## Summary

- Implement `ThresholdSegmenter` class with ITK BinaryThreshold, Otsu, and Multi-Otsu filters
- Add manual threshold segmentation with user-defined lower/upper bounds
- Add automatic Otsu threshold calculation for optimal binary segmentation
- Add multi-class Otsu threshold for segmenting multiple regions

## Implementation Details

### ThresholdSegmenter API
```cpp
class ThresholdSegmenter {
public:
    // Manual binary threshold
    std::expected<BinaryMaskType::Pointer, SegmentationError>
    manualThreshold(ImageType::Pointer input, double lower, double upper);

    // Otsu automatic threshold
    std::expected<OtsuThresholdResult, SegmentationError>
    otsuThreshold(ImageType::Pointer input);

    // Multi-class Otsu threshold
    std::expected<OtsuMultiThresholdResult, SegmentationError>
    otsuMultiThreshold(ImageType::Pointer input, unsigned int numThresholds);

    // 2D slice preview
    std::expected<Image2D::Pointer, SegmentationError>
    thresholdSlice(ImageType::Pointer input, unsigned int sliceIndex,
                   double lower, double upper);
};
```

### Key Features
- Full ITK integration with proper error handling
- Progress callback support for long operations
- Comprehensive parameter validation
- 2D slice preview for real-time feedback

## Test Plan

- [x] Manual threshold with valid parameters
- [x] Manual threshold with null input (error handling)
- [x] Manual threshold with invalid range (error handling)
- [x] Otsu threshold calculation
- [x] Multi-class Otsu with multiple thresholds
- [x] Slice threshold preview
- [x] Edge case handling (empty range, entire range)

Closes #23