### PR TITLE
feat(measurement): implement 3D volume calculation (SRS-FR-029)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ add_library(measurement_service STATIC
     src/services/measurement/area_tool.cpp
     src/services/measurement/statistics.cpp
     src/services/measurement/roi_statistics.cpp
+    src/services/measurement/volume_calculator.cpp
 )
 
 target_link_libraries(measurement_service PUBLIC

--- a/include/services/measurement/volume_calculator.hpp
+++ b/include/services/measurement/volume_calculator.hpp
@@ -1,0 +1,299 @@
+#pragma once
+
+#include <cstdint>
+#include <expected>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <itkImage.h>
+#include <itkSmartPointer.h>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Error information for volume calculation operations
+ *
+ * @trace SRS-FR-029
+ */
+struct VolumeError {
+    enum class Code {
+        Success,
+        InvalidLabelMap,
+        InvalidSpacing,
+        LabelNotFound,
+        MeshGenerationFailed,
+        CalculationFailed,
+        ExportFailed,
+        InternalError
+    };
+
+    Code code = Code::Success;
+    std::string message;
+
+    [[nodiscard]] bool isSuccess() const noexcept {
+        return code == Code::Success;
+    }
+
+    [[nodiscard]] std::string toString() const {
+        switch (code) {
+            case Code::Success: return "Success";
+            case Code::InvalidLabelMap: return "Invalid label map: " + message;
+            case Code::InvalidSpacing: return "Invalid spacing: " + message;
+            case Code::LabelNotFound: return "Label not found: " + message;
+            case Code::MeshGenerationFailed: return "Mesh generation failed: " + message;
+            case Code::CalculationFailed: return "Calculation failed: " + message;
+            case Code::ExportFailed: return "Export failed: " + message;
+            case Code::InternalError: return "Internal error: " + message;
+        }
+        return "Unknown error";
+    }
+};
+
+/**
+ * @brief Result of volume calculation for a segmentation label
+ *
+ * Contains volume measurements in multiple units and optional surface area.
+ *
+ * @trace SRS-FR-029
+ */
+struct VolumeResult {
+    /// Label ID (1-255)
+    uint8_t labelId = 0;
+
+    /// Label name for display
+    std::string labelName;
+
+    /// Number of voxels in the segmented region
+    int64_t voxelCount = 0;
+
+    /// Volume in cubic millimeters
+    double volumeMm3 = 0.0;
+
+    /// Volume in cubic centimeters (volumeMm3 / 1000)
+    double volumeCm3 = 0.0;
+
+    /// Volume in milliliters (equal to volumeCm3)
+    double volumeML = 0.0;
+
+    /// Surface area in square millimeters (optional, requires mesh generation)
+    std::optional<double> surfaceAreaMm2;
+
+    /// Sphericity: ratio of surface area of equivalent sphere to actual surface area
+    /// (1.0 = perfect sphere, <1.0 = irregular shape)
+    std::optional<double> sphericity;
+
+    /// Bounding box dimensions [x, y, z] in mm
+    std::array<double, 3> boundingBoxMm = {0.0, 0.0, 0.0};
+
+    /**
+     * @brief Convert result to formatted string
+     * @return Formatted volume string
+     */
+    [[nodiscard]] std::string toString() const;
+
+    /**
+     * @brief Get header row for CSV export
+     * @return Vector of column names
+     */
+    [[nodiscard]] static std::vector<std::string> getCsvHeader();
+
+    /**
+     * @brief Get data row for CSV export
+     * @return Vector of values as strings
+     */
+    [[nodiscard]] std::vector<std::string> getCsvRow() const;
+};
+
+/**
+ * @brief Volume tracking entry for serial studies
+ *
+ * Stores volume measurements over time for trend analysis.
+ *
+ * @trace SRS-FR-029
+ */
+struct VolumeTimePoint {
+    /// Study date (YYYYMMDD format)
+    std::string studyDate;
+
+    /// Study description
+    std::string studyDescription;
+
+    /// Volume result at this time point
+    VolumeResult volume;
+
+    /// Change from previous measurement (if available)
+    std::optional<double> changeFromPreviousMm3;
+
+    /// Percentage change from previous measurement
+    std::optional<double> changePercentage;
+};
+
+/**
+ * @brief Comparison table for multiple label volumes
+ *
+ * @trace SRS-FR-029
+ */
+struct VolumeComparisonTable {
+    /// All volume results
+    std::vector<VolumeResult> results;
+
+    /// Total volume of all labels combined
+    double totalVolumeMm3 = 0.0;
+
+    /// Percentage contribution of each label
+    std::vector<double> percentages;
+
+    /**
+     * @brief Generate formatted comparison table string
+     * @return Formatted table
+     */
+    [[nodiscard]] std::string toString() const;
+
+    /**
+     * @brief Export comparison table to CSV
+     * @param filePath Output file path
+     * @return Success or error message
+     */
+    [[nodiscard]] std::expected<void, std::string>
+    exportToCsv(const std::filesystem::path& filePath) const;
+};
+
+/**
+ * @brief Calculator for 3D volume measurements of segmented regions
+ *
+ * Provides accurate volume calculation with proper unit conversion,
+ * optional surface area measurement using marching cubes mesh generation,
+ * and comparison/tracking features for multiple labels and serial studies.
+ *
+ * @example
+ * @code
+ * VolumeCalculator calculator;
+ *
+ * // Calculate single label volume
+ * auto result = calculator.calculate(labelMap, labelId, spacing);
+ * if (result) {
+ *     std::cout << "Volume: " << result->volumeCm3 << " cm^3" << std::endl;
+ * }
+ *
+ * // Calculate all labels with surface area
+ * auto allResults = calculator.calculateAll(labelMap, spacing, true);
+ * for (const auto& res : allResults) {
+ *     if (res) {
+ *         std::cout << res->labelName << ": " << res->volumeML << " mL" << std::endl;
+ *     }
+ * }
+ *
+ * // Export to CSV
+ * VolumeCalculator::exportToCsv(allResults, "/path/to/output.csv");
+ * @endcode
+ *
+ * @trace SRS-FR-029
+ */
+class VolumeCalculator {
+public:
+    /// Label map type for segmentation
+    using LabelMapType = itk::Image<uint8_t, 3>;
+
+    /// Spacing type [x, y, z] in mm
+    using SpacingType = std::array<double, 3>;
+
+    /// Callback for progress updates
+    using ProgressCallback = std::function<void(double progress)>;
+
+    VolumeCalculator();
+    ~VolumeCalculator();
+
+    // Non-copyable, movable
+    VolumeCalculator(const VolumeCalculator&) = delete;
+    VolumeCalculator& operator=(const VolumeCalculator&) = delete;
+    VolumeCalculator(VolumeCalculator&&) noexcept;
+    VolumeCalculator& operator=(VolumeCalculator&&) noexcept;
+
+    /**
+     * @brief Set progress callback for long operations
+     * @param callback Callback function receiving progress (0.0 to 1.0)
+     */
+    void setProgressCallback(ProgressCallback callback);
+
+    /**
+     * @brief Calculate volume for a single segmentation label
+     *
+     * @param labelMap Label map containing segmentation
+     * @param labelId Label ID to analyze (1-255)
+     * @param spacing Voxel spacing [x, y, z] in mm
+     * @param computeSurfaceArea If true, compute surface area using mesh (slower)
+     * @return Volume result or error
+     */
+    [[nodiscard]] std::expected<VolumeResult, VolumeError>
+    calculate(LabelMapType::Pointer labelMap,
+              uint8_t labelId,
+              const SpacingType& spacing,
+              bool computeSurfaceArea = false);
+
+    /**
+     * @brief Calculate volumes for all labels in the label map
+     *
+     * @param labelMap Label map containing segmentation
+     * @param spacing Voxel spacing [x, y, z] in mm
+     * @param computeSurfaceArea If true, compute surface area for each label
+     * @return Vector of volume results (one per label found)
+     */
+    [[nodiscard]] std::vector<std::expected<VolumeResult, VolumeError>>
+    calculateAll(LabelMapType::Pointer labelMap,
+                 const SpacingType& spacing,
+                 bool computeSurfaceArea = false);
+
+    /**
+     * @brief Create comparison table for multiple labels
+     *
+     * @param results Vector of successful volume results
+     * @return Comparison table with percentages
+     */
+    [[nodiscard]] static VolumeComparisonTable
+    createComparisonTable(const std::vector<VolumeResult>& results);
+
+    /**
+     * @brief Calculate volume change between two time points
+     *
+     * @param current Current volume result
+     * @param previous Previous volume result
+     * @return Time point with change information
+     */
+    [[nodiscard]] static VolumeTimePoint
+    calculateChange(const VolumeResult& current,
+                    const VolumeResult& previous,
+                    const std::string& studyDate,
+                    const std::string& studyDescription = "");
+
+    /**
+     * @brief Export volume results to CSV file
+     *
+     * @param results Vector of volume results to export
+     * @param filePath Output file path
+     * @return Success or error
+     */
+    [[nodiscard]] static std::expected<void, VolumeError>
+    exportToCsv(const std::vector<VolumeResult>& results,
+                const std::filesystem::path& filePath);
+
+    /**
+     * @brief Export volume tracking data to CSV file
+     *
+     * @param timePoints Vector of volume time points
+     * @param filePath Output file path
+     * @return Success or error
+     */
+    [[nodiscard]] static std::expected<void, VolumeError>
+    exportTrackingToCsv(const std::vector<VolumeTimePoint>& timePoints,
+                        const std::filesystem::path& filePath);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace dicom_viewer::services

--- a/src/services/measurement/volume_calculator.cpp
+++ b/src/services/measurement/volume_calculator.cpp
@@ -1,0 +1,556 @@
+#include "services/measurement/volume_calculator.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <iomanip>
+#include <numeric>
+#include <set>
+#include <sstream>
+
+#include <itkImageRegionConstIterator.h>
+#include <itkLabelStatisticsImageFilter.h>
+
+#include <vtkImageData.h>
+#include <vtkMarchingCubes.h>
+#include <vtkMassProperties.h>
+#include <vtkSmartPointer.h>
+
+namespace dicom_viewer::services {
+
+// =============================================================================
+// VolumeResult implementation
+// =============================================================================
+
+std::string VolumeResult::toString() const {
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(2);
+
+    oss << "Volume Measurement";
+    if (!labelName.empty()) {
+        oss << " (" << labelName << ")";
+    }
+    oss << ":\n";
+
+    oss << "  Label ID:    " << static_cast<int>(labelId) << "\n";
+    oss << "  Voxel Count: " << voxelCount << "\n";
+    oss << "  Volume:      " << volumeMm3 << " mm^3\n";
+    oss << "               " << volumeCm3 << " cm^3\n";
+    oss << "               " << volumeML << " mL\n";
+
+    if (surfaceAreaMm2.has_value()) {
+        oss << "  Surface:     " << surfaceAreaMm2.value() << " mm^2\n";
+    }
+
+    if (sphericity.has_value()) {
+        oss << "  Sphericity:  " << sphericity.value() << "\n";
+    }
+
+    oss << "  Bounding:    " << boundingBoxMm[0] << " x "
+        << boundingBoxMm[1] << " x " << boundingBoxMm[2] << " mm\n";
+
+    return oss.str();
+}
+
+std::vector<std::string> VolumeResult::getCsvHeader() {
+    return {
+        "LabelID", "LabelName", "VoxelCount",
+        "VolumeMm3", "VolumeCm3", "VolumeML",
+        "SurfaceAreaMm2", "Sphericity",
+        "BoundingX_mm", "BoundingY_mm", "BoundingZ_mm"
+    };
+}
+
+std::vector<std::string> VolumeResult::getCsvRow() const {
+    auto format = [](double val) {
+        std::ostringstream oss;
+        oss << std::fixed << std::setprecision(4) << val;
+        return oss.str();
+    };
+
+    auto formatOpt = [&format](const std::optional<double>& val) {
+        return val.has_value() ? format(val.value()) : "";
+    };
+
+    return {
+        std::to_string(labelId),
+        labelName,
+        std::to_string(voxelCount),
+        format(volumeMm3),
+        format(volumeCm3),
+        format(volumeML),
+        formatOpt(surfaceAreaMm2),
+        formatOpt(sphericity),
+        format(boundingBoxMm[0]),
+        format(boundingBoxMm[1]),
+        format(boundingBoxMm[2])
+    };
+}
+
+// =============================================================================
+// VolumeComparisonTable implementation
+// =============================================================================
+
+std::string VolumeComparisonTable::toString() const {
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(2);
+
+    oss << "Volume Comparison Table\n";
+    oss << "==================================================\n";
+    oss << std::left << std::setw(20) << "Label"
+        << std::right << std::setw(15) << "Volume (mL)"
+        << std::setw(12) << "Percentage" << "\n";
+    oss << "--------------------------------------------------\n";
+
+    for (size_t i = 0; i < results.size(); ++i) {
+        oss << std::left << std::setw(20);
+        if (results[i].labelName.empty()) {
+            oss << ("Label " + std::to_string(results[i].labelId));
+        } else {
+            oss << results[i].labelName;
+        }
+        oss << std::right << std::setw(15) << results[i].volumeML
+            << std::setw(11) << percentages[i] << "%" << "\n";
+    }
+
+    oss << "--------------------------------------------------\n";
+    oss << std::left << std::setw(20) << "Total"
+        << std::right << std::setw(15) << (totalVolumeMm3 / 1000.0)
+        << std::setw(11) << "100.00" << "%" << "\n";
+
+    return oss.str();
+}
+
+std::expected<void, std::string>
+VolumeComparisonTable::exportToCsv(const std::filesystem::path& filePath) const {
+    std::ofstream file(filePath);
+    if (!file.is_open()) {
+        return std::unexpected("Failed to open file for writing: " + filePath.string());
+    }
+
+    // Write header
+    auto header = VolumeResult::getCsvHeader();
+    for (const auto& col : header) {
+        file << col << ",";
+    }
+    file << "Percentage\n";
+
+    // Write data rows
+    for (size_t i = 0; i < results.size(); ++i) {
+        auto row = results[i].getCsvRow();
+        for (const auto& val : row) {
+            file << val << ",";
+        }
+        std::ostringstream pct;
+        pct << std::fixed << std::setprecision(2) << percentages[i];
+        file << pct.str() << "\n";
+    }
+
+    // Write total row
+    file << ",Total," << std::accumulate(
+        results.begin(), results.end(), int64_t(0),
+        [](int64_t sum, const VolumeResult& r) { return sum + r.voxelCount; }
+    ) << ",";
+
+    std::ostringstream total;
+    total << std::fixed << std::setprecision(4);
+    total << totalVolumeMm3 << "," << (totalVolumeMm3 / 1000.0) << ","
+          << (totalVolumeMm3 / 1000.0) << ",,,,,100.00\n";
+    file << total.str();
+
+    return {};
+}
+
+// =============================================================================
+// VolumeCalculator::Impl
+// =============================================================================
+
+class VolumeCalculator::Impl {
+public:
+    ProgressCallback progressCallback;
+
+    // Find all unique label IDs in the label map
+    std::set<uint8_t> findAllLabels(LabelMapType::Pointer labelMap) {
+        std::set<uint8_t> labels;
+
+        using IteratorType = itk::ImageRegionConstIterator<LabelMapType>;
+        IteratorType it(labelMap, labelMap->GetLargestPossibleRegion());
+
+        for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+            uint8_t val = it.Get();
+            if (val > 0) {  // Exclude background
+                labels.insert(val);
+            }
+        }
+
+        return labels;
+    }
+
+    // Calculate bounding box for a label
+    std::array<double, 3> calculateBoundingBox(
+        LabelMapType::Pointer labelMap,
+        uint8_t labelId,
+        const SpacingType& spacing
+    ) {
+        auto region = labelMap->GetLargestPossibleRegion();
+        auto size = region.GetSize();
+
+        int minX = static_cast<int>(size[0]), maxX = 0;
+        int minY = static_cast<int>(size[1]), maxY = 0;
+        int minZ = static_cast<int>(size[2]), maxZ = 0;
+
+        using IteratorType = itk::ImageRegionConstIterator<LabelMapType>;
+        IteratorType it(labelMap, region);
+
+        LabelMapType::IndexType idx;
+        for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+            if (it.Get() == labelId) {
+                idx = it.GetIndex();
+                minX = std::min(minX, static_cast<int>(idx[0]));
+                maxX = std::max(maxX, static_cast<int>(idx[0]));
+                minY = std::min(minY, static_cast<int>(idx[1]));
+                maxY = std::max(maxY, static_cast<int>(idx[1]));
+                minZ = std::min(minZ, static_cast<int>(idx[2]));
+                maxZ = std::max(maxZ, static_cast<int>(idx[2]));
+            }
+        }
+
+        if (maxX < minX) {
+            return {0.0, 0.0, 0.0};
+        }
+
+        return {
+            static_cast<double>(maxX - minX + 1) * spacing[0],
+            static_cast<double>(maxY - minY + 1) * spacing[1],
+            static_cast<double>(maxZ - minZ + 1) * spacing[2]
+        };
+    }
+
+    // Create VTK image data from label map for marching cubes
+    vtkSmartPointer<vtkImageData> createVtkBinaryImage(
+        LabelMapType::Pointer labelMap,
+        uint8_t labelId,
+        const SpacingType& spacing
+    ) {
+        auto region = labelMap->GetLargestPossibleRegion();
+        auto size = region.GetSize();
+        auto origin = labelMap->GetOrigin();
+
+        auto vtkImage = vtkSmartPointer<vtkImageData>::New();
+        vtkImage->SetDimensions(
+            static_cast<int>(size[0]),
+            static_cast<int>(size[1]),
+            static_cast<int>(size[2])
+        );
+        vtkImage->SetSpacing(spacing[0], spacing[1], spacing[2]);
+        vtkImage->SetOrigin(origin[0], origin[1], origin[2]);
+        vtkImage->AllocateScalars(VTK_UNSIGNED_CHAR, 1);
+
+        unsigned char* ptr = static_cast<unsigned char*>(vtkImage->GetScalarPointer());
+
+        using IteratorType = itk::ImageRegionConstIterator<LabelMapType>;
+        IteratorType it(labelMap, region);
+
+        size_t i = 0;
+        for (it.GoToBegin(); !it.IsAtEnd(); ++it, ++i) {
+            ptr[i] = (it.Get() == labelId) ? 255 : 0;
+        }
+
+        return vtkImage;
+    }
+
+    // Calculate surface area using marching cubes
+    std::optional<double> calculateSurfaceArea(
+        LabelMapType::Pointer labelMap,
+        uint8_t labelId,
+        const SpacingType& spacing
+    ) {
+        try {
+            auto vtkImage = createVtkBinaryImage(labelMap, labelId, spacing);
+
+            auto marchingCubes = vtkSmartPointer<vtkMarchingCubes>::New();
+            marchingCubes->SetInputData(vtkImage);
+            marchingCubes->SetValue(0, 127.5);  // Threshold between 0 and 255
+            marchingCubes->ComputeNormalsOff();
+            marchingCubes->Update();
+
+            auto mesh = marchingCubes->GetOutput();
+            if (mesh->GetNumberOfPolys() == 0) {
+                return std::nullopt;
+            }
+
+            auto massProperties = vtkSmartPointer<vtkMassProperties>::New();
+            massProperties->SetInputData(mesh);
+            massProperties->Update();
+
+            return massProperties->GetSurfaceArea();
+        } catch (...) {
+            return std::nullopt;
+        }
+    }
+
+    // Calculate sphericity (ratio of surface area of equivalent sphere to actual)
+    std::optional<double> calculateSphericity(double volume, double surfaceArea) {
+        if (surfaceArea <= 0.0 || volume <= 0.0) {
+            return std::nullopt;
+        }
+
+        // Surface area of sphere with same volume
+        // V = (4/3) * pi * r^3  =>  r = cbrt(3V / 4pi)
+        // A = 4 * pi * r^2
+        double r = std::cbrt(3.0 * volume / (4.0 * M_PI));
+        double sphereSurfaceArea = 4.0 * M_PI * r * r;
+
+        return sphereSurfaceArea / surfaceArea;
+    }
+};
+
+// =============================================================================
+// VolumeCalculator implementation
+// =============================================================================
+
+VolumeCalculator::VolumeCalculator()
+    : impl_(std::make_unique<Impl>())
+{
+}
+
+VolumeCalculator::~VolumeCalculator() = default;
+
+VolumeCalculator::VolumeCalculator(VolumeCalculator&&) noexcept = default;
+VolumeCalculator& VolumeCalculator::operator=(VolumeCalculator&&) noexcept = default;
+
+void VolumeCalculator::setProgressCallback(ProgressCallback callback) {
+    impl_->progressCallback = std::move(callback);
+}
+
+std::expected<VolumeResult, VolumeError>
+VolumeCalculator::calculate(LabelMapType::Pointer labelMap,
+                             uint8_t labelId,
+                             const SpacingType& spacing,
+                             bool computeSurfaceArea) {
+    if (!labelMap) {
+        return std::unexpected(VolumeError{
+            VolumeError::Code::InvalidLabelMap,
+            "Label map is null"
+        });
+    }
+
+    if (labelId == 0) {
+        return std::unexpected(VolumeError{
+            VolumeError::Code::LabelNotFound,
+            "Label ID 0 is reserved for background"
+        });
+    }
+
+    if (spacing[0] <= 0 || spacing[1] <= 0 || spacing[2] <= 0) {
+        return std::unexpected(VolumeError{
+            VolumeError::Code::InvalidSpacing,
+            "Spacing values must be positive"
+        });
+    }
+
+    // Count voxels with the specified label
+    int64_t voxelCount = 0;
+    using IteratorType = itk::ImageRegionConstIterator<LabelMapType>;
+    IteratorType it(labelMap, labelMap->GetLargestPossibleRegion());
+
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        if (it.Get() == labelId) {
+            ++voxelCount;
+        }
+    }
+
+    if (voxelCount == 0) {
+        return std::unexpected(VolumeError{
+            VolumeError::Code::LabelNotFound,
+            "No voxels found with label ID " + std::to_string(labelId)
+        });
+    }
+
+    VolumeResult result;
+    result.labelId = labelId;
+    result.voxelCount = voxelCount;
+
+    // Calculate volume
+    double voxelVolume = spacing[0] * spacing[1] * spacing[2];
+    result.volumeMm3 = static_cast<double>(voxelCount) * voxelVolume;
+    result.volumeCm3 = result.volumeMm3 / 1000.0;
+    result.volumeML = result.volumeCm3;  // 1 cm^3 = 1 mL
+
+    // Calculate bounding box
+    result.boundingBoxMm = impl_->calculateBoundingBox(labelMap, labelId, spacing);
+
+    // Calculate surface area if requested
+    if (computeSurfaceArea) {
+        result.surfaceAreaMm2 = impl_->calculateSurfaceArea(labelMap, labelId, spacing);
+
+        if (result.surfaceAreaMm2.has_value()) {
+            result.sphericity = impl_->calculateSphericity(
+                result.volumeMm3, result.surfaceAreaMm2.value()
+            );
+        }
+    }
+
+    return result;
+}
+
+std::vector<std::expected<VolumeResult, VolumeError>>
+VolumeCalculator::calculateAll(LabelMapType::Pointer labelMap,
+                                const SpacingType& spacing,
+                                bool computeSurfaceArea) {
+    std::vector<std::expected<VolumeResult, VolumeError>> results;
+
+    if (!labelMap) {
+        results.push_back(std::unexpected(VolumeError{
+            VolumeError::Code::InvalidLabelMap,
+            "Label map is null"
+        }));
+        return results;
+    }
+
+    auto labels = impl_->findAllLabels(labelMap);
+    if (labels.empty()) {
+        return results;  // No labels found, return empty vector
+    }
+
+    results.reserve(labels.size());
+
+    size_t processed = 0;
+    for (uint8_t labelId : labels) {
+        results.push_back(calculate(labelMap, labelId, spacing, computeSurfaceArea));
+
+        if (impl_->progressCallback) {
+            impl_->progressCallback(
+                static_cast<double>(++processed) / static_cast<double>(labels.size())
+            );
+        }
+    }
+
+    return results;
+}
+
+VolumeComparisonTable
+VolumeCalculator::createComparisonTable(const std::vector<VolumeResult>& results) {
+    VolumeComparisonTable table;
+    table.results = results;
+
+    // Calculate total volume
+    table.totalVolumeMm3 = 0.0;
+    for (const auto& result : results) {
+        table.totalVolumeMm3 += result.volumeMm3;
+    }
+
+    // Calculate percentages
+    table.percentages.reserve(results.size());
+    for (const auto& result : results) {
+        if (table.totalVolumeMm3 > 0.0) {
+            table.percentages.push_back(
+                (result.volumeMm3 / table.totalVolumeMm3) * 100.0
+            );
+        } else {
+            table.percentages.push_back(0.0);
+        }
+    }
+
+    return table;
+}
+
+VolumeTimePoint
+VolumeCalculator::calculateChange(const VolumeResult& current,
+                                   const VolumeResult& previous,
+                                   const std::string& studyDate,
+                                   const std::string& studyDescription) {
+    VolumeTimePoint timePoint;
+    timePoint.studyDate = studyDate;
+    timePoint.studyDescription = studyDescription;
+    timePoint.volume = current;
+
+    double change = current.volumeMm3 - previous.volumeMm3;
+    timePoint.changeFromPreviousMm3 = change;
+
+    if (previous.volumeMm3 > 0.0) {
+        timePoint.changePercentage = (change / previous.volumeMm3) * 100.0;
+    }
+
+    return timePoint;
+}
+
+std::expected<void, VolumeError>
+VolumeCalculator::exportToCsv(const std::vector<VolumeResult>& results,
+                               const std::filesystem::path& filePath) {
+    std::ofstream file(filePath);
+    if (!file.is_open()) {
+        return std::unexpected(VolumeError{
+            VolumeError::Code::ExportFailed,
+            "Failed to open file: " + filePath.string()
+        });
+    }
+
+    // Write header
+    auto header = VolumeResult::getCsvHeader();
+    for (size_t i = 0; i < header.size(); ++i) {
+        file << header[i];
+        if (i < header.size() - 1) file << ",";
+    }
+    file << "\n";
+
+    // Write data rows
+    for (const auto& result : results) {
+        auto row = result.getCsvRow();
+        for (size_t i = 0; i < row.size(); ++i) {
+            file << row[i];
+            if (i < row.size() - 1) file << ",";
+        }
+        file << "\n";
+    }
+
+    return {};
+}
+
+std::expected<void, VolumeError>
+VolumeCalculator::exportTrackingToCsv(const std::vector<VolumeTimePoint>& timePoints,
+                                       const std::filesystem::path& filePath) {
+    std::ofstream file(filePath);
+    if (!file.is_open()) {
+        return std::unexpected(VolumeError{
+            VolumeError::Code::ExportFailed,
+            "Failed to open file: " + filePath.string()
+        });
+    }
+
+    // Write header
+    file << "StudyDate,StudyDescription,LabelID,LabelName,VoxelCount,"
+         << "VolumeMm3,VolumeCm3,VolumeML,ChangeMm3,ChangePercent\n";
+
+    auto format = [](double val) {
+        std::ostringstream oss;
+        oss << std::fixed << std::setprecision(4) << val;
+        return oss.str();
+    };
+
+    // Write data rows
+    for (const auto& tp : timePoints) {
+        file << tp.studyDate << ","
+             << tp.studyDescription << ","
+             << static_cast<int>(tp.volume.labelId) << ","
+             << tp.volume.labelName << ","
+             << tp.volume.voxelCount << ","
+             << format(tp.volume.volumeMm3) << ","
+             << format(tp.volume.volumeCm3) << ","
+             << format(tp.volume.volumeML) << ",";
+
+        if (tp.changeFromPreviousMm3.has_value()) {
+            file << format(tp.changeFromPreviousMm3.value());
+        }
+        file << ",";
+
+        if (tp.changePercentage.has_value()) {
+            file << format(tp.changePercentage.value());
+        }
+        file << "\n";
+    }
+
+    return {};
+}
+
+}  // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -310,3 +310,29 @@ target_include_directories(roi_statistics_test PRIVATE
 )
 
 gtest_discover_tests(roi_statistics_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for Volume Calculator
+add_executable(volume_calculator_test
+    unit/volume_calculator_test.cpp
+)
+
+target_link_directories(volume_calculator_test PRIVATE
+    /opt/homebrew/lib
+)
+
+target_link_libraries(volume_calculator_test PRIVATE
+    measurement_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(volume_calculator_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+vtk_module_autoinit(
+    TARGETS volume_calculator_test
+    MODULES ${VTK_LIBRARIES}
+)
+
+gtest_discover_tests(volume_calculator_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/volume_calculator_test.cpp
+++ b/tests/unit/volume_calculator_test.cpp
@@ -1,0 +1,563 @@
+#include "services/measurement/volume_calculator.hpp"
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+
+namespace dicom_viewer::services {
+namespace {
+
+class VolumeCalculatorTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Create a simple label map (10x10x10)
+        testLabelMap_ = LabelMapType::New();
+
+        LabelMapType::SizeType size;
+        size[0] = 10;
+        size[1] = 10;
+        size[2] = 10;
+
+        LabelMapType::IndexType start;
+        start.Fill(0);
+
+        LabelMapType::RegionType region;
+        region.SetSize(size);
+        region.SetIndex(start);
+
+        testLabelMap_->SetRegions(region);
+        testLabelMap_->Allocate();
+        testLabelMap_->FillBuffer(0);
+
+        // Set spacing (1mm x 1mm x 1mm)
+        LabelMapType::SpacingType spacing;
+        spacing[0] = 1.0;
+        spacing[1] = 1.0;
+        spacing[2] = 1.0;
+        testLabelMap_->SetSpacing(spacing);
+
+        // Fill label 1: center cube (3-7, 3-7, 3-7) = 5x5x5 = 125 voxels
+        for (int z = 3; z <= 7; ++z) {
+            for (int y = 3; y <= 7; ++y) {
+                for (int x = 3; x <= 7; ++x) {
+                    LabelMapType::IndexType idx = {x, y, z};
+                    testLabelMap_->SetPixel(idx, 1);
+                }
+            }
+        }
+
+        // Fill label 2: corner cube (0-1, 0-1, 0-1) = 2x2x2 = 8 voxels
+        for (int z = 0; z <= 1; ++z) {
+            for (int y = 0; y <= 1; ++y) {
+                for (int x = 0; x <= 1; ++x) {
+                    LabelMapType::IndexType idx = {x, y, z};
+                    testLabelMap_->SetPixel(idx, 2);
+                }
+            }
+        }
+    }
+
+    void TearDown() override {
+        // Clean up temporary files
+        if (std::filesystem::exists(testCsvPath_)) {
+            std::filesystem::remove(testCsvPath_);
+        }
+        if (std::filesystem::exists(testTrackingCsvPath_)) {
+            std::filesystem::remove(testTrackingCsvPath_);
+        }
+    }
+
+    using LabelMapType = VolumeCalculator::LabelMapType;
+    using SpacingType = VolumeCalculator::SpacingType;
+
+    LabelMapType::Pointer testLabelMap_;
+    SpacingType testSpacing_ = {1.0, 1.0, 1.0};
+    std::filesystem::path testCsvPath_ = std::filesystem::temp_directory_path() / "test_volume.csv";
+    std::filesystem::path testTrackingCsvPath_ = std::filesystem::temp_directory_path() / "test_tracking.csv";
+};
+
+// =============================================================================
+// VolumeResult struct tests
+// =============================================================================
+
+TEST_F(VolumeCalculatorTest, VolumeResultDefaultValues) {
+    VolumeResult result;
+
+    EXPECT_EQ(result.labelId, 0);
+    EXPECT_TRUE(result.labelName.empty());
+    EXPECT_EQ(result.voxelCount, 0);
+    EXPECT_DOUBLE_EQ(result.volumeMm3, 0.0);
+    EXPECT_DOUBLE_EQ(result.volumeCm3, 0.0);
+    EXPECT_DOUBLE_EQ(result.volumeML, 0.0);
+    EXPECT_FALSE(result.surfaceAreaMm2.has_value());
+    EXPECT_FALSE(result.sphericity.has_value());
+}
+
+TEST_F(VolumeCalculatorTest, VolumeResultToString) {
+    VolumeResult result;
+    result.labelId = 1;
+    result.labelName = "Liver";
+    result.voxelCount = 1000;
+    result.volumeMm3 = 1000.0;
+    result.volumeCm3 = 1.0;
+    result.volumeML = 1.0;
+    result.surfaceAreaMm2 = 600.0;
+    result.sphericity = 0.85;
+    result.boundingBoxMm = {10.0, 10.0, 10.0};
+
+    std::string str = result.toString();
+
+    EXPECT_NE(str.find("Liver"), std::string::npos);
+    EXPECT_NE(str.find("1000"), std::string::npos);
+    EXPECT_NE(str.find("mm^3"), std::string::npos);
+    EXPECT_NE(str.find("cm^3"), std::string::npos);
+    EXPECT_NE(str.find("mL"), std::string::npos);
+    EXPECT_NE(str.find("Surface"), std::string::npos);
+    EXPECT_NE(str.find("Sphericity"), std::string::npos);
+}
+
+TEST_F(VolumeCalculatorTest, VolumeResultGetCsvHeader) {
+    auto header = VolumeResult::getCsvHeader();
+
+    EXPECT_FALSE(header.empty());
+    EXPECT_EQ(header[0], "LabelID");
+    EXPECT_EQ(header[1], "LabelName");
+    EXPECT_EQ(header[2], "VoxelCount");
+}
+
+TEST_F(VolumeCalculatorTest, VolumeResultGetCsvRow) {
+    VolumeResult result;
+    result.labelId = 1;
+    result.labelName = "TestLabel";
+    result.voxelCount = 125;
+    result.volumeMm3 = 125.0;
+    result.volumeCm3 = 0.125;
+    result.volumeML = 0.125;
+
+    auto row = result.getCsvRow();
+
+    EXPECT_FALSE(row.empty());
+    EXPECT_EQ(row[0], "1");
+    EXPECT_EQ(row[1], "TestLabel");
+    EXPECT_EQ(row[2], "125");
+}
+
+// =============================================================================
+// VolumeError tests
+// =============================================================================
+
+TEST_F(VolumeCalculatorTest, VolumeErrorSuccess) {
+    VolumeError error;
+    EXPECT_TRUE(error.isSuccess());
+    EXPECT_EQ(error.code, VolumeError::Code::Success);
+}
+
+TEST_F(VolumeCalculatorTest, VolumeErrorToString) {
+    VolumeError error;
+    error.code = VolumeError::Code::InvalidLabelMap;
+    error.message = "test message";
+
+    std::string result = error.toString();
+    EXPECT_NE(result.find("Invalid label map"), std::string::npos);
+    EXPECT_NE(result.find("test message"), std::string::npos);
+}
+
+// =============================================================================
+// VolumeCalculator basic tests
+// =============================================================================
+
+TEST_F(VolumeCalculatorTest, CalculatorDefaultConstruction) {
+    VolumeCalculator calculator;
+    // Should not crash
+}
+
+TEST_F(VolumeCalculatorTest, CalculatorMoveConstruction) {
+    VolumeCalculator calculator1;
+    VolumeCalculator calculator2(std::move(calculator1));
+    // Should not crash
+}
+
+TEST_F(VolumeCalculatorTest, CalculatorNullLabelMapError) {
+    VolumeCalculator calculator;
+
+    auto result = calculator.calculate(nullptr, 1, testSpacing_);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, VolumeError::Code::InvalidLabelMap);
+}
+
+TEST_F(VolumeCalculatorTest, CalculatorBackgroundLabelError) {
+    VolumeCalculator calculator;
+
+    auto result = calculator.calculate(testLabelMap_, 0, testSpacing_);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, VolumeError::Code::LabelNotFound);
+}
+
+TEST_F(VolumeCalculatorTest, CalculatorInvalidSpacingError) {
+    VolumeCalculator calculator;
+    SpacingType invalidSpacing = {0.0, 1.0, 1.0};
+
+    auto result = calculator.calculate(testLabelMap_, 1, invalidSpacing);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, VolumeError::Code::InvalidSpacing);
+}
+
+TEST_F(VolumeCalculatorTest, CalculatorLabelNotFoundError) {
+    VolumeCalculator calculator;
+
+    auto result = calculator.calculate(testLabelMap_, 99, testSpacing_);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, VolumeError::Code::LabelNotFound);
+}
+
+// =============================================================================
+// Volume calculation tests
+// =============================================================================
+
+TEST_F(VolumeCalculatorTest, CalculateSingleLabelVolume) {
+    VolumeCalculator calculator;
+
+    auto result = calculator.calculate(testLabelMap_, 1, testSpacing_);
+    EXPECT_TRUE(result.has_value());
+
+    if (result) {
+        EXPECT_EQ(result->labelId, 1);
+        EXPECT_EQ(result->voxelCount, 125);  // 5x5x5 cube
+        EXPECT_DOUBLE_EQ(result->volumeMm3, 125.0);  // 125 mm^3
+        EXPECT_DOUBLE_EQ(result->volumeCm3, 0.125);  // 0.125 cm^3
+        EXPECT_DOUBLE_EQ(result->volumeML, 0.125);   // 0.125 mL
+    }
+}
+
+TEST_F(VolumeCalculatorTest, CalculateSingleLabelWithDifferentSpacing) {
+    VolumeCalculator calculator;
+    SpacingType spacing = {0.5, 0.5, 2.0};  // 0.5 mm^3 voxel volume
+
+    auto result = calculator.calculate(testLabelMap_, 1, spacing);
+    EXPECT_TRUE(result.has_value());
+
+    if (result) {
+        // Voxel volume = 0.5 * 0.5 * 2.0 = 0.5 mm^3
+        // Total volume = 125 * 0.5 = 62.5 mm^3
+        EXPECT_EQ(result->voxelCount, 125);
+        EXPECT_DOUBLE_EQ(result->volumeMm3, 62.5);
+        EXPECT_DOUBLE_EQ(result->volumeCm3, 0.0625);
+    }
+}
+
+TEST_F(VolumeCalculatorTest, CalculateSecondLabel) {
+    VolumeCalculator calculator;
+
+    auto result = calculator.calculate(testLabelMap_, 2, testSpacing_);
+    EXPECT_TRUE(result.has_value());
+
+    if (result) {
+        EXPECT_EQ(result->labelId, 2);
+        EXPECT_EQ(result->voxelCount, 8);  // 2x2x2 cube
+        EXPECT_DOUBLE_EQ(result->volumeMm3, 8.0);
+        EXPECT_DOUBLE_EQ(result->volumeCm3, 0.008);
+    }
+}
+
+TEST_F(VolumeCalculatorTest, CalculateWithSurfaceArea) {
+    VolumeCalculator calculator;
+
+    auto result = calculator.calculate(testLabelMap_, 1, testSpacing_, true);
+    EXPECT_TRUE(result.has_value());
+
+    if (result) {
+        EXPECT_TRUE(result->surfaceAreaMm2.has_value());
+        EXPECT_GT(result->surfaceAreaMm2.value(), 0.0);
+        // Theoretical surface area of 5x5x5 cube = 6 * 5^2 = 150 mm^2
+        // Marching cubes gives slightly different due to mesh approximation
+        EXPECT_GT(result->surfaceAreaMm2.value(), 100.0);
+        EXPECT_LT(result->surfaceAreaMm2.value(), 200.0);
+
+        EXPECT_TRUE(result->sphericity.has_value());
+        // Cube has lower sphericity than sphere
+        EXPECT_GT(result->sphericity.value(), 0.0);
+        EXPECT_LE(result->sphericity.value(), 1.0);
+    }
+}
+
+TEST_F(VolumeCalculatorTest, CalculateBoundingBox) {
+    VolumeCalculator calculator;
+
+    auto result = calculator.calculate(testLabelMap_, 1, testSpacing_);
+    EXPECT_TRUE(result.has_value());
+
+    if (result) {
+        // Bounding box should be 5x5x5 mm (indices 3-7 = 5 voxels)
+        EXPECT_DOUBLE_EQ(result->boundingBoxMm[0], 5.0);
+        EXPECT_DOUBLE_EQ(result->boundingBoxMm[1], 5.0);
+        EXPECT_DOUBLE_EQ(result->boundingBoxMm[2], 5.0);
+    }
+}
+
+// =============================================================================
+// CalculateAll tests
+// =============================================================================
+
+TEST_F(VolumeCalculatorTest, CalculateAllLabels) {
+    VolumeCalculator calculator;
+
+    auto results = calculator.calculateAll(testLabelMap_, testSpacing_);
+    EXPECT_EQ(results.size(), 2);  // Labels 1 and 2
+
+    int successCount = 0;
+    for (const auto& result : results) {
+        if (result.has_value()) {
+            ++successCount;
+        }
+    }
+    EXPECT_EQ(successCount, 2);
+}
+
+TEST_F(VolumeCalculatorTest, CalculateAllWithSurfaceArea) {
+    VolumeCalculator calculator;
+
+    auto results = calculator.calculateAll(testLabelMap_, testSpacing_, true);
+    EXPECT_EQ(results.size(), 2);
+
+    for (const auto& result : results) {
+        if (result.has_value()) {
+            EXPECT_TRUE(result->surfaceAreaMm2.has_value());
+        }
+    }
+}
+
+TEST_F(VolumeCalculatorTest, CalculateAllEmptyLabelMap) {
+    VolumeCalculator calculator;
+
+    // Create empty label map
+    auto emptyLabelMap = LabelMapType::New();
+    emptyLabelMap->SetRegions(testLabelMap_->GetLargestPossibleRegion());
+    emptyLabelMap->Allocate();
+    emptyLabelMap->FillBuffer(0);
+
+    auto results = calculator.calculateAll(emptyLabelMap, testSpacing_);
+    EXPECT_TRUE(results.empty());
+}
+
+// =============================================================================
+// Comparison table tests
+// =============================================================================
+
+TEST_F(VolumeCalculatorTest, CreateComparisonTable) {
+    std::vector<VolumeResult> results;
+
+    VolumeResult r1;
+    r1.labelId = 1;
+    r1.labelName = "Liver";
+    r1.volumeMm3 = 1000.0;
+    results.push_back(r1);
+
+    VolumeResult r2;
+    r2.labelId = 2;
+    r2.labelName = "Kidney";
+    r2.volumeMm3 = 500.0;
+    results.push_back(r2);
+
+    auto table = VolumeCalculator::createComparisonTable(results);
+
+    EXPECT_EQ(table.results.size(), 2);
+    EXPECT_DOUBLE_EQ(table.totalVolumeMm3, 1500.0);
+    EXPECT_EQ(table.percentages.size(), 2);
+    EXPECT_NEAR(table.percentages[0], 66.67, 0.1);  // 1000/1500 * 100
+    EXPECT_NEAR(table.percentages[1], 33.33, 0.1);  // 500/1500 * 100
+}
+
+TEST_F(VolumeCalculatorTest, ComparisonTableToString) {
+    std::vector<VolumeResult> results;
+
+    VolumeResult r1;
+    r1.labelId = 1;
+    r1.labelName = "Liver";
+    r1.volumeMm3 = 1000.0;
+    r1.volumeML = 1.0;
+    results.push_back(r1);
+
+    auto table = VolumeCalculator::createComparisonTable(results);
+    std::string str = table.toString();
+
+    EXPECT_NE(str.find("Liver"), std::string::npos);
+    EXPECT_NE(str.find("Total"), std::string::npos);
+    EXPECT_NE(str.find("100"), std::string::npos);  // 100%
+}
+
+TEST_F(VolumeCalculatorTest, ComparisonTableExportToCsv) {
+    std::vector<VolumeResult> results;
+
+    VolumeResult r1;
+    r1.labelId = 1;
+    r1.labelName = "Test1";
+    r1.volumeMm3 = 100.0;
+    results.push_back(r1);
+
+    auto table = VolumeCalculator::createComparisonTable(results);
+    auto exportResult = table.exportToCsv(testCsvPath_);
+
+    EXPECT_TRUE(exportResult.has_value());
+    EXPECT_TRUE(std::filesystem::exists(testCsvPath_));
+}
+
+// =============================================================================
+// Volume change calculation tests
+// =============================================================================
+
+TEST_F(VolumeCalculatorTest, CalculateVolumeChange) {
+    VolumeResult current;
+    current.labelId = 1;
+    current.labelName = "Tumor";
+    current.volumeMm3 = 1200.0;
+
+    VolumeResult previous;
+    previous.labelId = 1;
+    previous.labelName = "Tumor";
+    previous.volumeMm3 = 1000.0;
+
+    auto timePoint = VolumeCalculator::calculateChange(
+        current, previous, "20250101", "Follow-up"
+    );
+
+    EXPECT_EQ(timePoint.studyDate, "20250101");
+    EXPECT_EQ(timePoint.studyDescription, "Follow-up");
+    EXPECT_DOUBLE_EQ(timePoint.volume.volumeMm3, 1200.0);
+    EXPECT_TRUE(timePoint.changeFromPreviousMm3.has_value());
+    EXPECT_DOUBLE_EQ(timePoint.changeFromPreviousMm3.value(), 200.0);
+    EXPECT_TRUE(timePoint.changePercentage.has_value());
+    EXPECT_DOUBLE_EQ(timePoint.changePercentage.value(), 20.0);
+}
+
+TEST_F(VolumeCalculatorTest, CalculateNegativeVolumeChange) {
+    VolumeResult current;
+    current.volumeMm3 = 800.0;
+
+    VolumeResult previous;
+    previous.volumeMm3 = 1000.0;
+
+    auto timePoint = VolumeCalculator::calculateChange(
+        current, previous, "20250101"
+    );
+
+    EXPECT_DOUBLE_EQ(timePoint.changeFromPreviousMm3.value(), -200.0);
+    EXPECT_DOUBLE_EQ(timePoint.changePercentage.value(), -20.0);
+}
+
+// =============================================================================
+// Export tests
+// =============================================================================
+
+TEST_F(VolumeCalculatorTest, ExportToCsv) {
+    std::vector<VolumeResult> results;
+
+    VolumeResult r1;
+    r1.labelId = 1;
+    r1.labelName = "Label1";
+    r1.voxelCount = 100;
+    r1.volumeMm3 = 100.0;
+    r1.volumeCm3 = 0.1;
+    r1.volumeML = 0.1;
+    results.push_back(r1);
+
+    VolumeResult r2;
+    r2.labelId = 2;
+    r2.labelName = "Label2";
+    r2.voxelCount = 200;
+    r2.volumeMm3 = 200.0;
+    r2.volumeCm3 = 0.2;
+    r2.volumeML = 0.2;
+    results.push_back(r2);
+
+    auto result = VolumeCalculator::exportToCsv(results, testCsvPath_);
+    EXPECT_TRUE(result.has_value());
+    EXPECT_TRUE(std::filesystem::exists(testCsvPath_));
+
+    // Verify file content
+    std::ifstream file(testCsvPath_);
+    int lineCount = 0;
+    std::string line;
+    while (std::getline(file, line)) {
+        ++lineCount;
+    }
+    EXPECT_EQ(lineCount, 3);  // Header + 2 data rows
+}
+
+TEST_F(VolumeCalculatorTest, ExportToCsvInvalidPath) {
+    std::vector<VolumeResult> results;
+    VolumeResult r1;
+    results.push_back(r1);
+
+    auto result = VolumeCalculator::exportToCsv(results, "/invalid/path/file.csv");
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, VolumeError::Code::ExportFailed);
+}
+
+TEST_F(VolumeCalculatorTest, ExportTrackingToCsv) {
+    std::vector<VolumeTimePoint> timePoints;
+
+    VolumeResult r1;
+    r1.labelId = 1;
+    r1.labelName = "Tumor";
+    r1.volumeMm3 = 1000.0;
+    r1.volumeCm3 = 1.0;
+    r1.volumeML = 1.0;
+
+    VolumeTimePoint tp1;
+    tp1.studyDate = "20240101";
+    tp1.studyDescription = "Baseline";
+    tp1.volume = r1;
+    timePoints.push_back(tp1);
+
+    VolumeResult r2;
+    r2.labelId = 1;
+    r2.labelName = "Tumor";
+    r2.volumeMm3 = 1200.0;
+    r2.volumeCm3 = 1.2;
+    r2.volumeML = 1.2;
+
+    VolumeTimePoint tp2;
+    tp2.studyDate = "20250101";
+    tp2.studyDescription = "Follow-up";
+    tp2.volume = r2;
+    tp2.changeFromPreviousMm3 = 200.0;
+    tp2.changePercentage = 20.0;
+    timePoints.push_back(tp2);
+
+    auto result = VolumeCalculator::exportTrackingToCsv(timePoints, testTrackingCsvPath_);
+    EXPECT_TRUE(result.has_value());
+    EXPECT_TRUE(std::filesystem::exists(testTrackingCsvPath_));
+
+    // Verify file content
+    std::ifstream file(testTrackingCsvPath_);
+    std::string header;
+    std::getline(file, header);
+    EXPECT_NE(header.find("StudyDate"), std::string::npos);
+    EXPECT_NE(header.find("ChangePercent"), std::string::npos);
+}
+
+// =============================================================================
+// Progress callback test
+// =============================================================================
+
+TEST_F(VolumeCalculatorTest, ProgressCallback) {
+    VolumeCalculator calculator;
+
+    int callCount = 0;
+    double lastProgress = 0.0;
+
+    calculator.setProgressCallback([&](double progress) {
+        ++callCount;
+        lastProgress = progress;
+    });
+
+    auto unused = calculator.calculateAll(testLabelMap_, testSpacing_);
+    (void)unused;
+
+    EXPECT_EQ(callCount, 2);  // Two labels
+    EXPECT_DOUBLE_EQ(lastProgress, 1.0);
+}
+
+}  // namespace
+}  // namespace dicom_viewer::services


