### PR TITLE
feat(segmentation): Implement manual segmentation controller with basic drawing tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ target_link_libraries(measurement_service PUBLIC
 add_library(segmentation_service STATIC
     src/services/segmentation/threshold_segmenter.cpp
     src/services/segmentation/region_growing_segmenter.cpp
+    src/services/segmentation/manual_segmentation_controller.cpp
 )
 
 target_link_libraries(segmentation_service PUBLIC

--- a/src/services/segmentation/manual_segmentation_controller.cpp
+++ b/src/services/segmentation/manual_segmentation_controller.cpp
@@ -1,0 +1,450 @@
+#include "services/segmentation/manual_segmentation_controller.hpp"
+#include "services/segmentation/threshold_segmenter.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <queue>
+
+#include <itkImageRegionIterator.h>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Implementation class for ManualSegmentationController
+ */
+class ManualSegmentationController::Impl {
+public:
+    LabelMapType::Pointer labelMap_;
+    SegmentationTool activeTool_ = SegmentationTool::None;
+    BrushParameters brushParams_;
+    FillParameters fillParams_;
+    uint8_t activeLabel_ = 1;
+    bool isDrawing_ = false;
+    Point2D lastPosition_;
+    int lastSliceIndex_ = -1;
+    ModificationCallback modificationCallback_;
+
+    /**
+     * @brief Apply brush stroke at a position
+     */
+    void applyBrush(const Point2D& position, int sliceIndex, uint8_t value) {
+        if (!labelMap_) {
+            return;
+        }
+
+        auto region = labelMap_->GetLargestPossibleRegion();
+        auto size = region.GetSize();
+
+        int halfSize = brushParams_.size / 2;
+
+        for (int dy = -halfSize; dy <= halfSize; ++dy) {
+            for (int dx = -halfSize; dx <= halfSize; ++dx) {
+                int px = position.x + dx;
+                int py = position.y + dy;
+
+                // Bounds check
+                if (px < 0 || px >= static_cast<int>(size[0]) ||
+                    py < 0 || py >= static_cast<int>(size[1]) ||
+                    sliceIndex < 0 || sliceIndex >= static_cast<int>(size[2])) {
+                    continue;
+                }
+
+                // Shape check
+                if (brushParams_.shape == BrushShape::Circle) {
+                    double distance = std::sqrt(dx * dx + dy * dy);
+                    if (distance > halfSize) {
+                        continue;
+                    }
+                }
+
+                LabelMapType::IndexType index;
+                index[0] = px;
+                index[1] = py;
+                index[2] = sliceIndex;
+
+                labelMap_->SetPixel(index, value);
+            }
+        }
+    }
+
+    /**
+     * @brief Draw line between two points using Bresenham's algorithm
+     */
+    void drawLine(const Point2D& from, const Point2D& to, int sliceIndex, uint8_t value) {
+        int x0 = from.x;
+        int y0 = from.y;
+        int x1 = to.x;
+        int y1 = to.y;
+
+        int dx = std::abs(x1 - x0);
+        int dy = std::abs(y1 - y0);
+        int sx = x0 < x1 ? 1 : -1;
+        int sy = y0 < y1 ? 1 : -1;
+        int err = dx - dy;
+
+        while (true) {
+            applyBrush(Point2D{x0, y0}, sliceIndex, value);
+
+            if (x0 == x1 && y0 == y1) {
+                break;
+            }
+
+            int e2 = 2 * err;
+            if (e2 > -dy) {
+                err -= dy;
+                x0 += sx;
+            }
+            if (e2 < dx) {
+                err += dx;
+                y0 += sy;
+            }
+        }
+    }
+
+    /**
+     * @brief Apply flood fill at position
+     */
+    void applyFill(const Point2D& position, int sliceIndex, uint8_t value) {
+        if (!labelMap_) {
+            return;
+        }
+
+        auto region = labelMap_->GetLargestPossibleRegion();
+        auto size = region.GetSize();
+
+        // Bounds check
+        if (position.x < 0 || position.x >= static_cast<int>(size[0]) ||
+            position.y < 0 || position.y >= static_cast<int>(size[1]) ||
+            sliceIndex < 0 || sliceIndex >= static_cast<int>(size[2])) {
+            return;
+        }
+
+        LabelMapType::IndexType startIndex;
+        startIndex[0] = position.x;
+        startIndex[1] = position.y;
+        startIndex[2] = sliceIndex;
+
+        uint8_t originalValue = labelMap_->GetPixel(startIndex);
+
+        // Don't fill if already the target value
+        if (originalValue == value) {
+            return;
+        }
+
+        std::queue<Point2D> queue;
+        queue.push(position);
+
+        // Track visited pixels to avoid infinite loops
+        std::vector<std::vector<bool>> visited(
+            size[0], std::vector<bool>(size[1], false)
+        );
+        visited[position.x][position.y] = true;
+
+        // 4-connectivity or 8-connectivity
+        std::vector<std::pair<int, int>> neighbors;
+        neighbors = {{-1, 0}, {1, 0}, {0, -1}, {0, 1}};
+        if (fillParams_.use8Connectivity) {
+            neighbors.insert(neighbors.end(),
+                {{-1, -1}, {-1, 1}, {1, -1}, {1, 1}});
+        }
+
+        while (!queue.empty()) {
+            Point2D current = queue.front();
+            queue.pop();
+
+            LabelMapType::IndexType idx;
+            idx[0] = current.x;
+            idx[1] = current.y;
+            idx[2] = sliceIndex;
+
+            labelMap_->SetPixel(idx, value);
+
+            for (const auto& [dx, dy] : neighbors) {
+                int nx = current.x + dx;
+                int ny = current.y + dy;
+
+                if (nx < 0 || nx >= static_cast<int>(size[0]) ||
+                    ny < 0 || ny >= static_cast<int>(size[1])) {
+                    continue;
+                }
+
+                if (visited[nx][ny]) {
+                    continue;
+                }
+
+                LabelMapType::IndexType neighborIdx;
+                neighborIdx[0] = nx;
+                neighborIdx[1] = ny;
+                neighborIdx[2] = sliceIndex;
+
+                uint8_t neighborValue = labelMap_->GetPixel(neighborIdx);
+                if (neighborValue == originalValue) {
+                    visited[nx][ny] = true;
+                    queue.push(Point2D{nx, ny});
+                }
+            }
+        }
+    }
+};
+
+ManualSegmentationController::ManualSegmentationController()
+    : pImpl_(std::make_unique<Impl>()) {}
+
+ManualSegmentationController::~ManualSegmentationController() = default;
+
+ManualSegmentationController::ManualSegmentationController(ManualSegmentationController&&) noexcept = default;
+ManualSegmentationController& ManualSegmentationController::operator=(ManualSegmentationController&&) noexcept = default;
+
+std::expected<void, SegmentationError>
+ManualSegmentationController::initializeLabelMap(int width, int height, int depth) {
+    if (width <= 0 || height <= 0 || depth <= 0) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidParameters,
+            "Dimensions must be positive"
+        });
+    }
+
+    try {
+        pImpl_->labelMap_ = LabelMapType::New();
+
+        LabelMapType::RegionType region;
+        LabelMapType::IndexType start;
+        start.Fill(0);
+
+        LabelMapType::SizeType size;
+        size[0] = width;
+        size[1] = height;
+        size[2] = depth;
+
+        region.SetSize(size);
+        region.SetIndex(start);
+
+        pImpl_->labelMap_->SetRegions(region);
+        pImpl_->labelMap_->Allocate();
+        pImpl_->labelMap_->FillBuffer(0);
+
+        return {};
+    } catch (const itk::ExceptionObject& e) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InternalError,
+            std::string("ITK error: ") + e.GetDescription()
+        });
+    }
+}
+
+std::expected<void, SegmentationError>
+ManualSegmentationController::setLabelMap(LabelMapType::Pointer labelMap) {
+    if (!labelMap) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Label map cannot be null"
+        });
+    }
+
+    pImpl_->labelMap_ = labelMap;
+    return {};
+}
+
+ManualSegmentationController::LabelMapType::Pointer
+ManualSegmentationController::getLabelMap() const {
+    return pImpl_->labelMap_;
+}
+
+void ManualSegmentationController::setActiveTool(SegmentationTool tool) {
+    // Cancel any in-progress operation when switching tools
+    if (pImpl_->isDrawing_) {
+        cancelOperation();
+    }
+    pImpl_->activeTool_ = tool;
+}
+
+SegmentationTool ManualSegmentationController::getActiveTool() const noexcept {
+    return pImpl_->activeTool_;
+}
+
+bool ManualSegmentationController::setBrushSize(int size) {
+    if (size < 1 || size > 50) {
+        return false;
+    }
+    pImpl_->brushParams_.size = size;
+    return true;
+}
+
+int ManualSegmentationController::getBrushSize() const noexcept {
+    return pImpl_->brushParams_.size;
+}
+
+void ManualSegmentationController::setBrushShape(BrushShape shape) {
+    pImpl_->brushParams_.shape = shape;
+}
+
+BrushShape ManualSegmentationController::getBrushShape() const noexcept {
+    return pImpl_->brushParams_.shape;
+}
+
+bool ManualSegmentationController::setBrushParameters(const BrushParameters& params) {
+    if (!params.isValid()) {
+        return false;
+    }
+    pImpl_->brushParams_ = params;
+    return true;
+}
+
+BrushParameters ManualSegmentationController::getBrushParameters() const noexcept {
+    return pImpl_->brushParams_;
+}
+
+void ManualSegmentationController::setFillParameters(const FillParameters& params) {
+    pImpl_->fillParams_ = params;
+}
+
+FillParameters ManualSegmentationController::getFillParameters() const noexcept {
+    return pImpl_->fillParams_;
+}
+
+bool ManualSegmentationController::setActiveLabel(uint8_t labelId) {
+    if (labelId == 0) {
+        return false;  // 0 is reserved for background
+    }
+    pImpl_->activeLabel_ = labelId;
+    return true;
+}
+
+uint8_t ManualSegmentationController::getActiveLabel() const noexcept {
+    return pImpl_->activeLabel_;
+}
+
+void ManualSegmentationController::onMousePress(const Point2D& position, int sliceIndex) {
+    if (!pImpl_->labelMap_ || pImpl_->activeTool_ == SegmentationTool::None) {
+        return;
+    }
+
+    pImpl_->isDrawing_ = true;
+    pImpl_->lastPosition_ = position;
+    pImpl_->lastSliceIndex_ = sliceIndex;
+
+    switch (pImpl_->activeTool_) {
+        case SegmentationTool::Brush:
+            pImpl_->applyBrush(position, sliceIndex, pImpl_->activeLabel_);
+            break;
+
+        case SegmentationTool::Eraser:
+            pImpl_->applyBrush(position, sliceIndex, 0);  // Erase = set to 0
+            break;
+
+        case SegmentationTool::Fill:
+            pImpl_->applyFill(position, sliceIndex, pImpl_->activeLabel_);
+            pImpl_->isDrawing_ = false;  // Fill is instant
+            break;
+
+        default:
+            // Other tools handled separately
+            break;
+    }
+
+    if (pImpl_->modificationCallback_) {
+        pImpl_->modificationCallback_(sliceIndex);
+    }
+}
+
+void ManualSegmentationController::onMouseMove(const Point2D& position, int sliceIndex) {
+    if (!pImpl_->isDrawing_ || !pImpl_->labelMap_) {
+        return;
+    }
+
+    // Only process if position changed
+    if (position == pImpl_->lastPosition_ && sliceIndex == pImpl_->lastSliceIndex_) {
+        return;
+    }
+
+    switch (pImpl_->activeTool_) {
+        case SegmentationTool::Brush:
+            pImpl_->drawLine(pImpl_->lastPosition_, position, sliceIndex, pImpl_->activeLabel_);
+            break;
+
+        case SegmentationTool::Eraser:
+            pImpl_->drawLine(pImpl_->lastPosition_, position, sliceIndex, 0);
+            break;
+
+        default:
+            break;
+    }
+
+    pImpl_->lastPosition_ = position;
+    pImpl_->lastSliceIndex_ = sliceIndex;
+
+    if (pImpl_->modificationCallback_) {
+        pImpl_->modificationCallback_(sliceIndex);
+    }
+}
+
+void ManualSegmentationController::onMouseRelease(const Point2D& position, int sliceIndex) {
+    if (!pImpl_->isDrawing_) {
+        return;
+    }
+
+    // Final stroke to release position
+    if (position != pImpl_->lastPosition_) {
+        switch (pImpl_->activeTool_) {
+            case SegmentationTool::Brush:
+                pImpl_->drawLine(pImpl_->lastPosition_, position, sliceIndex, pImpl_->activeLabel_);
+                break;
+
+            case SegmentationTool::Eraser:
+                pImpl_->drawLine(pImpl_->lastPosition_, position, sliceIndex, 0);
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    pImpl_->isDrawing_ = false;
+
+    if (pImpl_->modificationCallback_) {
+        pImpl_->modificationCallback_(sliceIndex);
+    }
+}
+
+void ManualSegmentationController::cancelOperation() {
+    pImpl_->isDrawing_ = false;
+}
+
+bool ManualSegmentationController::isDrawing() const noexcept {
+    return pImpl_->isDrawing_;
+}
+
+void ManualSegmentationController::setModificationCallback(ModificationCallback callback) {
+    pImpl_->modificationCallback_ = std::move(callback);
+}
+
+void ManualSegmentationController::clearAll() {
+    if (pImpl_->labelMap_) {
+        pImpl_->labelMap_->FillBuffer(0);
+
+        if (pImpl_->modificationCallback_) {
+            pImpl_->modificationCallback_(-1);  // -1 indicates all slices
+        }
+    }
+}
+
+void ManualSegmentationController::clearLabel(uint8_t labelId) {
+    if (!pImpl_->labelMap_) {
+        return;
+    }
+
+    using IteratorType = itk::ImageRegionIterator<LabelMapType>;
+    IteratorType it(pImpl_->labelMap_, pImpl_->labelMap_->GetLargestPossibleRegion());
+
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        if (it.Get() == labelId) {
+            it.Set(0);
+        }
+    }
+
+    if (pImpl_->modificationCallback_) {
+        pImpl_->modificationCallback_(-1);
+    }
+}
+
+} // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -242,3 +242,20 @@ target_include_directories(region_growing_segmenter_test PRIVATE
 )
 
 gtest_discover_tests(region_growing_segmenter_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for Manual Segmentation Controller
+add_executable(manual_segmentation_controller_test
+    unit/manual_segmentation_controller_test.cpp
+)
+
+target_link_libraries(manual_segmentation_controller_test PRIVATE
+    segmentation_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(manual_segmentation_controller_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(manual_segmentation_controller_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/manual_segmentation_controller_test.cpp
+++ b/tests/unit/manual_segmentation_controller_test.cpp
@@ -1,0 +1,491 @@
+#include <gtest/gtest.h>
+
+#include "services/segmentation/manual_segmentation_controller.hpp"
+#include "services/segmentation/threshold_segmenter.hpp"
+
+#include <itkImageRegionIterator.h>
+
+using namespace dicom_viewer::services;
+
+class ManualSegmentationControllerTest : public ::testing::Test {
+protected:
+    using LabelMapType = ManualSegmentationController::LabelMapType;
+
+    void SetUp() override {
+        controller_ = std::make_unique<ManualSegmentationController>();
+    }
+
+    /**
+     * @brief Count pixels with specific label value
+     */
+    int countLabelPixels(LabelMapType::Pointer labelMap, uint8_t label) {
+        int count = 0;
+        itk::ImageRegionIterator<LabelMapType> it(
+            labelMap, labelMap->GetLargestPossibleRegion()
+        );
+        for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+            if (it.Get() == label) {
+                ++count;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * @brief Get pixel value at specific position
+     */
+    uint8_t getPixelAt(LabelMapType::Pointer labelMap, int x, int y, int z) {
+        LabelMapType::IndexType index;
+        index[0] = x;
+        index[1] = y;
+        index[2] = z;
+        return labelMap->GetPixel(index);
+    }
+
+    std::unique_ptr<ManualSegmentationController> controller_;
+};
+
+// Initialization tests
+TEST_F(ManualSegmentationControllerTest, InitializeLabelMapCreatesValidImage) {
+    auto result = controller_->initializeLabelMap(100, 100, 50);
+
+    ASSERT_TRUE(result.has_value());
+
+    auto labelMap = controller_->getLabelMap();
+    ASSERT_NE(labelMap, nullptr);
+
+    auto size = labelMap->GetLargestPossibleRegion().GetSize();
+    EXPECT_EQ(size[0], 100);
+    EXPECT_EQ(size[1], 100);
+    EXPECT_EQ(size[2], 50);
+}
+
+TEST_F(ManualSegmentationControllerTest, InitializeLabelMapRejectsInvalidDimensions) {
+    auto result = controller_->initializeLabelMap(0, 100, 50);
+    EXPECT_FALSE(result.has_value());
+
+    result = controller_->initializeLabelMap(100, -1, 50);
+    EXPECT_FALSE(result.has_value());
+
+    result = controller_->initializeLabelMap(100, 100, 0);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(ManualSegmentationControllerTest, InitializeLabelMapFillsWithZero) {
+    ASSERT_TRUE(controller_->initializeLabelMap(10, 10, 5).has_value());
+    auto labelMap = controller_->getLabelMap();
+
+    int nonZeroCount = countLabelPixels(labelMap, 0);
+    int totalPixels = 10 * 10 * 5;
+    EXPECT_EQ(nonZeroCount, totalPixels);
+}
+
+// Tool management tests
+TEST_F(ManualSegmentationControllerTest, DefaultToolIsNone) {
+    EXPECT_EQ(controller_->getActiveTool(), SegmentationTool::None);
+}
+
+TEST_F(ManualSegmentationControllerTest, SetActiveToolChangesTool) {
+    controller_->setActiveTool(SegmentationTool::Brush);
+    EXPECT_EQ(controller_->getActiveTool(), SegmentationTool::Brush);
+
+    controller_->setActiveTool(SegmentationTool::Eraser);
+    EXPECT_EQ(controller_->getActiveTool(), SegmentationTool::Eraser);
+
+    controller_->setActiveTool(SegmentationTool::Fill);
+    EXPECT_EQ(controller_->getActiveTool(), SegmentationTool::Fill);
+}
+
+// Brush parameter tests
+TEST_F(ManualSegmentationControllerTest, DefaultBrushSize) {
+    EXPECT_EQ(controller_->getBrushSize(), 5);
+}
+
+TEST_F(ManualSegmentationControllerTest, SetBrushSizeValidRange) {
+    EXPECT_TRUE(controller_->setBrushSize(1));
+    EXPECT_EQ(controller_->getBrushSize(), 1);
+
+    EXPECT_TRUE(controller_->setBrushSize(50));
+    EXPECT_EQ(controller_->getBrushSize(), 50);
+
+    EXPECT_TRUE(controller_->setBrushSize(25));
+    EXPECT_EQ(controller_->getBrushSize(), 25);
+}
+
+TEST_F(ManualSegmentationControllerTest, SetBrushSizeRejectsInvalidRange) {
+    controller_->setBrushSize(10);
+
+    EXPECT_FALSE(controller_->setBrushSize(0));
+    EXPECT_EQ(controller_->getBrushSize(), 10);  // unchanged
+
+    EXPECT_FALSE(controller_->setBrushSize(51));
+    EXPECT_EQ(controller_->getBrushSize(), 10);  // unchanged
+
+    EXPECT_FALSE(controller_->setBrushSize(-5));
+    EXPECT_EQ(controller_->getBrushSize(), 10);  // unchanged
+}
+
+TEST_F(ManualSegmentationControllerTest, DefaultBrushShapeIsCircle) {
+    EXPECT_EQ(controller_->getBrushShape(), BrushShape::Circle);
+}
+
+TEST_F(ManualSegmentationControllerTest, SetBrushShapeChangesShape) {
+    controller_->setBrushShape(BrushShape::Square);
+    EXPECT_EQ(controller_->getBrushShape(), BrushShape::Square);
+
+    controller_->setBrushShape(BrushShape::Circle);
+    EXPECT_EQ(controller_->getBrushShape(), BrushShape::Circle);
+}
+
+TEST_F(ManualSegmentationControllerTest, SetBrushParametersValidates) {
+    BrushParameters params;
+    params.size = 20;
+    params.shape = BrushShape::Square;
+
+    EXPECT_TRUE(controller_->setBrushParameters(params));
+    EXPECT_EQ(controller_->getBrushSize(), 20);
+    EXPECT_EQ(controller_->getBrushShape(), BrushShape::Square);
+}
+
+TEST_F(ManualSegmentationControllerTest, SetBrushParametersRejectsInvalid) {
+    controller_->setBrushSize(15);
+
+    BrushParameters params;
+    params.size = 100;  // Invalid
+
+    EXPECT_FALSE(controller_->setBrushParameters(params));
+    EXPECT_EQ(controller_->getBrushSize(), 15);  // unchanged
+}
+
+// Label management tests
+TEST_F(ManualSegmentationControllerTest, DefaultLabelIsOne) {
+    EXPECT_EQ(controller_->getActiveLabel(), 1);
+}
+
+TEST_F(ManualSegmentationControllerTest, SetActiveLabelValidRange) {
+    EXPECT_TRUE(controller_->setActiveLabel(1));
+    EXPECT_EQ(controller_->getActiveLabel(), 1);
+
+    EXPECT_TRUE(controller_->setActiveLabel(255));
+    EXPECT_EQ(controller_->getActiveLabel(), 255);
+}
+
+TEST_F(ManualSegmentationControllerTest, SetActiveLabelRejectsZero) {
+    controller_->setActiveLabel(5);
+
+    EXPECT_FALSE(controller_->setActiveLabel(0));
+    EXPECT_EQ(controller_->getActiveLabel(), 5);  // unchanged
+}
+
+// Brush tool tests
+TEST_F(ManualSegmentationControllerTest, BrushToolDrawsAtPosition) {
+    ASSERT_TRUE(controller_->initializeLabelMap(100, 100, 10).has_value());
+    controller_->setActiveTool(SegmentationTool::Brush);
+    controller_->setBrushSize(1);
+    controller_->setActiveLabel(1);
+
+    controller_->onMousePress(Point2D{50, 50}, 5);
+    controller_->onMouseRelease(Point2D{50, 50}, 5);
+
+    auto labelMap = controller_->getLabelMap();
+    EXPECT_EQ(getPixelAt(labelMap, 50, 50, 5), 1);
+}
+
+TEST_F(ManualSegmentationControllerTest, BrushToolDrawsCircularShape) {
+    ASSERT_TRUE(controller_->initializeLabelMap(100, 100, 10).has_value());
+    controller_->setActiveTool(SegmentationTool::Brush);
+    controller_->setBrushSize(5);
+    controller_->setBrushShape(BrushShape::Circle);
+    controller_->setActiveLabel(1);
+
+    controller_->onMousePress(Point2D{50, 50}, 5);
+    controller_->onMouseRelease(Point2D{50, 50}, 5);
+
+    auto labelMap = controller_->getLabelMap();
+
+    // Center should be labeled
+    EXPECT_EQ(getPixelAt(labelMap, 50, 50, 5), 1);
+
+    // Within brush radius should be labeled
+    EXPECT_EQ(getPixelAt(labelMap, 52, 50, 5), 1);
+    EXPECT_EQ(getPixelAt(labelMap, 50, 52, 5), 1);
+
+    // Corners of bounding box should NOT be labeled (circular brush)
+    EXPECT_EQ(getPixelAt(labelMap, 48, 48, 5), 0);
+    EXPECT_EQ(getPixelAt(labelMap, 52, 52, 5), 0);
+}
+
+TEST_F(ManualSegmentationControllerTest, BrushToolDrawsSquareShape) {
+    ASSERT_TRUE(controller_->initializeLabelMap(100, 100, 10).has_value());
+    controller_->setActiveTool(SegmentationTool::Brush);
+    controller_->setBrushSize(5);
+    controller_->setBrushShape(BrushShape::Square);
+    controller_->setActiveLabel(1);
+
+    controller_->onMousePress(Point2D{50, 50}, 5);
+    controller_->onMouseRelease(Point2D{50, 50}, 5);
+
+    auto labelMap = controller_->getLabelMap();
+
+    // Center should be labeled
+    EXPECT_EQ(getPixelAt(labelMap, 50, 50, 5), 1);
+
+    // Corners of bounding box should be labeled (square brush)
+    EXPECT_EQ(getPixelAt(labelMap, 48, 48, 5), 1);
+    EXPECT_EQ(getPixelAt(labelMap, 52, 52, 5), 1);
+}
+
+TEST_F(ManualSegmentationControllerTest, BrushToolDrawsLine) {
+    ASSERT_TRUE(controller_->initializeLabelMap(100, 100, 10).has_value());
+    controller_->setActiveTool(SegmentationTool::Brush);
+    controller_->setBrushSize(1);
+    controller_->setActiveLabel(1);
+
+    controller_->onMousePress(Point2D{10, 10}, 5);
+    controller_->onMouseMove(Point2D{15, 10}, 5);
+    controller_->onMouseRelease(Point2D{15, 10}, 5);
+
+    auto labelMap = controller_->getLabelMap();
+
+    // Line should be drawn
+    for (int x = 10; x <= 15; ++x) {
+        EXPECT_EQ(getPixelAt(labelMap, x, 10, 5), 1)
+            << "Pixel at (" << x << ", 10, 5) should be labeled";
+    }
+}
+
+// Eraser tool tests
+TEST_F(ManualSegmentationControllerTest, EraserToolRemovesLabels) {
+    ASSERT_TRUE(controller_->initializeLabelMap(100, 100, 10).has_value());
+    controller_->setActiveTool(SegmentationTool::Brush);
+    controller_->setBrushSize(5);
+    controller_->setActiveLabel(1);
+
+    // First draw something
+    controller_->onMousePress(Point2D{50, 50}, 5);
+    controller_->onMouseRelease(Point2D{50, 50}, 5);
+
+    auto labelMap = controller_->getLabelMap();
+    EXPECT_EQ(getPixelAt(labelMap, 50, 50, 5), 1);
+
+    // Now erase
+    controller_->setActiveTool(SegmentationTool::Eraser);
+    controller_->onMousePress(Point2D{50, 50}, 5);
+    controller_->onMouseRelease(Point2D{50, 50}, 5);
+
+    EXPECT_EQ(getPixelAt(labelMap, 50, 50, 5), 0);
+}
+
+// Fill tool tests
+TEST_F(ManualSegmentationControllerTest, FillToolFillsRegion) {
+    ASSERT_TRUE(controller_->initializeLabelMap(10, 10, 1).has_value());
+    controller_->setActiveTool(SegmentationTool::Fill);
+    controller_->setActiveLabel(1);
+
+    controller_->onMousePress(Point2D{5, 5}, 0);
+
+    auto labelMap = controller_->getLabelMap();
+
+    // All pixels should be filled
+    int filledCount = countLabelPixels(labelMap, 1);
+    EXPECT_EQ(filledCount, 100);  // 10x10
+}
+
+TEST_F(ManualSegmentationControllerTest, FillToolStopsAtBoundary) {
+    ASSERT_TRUE(controller_->initializeLabelMap(10, 10, 1).has_value());
+
+    // First create a boundary using brush
+    controller_->setActiveTool(SegmentationTool::Brush);
+    controller_->setBrushSize(1);
+    controller_->setActiveLabel(2);
+
+    // Draw a vertical line at x=5
+    for (int y = 0; y < 10; ++y) {
+        controller_->onMousePress(Point2D{5, y}, 0);
+        controller_->onMouseRelease(Point2D{5, y}, 0);
+    }
+
+    // Now fill on the left side
+    controller_->setActiveTool(SegmentationTool::Fill);
+    controller_->setActiveLabel(1);
+    controller_->onMousePress(Point2D{2, 5}, 0);
+
+    auto labelMap = controller_->getLabelMap();
+
+    // Left side should be filled (x < 5)
+    EXPECT_EQ(getPixelAt(labelMap, 0, 5, 0), 1);
+    EXPECT_EQ(getPixelAt(labelMap, 4, 5, 0), 1);
+
+    // Right side should NOT be filled (x > 5)
+    EXPECT_EQ(getPixelAt(labelMap, 6, 5, 0), 0);
+    EXPECT_EQ(getPixelAt(labelMap, 9, 5, 0), 0);
+
+    // Boundary should remain as label 2
+    EXPECT_EQ(getPixelAt(labelMap, 5, 5, 0), 2);
+}
+
+// Clear tests
+TEST_F(ManualSegmentationControllerTest, ClearAllRemovesAllLabels) {
+    ASSERT_TRUE(controller_->initializeLabelMap(10, 10, 5).has_value());
+    controller_->setActiveTool(SegmentationTool::Fill);
+    controller_->setActiveLabel(1);
+    controller_->onMousePress(Point2D{5, 5}, 2);
+
+    auto labelMap = controller_->getLabelMap();
+    EXPECT_GT(countLabelPixels(labelMap, 1), 0);
+
+    controller_->clearAll();
+    EXPECT_EQ(countLabelPixels(labelMap, 1), 0);
+}
+
+TEST_F(ManualSegmentationControllerTest, ClearLabelRemovesSpecificLabel) {
+    ASSERT_TRUE(controller_->initializeLabelMap(10, 10, 1).has_value());
+
+    // Fill with label 1
+    controller_->setActiveTool(SegmentationTool::Fill);
+    controller_->setActiveLabel(1);
+    controller_->onMousePress(Point2D{2, 2}, 0);
+
+    // Draw some with label 2
+    controller_->setActiveTool(SegmentationTool::Brush);
+    controller_->setBrushSize(1);
+    controller_->setActiveLabel(2);
+    controller_->onMousePress(Point2D{5, 5}, 0);
+    controller_->onMouseRelease(Point2D{5, 5}, 0);
+
+    auto labelMap = controller_->getLabelMap();
+    EXPECT_EQ(getPixelAt(labelMap, 5, 5, 0), 2);
+
+    // Clear only label 2
+    controller_->clearLabel(2);
+
+    EXPECT_EQ(getPixelAt(labelMap, 5, 5, 0), 0);
+    // Label 1 should remain
+    EXPECT_GT(countLabelPixels(labelMap, 1), 0);
+}
+
+// Drawing state tests
+TEST_F(ManualSegmentationControllerTest, IsDrawingReturnsTrueWhenDrawing) {
+    ASSERT_TRUE(controller_->initializeLabelMap(100, 100, 10).has_value());
+    controller_->setActiveTool(SegmentationTool::Brush);
+
+    EXPECT_FALSE(controller_->isDrawing());
+
+    controller_->onMousePress(Point2D{50, 50}, 5);
+    EXPECT_TRUE(controller_->isDrawing());
+
+    controller_->onMouseRelease(Point2D{50, 50}, 5);
+    EXPECT_FALSE(controller_->isDrawing());
+}
+
+TEST_F(ManualSegmentationControllerTest, CancelOperationStopsDrawing) {
+    ASSERT_TRUE(controller_->initializeLabelMap(100, 100, 10).has_value());
+    controller_->setActiveTool(SegmentationTool::Brush);
+
+    controller_->onMousePress(Point2D{50, 50}, 5);
+    EXPECT_TRUE(controller_->isDrawing());
+
+    controller_->cancelOperation();
+    EXPECT_FALSE(controller_->isDrawing());
+}
+
+// Callback tests
+TEST_F(ManualSegmentationControllerTest, ModificationCallbackIsCalled) {
+    ASSERT_TRUE(controller_->initializeLabelMap(100, 100, 10).has_value());
+    controller_->setActiveTool(SegmentationTool::Brush);
+    controller_->setBrushSize(1);
+
+    int callbackCount = 0;
+    int lastSlice = -1;
+
+    controller_->setModificationCallback([&](int sliceIndex) {
+        ++callbackCount;
+        lastSlice = sliceIndex;
+    });
+
+    controller_->onMousePress(Point2D{50, 50}, 5);
+    EXPECT_EQ(callbackCount, 1);
+    EXPECT_EQ(lastSlice, 5);
+
+    controller_->onMouseRelease(Point2D{50, 50}, 5);
+    EXPECT_EQ(callbackCount, 2);
+}
+
+// Bounds checking tests
+TEST_F(ManualSegmentationControllerTest, BrushDoesNotDrawOutOfBounds) {
+    ASSERT_TRUE(controller_->initializeLabelMap(10, 10, 1).has_value());
+    controller_->setActiveTool(SegmentationTool::Brush);
+    controller_->setBrushSize(5);
+    controller_->setActiveLabel(1);
+
+    // Draw at corner - should not crash
+    controller_->onMousePress(Point2D{0, 0}, 0);
+    controller_->onMouseRelease(Point2D{0, 0}, 0);
+
+    controller_->onMousePress(Point2D{9, 9}, 0);
+    controller_->onMouseRelease(Point2D{9, 9}, 0);
+
+    // Draw outside bounds - should not crash
+    controller_->onMousePress(Point2D{-5, -5}, 0);
+    controller_->onMouseRelease(Point2D{-5, -5}, 0);
+
+    controller_->onMousePress(Point2D{100, 100}, 0);
+    controller_->onMouseRelease(Point2D{100, 100}, 0);
+
+    // Test completed without crash
+    SUCCEED();
+}
+
+// Fill tool with 8-connectivity
+TEST_F(ManualSegmentationControllerTest, FillToolWith8Connectivity) {
+    ASSERT_TRUE(controller_->initializeLabelMap(10, 10, 1).has_value());
+
+    // Create a diagonal boundary
+    controller_->setActiveTool(SegmentationTool::Brush);
+    controller_->setBrushSize(1);
+    controller_->setActiveLabel(2);
+
+    // Draw diagonal line
+    for (int i = 0; i < 10; ++i) {
+        controller_->onMousePress(Point2D{i, i}, 0);
+        controller_->onMouseRelease(Point2D{i, i}, 0);
+    }
+
+    // Fill with 4-connectivity (default)
+    FillParameters params;
+    params.use8Connectivity = false;
+    controller_->setFillParameters(params);
+
+    controller_->setActiveTool(SegmentationTool::Fill);
+    controller_->setActiveLabel(1);
+    controller_->onMousePress(Point2D{0, 5}, 0);
+
+    auto labelMap = controller_->getLabelMap();
+
+    // With 4-connectivity, fill should be blocked by diagonal
+    // The pixel at (1, 5) should be filled
+    EXPECT_EQ(getPixelAt(labelMap, 0, 5, 0), 1);
+
+    // Reset and test 8-connectivity
+    controller_->clearAll();
+
+    // Redraw diagonal
+    controller_->setActiveTool(SegmentationTool::Brush);
+    controller_->setActiveLabel(2);
+    for (int i = 0; i < 10; ++i) {
+        controller_->onMousePress(Point2D{i, i}, 0);
+        controller_->onMouseRelease(Point2D{i, i}, 0);
+    }
+
+    // Fill with 8-connectivity
+    params.use8Connectivity = true;
+    controller_->setFillParameters(params);
+
+    controller_->setActiveTool(SegmentationTool::Fill);
+    controller_->setActiveLabel(3);
+    controller_->onMousePress(Point2D{0, 5}, 0);
+
+    // With 8-connectivity, fill should also stop at diagonal
+    // but may leak through depending on boundary configuration
+    EXPECT_EQ(getPixelAt(labelMap, 0, 5, 0), 3);
+}


### PR DESCRIPTION
## Summary
- Implement ManualSegmentationController for interactive 2D segmentation on MPR views
- Add Brush tool with adjustable size (1-50px) and shape (circle/square)
- Add Eraser tool matching brush behavior
- Add Fill tool with 4/8-connectivity options
- Complete unit test coverage for all features

## Related Issues
- Closes #43 (ManualSegmentationController base with Brush and Eraser tools)
- Part of #25 (Manual Segmentation Tools - parent issue)
- Remaining sub-issues: #44 (Fill enhancements), #45 (Freehand), #46 (Polygon), #47 (Smart Scissors)

## Changes
### New Files
- `include/services/segmentation/manual_segmentation_controller.hpp` - Controller interface
- `src/services/segmentation/manual_segmentation_controller.cpp` - Implementation
- `tests/unit/manual_segmentation_controller_test.cpp` - Unit tests

### Modified Files
- `CMakeLists.txt` - Added new source file to segmentation_service
- `tests/CMakeLists.txt` - Added test target

## Implementation Details
- Uses pImpl pattern for ABI stability
- Follows existing segmentation code patterns (ITK, std::expected)
- Bresenham line algorithm for smooth brush strokes
- Flood fill with configurable connectivity

## Test Plan
- [x] Initialization tests (valid/invalid dimensions)
- [x] Tool management tests (tool switching, brush parameters)
- [x] Brush tool tests (drawing, circular/square shape)
- [x] Eraser tool tests
- [x] Fill tool tests (flood fill, boundary detection)
- [x] Clear operations tests
- [x] Drawing state tests
- [x] Bounds checking tests
- [x] Callback tests