### PR DESCRIPTION
## Summary

- Add `VolumeCalculator` class for computing 3D volumes of segmented regions
- Implement volume calculation with multiple unit support (mm³, cm³, mL)
- Add surface area calculation using VTK Marching Cubes algorithm
- Implement sphericity calculation for shape analysis
- Add volume comparison table for multiple labels
- Support volume tracking for serial studies with change calculation
- Provide CSV export for volume data and tracking history

## Implementation Details

### New Files
- `include/services/measurement/volume_calculator.hpp` - Header with VolumeResult, VolumeTimePoint, VolumeComparisonTable structs and VolumeCalculator class
- `src/services/measurement/volume_calculator.cpp` - Implementation
- `tests/unit/volume_calculator_test.cpp` - Unit tests (29 tests)

### Key Features
| Feature | Description |
|---------|-------------|
| Volume Calculation | Accurate volume from voxel count × voxel spacing |
| Unit Conversion | mm³ → cm³ → mL (1 cm³ = 1 mL) |
| Surface Area | Marching Cubes mesh generation + vtkMassProperties |
| Sphericity | Shape regularity measure (1.0 = perfect sphere) |
| Bounding Box | Region dimensions in mm |
| Comparison Table | Multi-label volume comparison with percentages |
| Volume Tracking | Serial study change calculation (absolute & percentage) |
| CSV Export | Export volume data and tracking history |

## Test Plan

- [x] All 29 unit tests passing
- [x] Volume calculation accuracy verified (125 voxels × 1mm³ = 125mm³)
- [x] Surface area calculation verified (Marching Cubes mesh)
- [x] CSV export functionality tested
- [x] Error handling tested (null labelmap, invalid spacing, label not found)

Closes #31