### PR TITLE
feat(preprocessing): implement N4 bias field correction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ find_package(ITK REQUIRED COMPONENTS
     ITKMathematicalMorphology
     ITKLabelMap
     ITKStatistics
+    ITKBiasCorrection
     ITKVtkGlue
 )
 
@@ -152,11 +153,18 @@ target_link_libraries(measurement_service PUBLIC
 add_library(preprocessing_service STATIC
     src/services/preprocessing/gaussian_smoother.cpp
     src/services/preprocessing/anisotropic_diffusion_filter.cpp
+    src/services/preprocessing/n4_bias_corrector.cpp
 )
+
+# Find FFTW for N4 bias correction (uses ITK's FFTW dependency)
+find_library(FFTW3_LIBRARY fftw3 HINTS /opt/homebrew/lib)
+find_library(FFTW3_THREADS_LIBRARY fftw3_threads HINTS /opt/homebrew/lib)
 
 target_link_libraries(preprocessing_service PUBLIC
     dicom_viewer_core
     ${ITK_LIBRARIES}
+    ${FFTW3_LIBRARY}
+    ${FFTW3_THREADS_LIBRARY}
 )
 
 add_library(segmentation_service STATIC

--- a/include/services/preprocessing/n4_bias_corrector.hpp
+++ b/include/services/preprocessing/n4_bias_corrector.hpp
@@ -1,0 +1,221 @@
+#pragma once
+
+#include <expected>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <itkImage.h>
+#include <itkSmartPointer.h>
+
+#include "services/preprocessing/gaussian_smoother.hpp"
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief N4 bias field correction for MRI intensity inhomogeneity
+ *
+ * Corrects MRI intensity inhomogeneity (bias field artifact) using the N4ITK
+ * algorithm. The bias field is a smooth, low-frequency artifact caused by
+ * magnetic field inhomogeneity in MRI scanners, which appears as slow
+ * intensity variation across the image.
+ *
+ * The filter uses ITK's N4BiasFieldCorrectionImageFilter which implements
+ * an improved version of the N3 (nonparametric nonuniform intensity
+ * normalization) algorithm.
+ *
+ * @example
+ * @code
+ * N4BiasCorrector corrector;
+ *
+ * // Apply with default parameters
+ * auto result = corrector.apply(mriImage);
+ * if (result) {
+ *     auto correctedImage = result->correctedImage;
+ *     auto biasField = result->biasField;
+ * }
+ *
+ * // Apply with custom parameters
+ * N4BiasCorrector::Parameters params;
+ * params.shrinkFactor = 2;
+ * params.numberOfFittingLevels = 4;
+ * auto customResult = corrector.apply(mriImage, params);
+ *
+ * // Apply with mask for ROI-based correction
+ * auto maskedResult = corrector.apply(mriImage, params, brainMask);
+ * @endcode
+ *
+ * @trace SRS-FR-018
+ */
+class N4BiasCorrector {
+public:
+    /// Input image type (short for DICOM compatibility)
+    using InputImageType = itk::Image<short, 3>;
+
+    /// Internal float image type for processing
+    using FloatImageType = itk::Image<float, 3>;
+
+    /// Binary mask type for ROI-based correction
+    using MaskImageType = itk::Image<unsigned char, 3>;
+
+    /// Progress callback (0.0 to 1.0)
+    using ProgressCallback = std::function<void(double progress)>;
+
+    /**
+     * @brief Parameters for N4 bias field correction
+     */
+    struct Parameters {
+        /// Shrink factor for speed optimization
+        /// Range: 1 to 8
+        /// Higher values = faster but less accurate
+        int shrinkFactor = 4;
+
+        /// Number of fitting levels in the B-spline hierarchy
+        /// Range: 1 to 8
+        int numberOfFittingLevels = 4;
+
+        /// Maximum number of iterations at each fitting level
+        /// Must have numberOfFittingLevels elements
+        std::vector<int> maxIterationsPerLevel = {50, 50, 50, 50};
+
+        /// Convergence threshold for the optimization
+        /// Range: 1e-7 to 1e-1
+        double convergenceThreshold = 0.001;
+
+        /// Number of control points in the B-spline grid
+        /// Initial number; doubles at each fitting level
+        int numberOfControlPoints = 4;
+
+        /// Spline order for B-spline fitting
+        /// Range: 2 to 4
+        int splineOrder = 3;
+
+        /// Wiener filter noise variance (0 = automatic estimation)
+        double wienerFilterNoise = 0.0;
+
+        /// Bias field full width at half maximum (in mm)
+        double biasFieldFullWidthAtHalfMaximum = 0.15;
+
+        /**
+         * @brief Validate parameters
+         * @return true if parameters are valid
+         */
+        [[nodiscard]] bool isValid() const noexcept {
+            if (shrinkFactor < 1 || shrinkFactor > 8) {
+                return false;
+            }
+            if (numberOfFittingLevels < 1 || numberOfFittingLevels > 8) {
+                return false;
+            }
+            if (maxIterationsPerLevel.size() !=
+                static_cast<size_t>(numberOfFittingLevels)) {
+                return false;
+            }
+            for (int iter : maxIterationsPerLevel) {
+                if (iter < 1 || iter > 500) {
+                    return false;
+                }
+            }
+            if (convergenceThreshold < 1e-7 || convergenceThreshold > 1e-1) {
+                return false;
+            }
+            if (numberOfControlPoints < 2 || numberOfControlPoints > 32) {
+                return false;
+            }
+            if (splineOrder < 2 || splineOrder > 4) {
+                return false;
+            }
+            if (wienerFilterNoise < 0.0) {
+                return false;
+            }
+            if (biasFieldFullWidthAtHalfMaximum <= 0.0) {
+                return false;
+            }
+            return true;
+        }
+    };
+
+    /**
+     * @brief Result of N4 bias field correction
+     */
+    struct Result {
+        /// Bias-corrected image
+        InputImageType::Pointer correctedImage;
+
+        /// Estimated bias field (logarithmic scale)
+        FloatImageType::Pointer biasField;
+    };
+
+    N4BiasCorrector();
+    ~N4BiasCorrector();
+
+    // Non-copyable, movable
+    N4BiasCorrector(const N4BiasCorrector&) = delete;
+    N4BiasCorrector& operator=(const N4BiasCorrector&) = delete;
+    N4BiasCorrector(N4BiasCorrector&&) noexcept;
+    N4BiasCorrector& operator=(N4BiasCorrector&&) noexcept;
+
+    /**
+     * @brief Set progress callback for long operations
+     * @param callback Callback function receiving progress (0.0 to 1.0)
+     */
+    void setProgressCallback(ProgressCallback callback);
+
+    /**
+     * @brief Apply N4 bias correction with default parameters
+     *
+     * Uses default shrink factor of 4 with 4 fitting levels.
+     *
+     * @param input Input 3D MRI image (short type)
+     * @return Result containing corrected image and bias field, or error
+     */
+    [[nodiscard]] std::expected<Result, PreprocessingError>
+    apply(InputImageType::Pointer input) const;
+
+    /**
+     * @brief Apply N4 bias correction with custom parameters
+     *
+     * @param input Input 3D MRI image (short type)
+     * @param params Correction parameters
+     * @return Result containing corrected image and bias field, or error
+     */
+    [[nodiscard]] std::expected<Result, PreprocessingError>
+    apply(InputImageType::Pointer input, const Parameters& params) const;
+
+    /**
+     * @brief Apply N4 bias correction with mask for ROI-based processing
+     *
+     * The mask specifies which voxels to use for bias field estimation.
+     * Typically a brain mask for brain MRI.
+     *
+     * @param input Input 3D MRI image (short type)
+     * @param params Correction parameters
+     * @param mask Binary mask (non-zero = include in estimation)
+     * @return Result containing corrected image and bias field, or error
+     */
+    [[nodiscard]] std::expected<Result, PreprocessingError>
+    apply(
+        InputImageType::Pointer input,
+        const Parameters& params,
+        MaskImageType::Pointer mask
+    ) const;
+
+    /**
+     * @brief Estimate processing time based on image size and parameters
+     *
+     * @param imageSize Image dimensions (x, y, z)
+     * @param params Correction parameters
+     * @return Estimated processing time in seconds
+     */
+    [[nodiscard]] static double estimateProcessingTime(
+        const std::array<unsigned int, 3>& imageSize,
+        const Parameters& params
+    );
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace dicom_viewer::services

--- a/src/services/preprocessing/n4_bias_corrector.cpp
+++ b/src/services/preprocessing/n4_bias_corrector.cpp
@@ -1,0 +1,313 @@
+#include "services/preprocessing/n4_bias_corrector.hpp"
+
+#include <cmath>
+
+#include <itkCastImageFilter.h>
+#include <itkCommand.h>
+#include <itkDivideImageFilter.h>
+#include <itkIdentityTransform.h>
+#include <itkLinearInterpolateImageFunction.h>
+#include <itkN4BiasFieldCorrectionImageFilter.h>
+#include <itkNearestNeighborInterpolateImageFunction.h>
+#include <itkOtsuThresholdImageFilter.h>
+#include <itkResampleImageFilter.h>
+
+namespace dicom_viewer::services {
+
+namespace {
+
+/**
+ * @brief ITK progress observer for N4 bias correction callback integration
+ */
+class N4ProgressObserver : public itk::Command {
+public:
+    using Self = N4ProgressObserver;
+    using Superclass = itk::Command;
+    using Pointer = itk::SmartPointer<Self>;
+
+    itkNewMacro(Self);
+
+    void setCallback(N4BiasCorrector::ProgressCallback callback) {
+        callback_ = std::move(callback);
+    }
+
+    void Execute(itk::Object* caller, const itk::EventObject& event) override {
+        Execute(static_cast<const itk::Object*>(caller), event);
+    }
+
+    void Execute(const itk::Object* caller, const itk::EventObject& event) override {
+        if (!callback_) return;
+
+        if (itk::ProgressEvent().CheckEvent(&event)) {
+            const auto* process = dynamic_cast<const itk::ProcessObject*>(caller);
+            if (process) {
+                callback_(process->GetProgress());
+            }
+        }
+    }
+
+private:
+    N4BiasCorrector::ProgressCallback callback_;
+};
+
+}  // anonymous namespace
+
+/**
+ * @brief PIMPL implementation for N4BiasCorrector
+ */
+class N4BiasCorrector::Impl {
+public:
+    ProgressCallback progressCallback;
+};
+
+N4BiasCorrector::N4BiasCorrector()
+    : impl_(std::make_unique<Impl>()) {}
+
+N4BiasCorrector::~N4BiasCorrector() = default;
+
+N4BiasCorrector::N4BiasCorrector(N4BiasCorrector&&) noexcept = default;
+
+N4BiasCorrector& N4BiasCorrector::operator=(N4BiasCorrector&&) noexcept = default;
+
+void N4BiasCorrector::setProgressCallback(ProgressCallback callback) {
+    impl_->progressCallback = std::move(callback);
+}
+
+std::expected<N4BiasCorrector::Result, PreprocessingError>
+N4BiasCorrector::apply(InputImageType::Pointer input) const {
+    return apply(input, Parameters{}, nullptr);
+}
+
+std::expected<N4BiasCorrector::Result, PreprocessingError>
+N4BiasCorrector::apply(
+    InputImageType::Pointer input,
+    const Parameters& params
+) const {
+    return apply(input, params, nullptr);
+}
+
+std::expected<N4BiasCorrector::Result, PreprocessingError>
+N4BiasCorrector::apply(
+    InputImageType::Pointer input,
+    const Parameters& params,
+    MaskImageType::Pointer mask
+) const {
+    // Validate input
+    if (!input) {
+        return std::unexpected(PreprocessingError{
+            PreprocessingError::Code::InvalidInput,
+            "Input image is null"
+        });
+    }
+
+    // Validate parameters
+    if (!params.isValid()) {
+        return std::unexpected(PreprocessingError{
+            PreprocessingError::Code::InvalidParameters,
+            "Invalid N4 correction parameters: check shrinkFactor, "
+            "numberOfFittingLevels, maxIterationsPerLevel, and convergenceThreshold"
+        });
+    }
+
+    try {
+        // Cast input to float for N4 filter (required by ITK)
+        using CastToFloatType = itk::CastImageFilter<InputImageType, FloatImageType>;
+        auto castToFloat = CastToFloatType::New();
+        castToFloat->SetInput(input);
+        castToFloat->Update();
+
+        FloatImageType::Pointer floatImage = castToFloat->GetOutput();
+
+        // Store original image information for resampling
+        auto originalSize = floatImage->GetLargestPossibleRegion().GetSize();
+        auto originalSpacing = floatImage->GetSpacing();
+        auto originalOrigin = floatImage->GetOrigin();
+        auto originalDirection = floatImage->GetDirection();
+
+        // Calculate shrunk image properties
+        FloatImageType::SizeType shrunkSize;
+        FloatImageType::SpacingType shrunkSpacing;
+        for (unsigned int d = 0; d < 3; ++d) {
+            shrunkSize[d] = originalSize[d] / params.shrinkFactor;
+            if (shrunkSize[d] < 1) shrunkSize[d] = 1;
+            shrunkSpacing[d] = originalSpacing[d] * params.shrinkFactor;
+        }
+
+        // Resample input image to shrunk size
+        using TransformType = itk::IdentityTransform<double, 3>;
+        using InterpolatorType = itk::LinearInterpolateImageFunction<FloatImageType, double>;
+        using ResampleFilterType = itk::ResampleImageFilter<FloatImageType, FloatImageType>;
+
+        auto resampleShrink = ResampleFilterType::New();
+        resampleShrink->SetInput(floatImage);
+        resampleShrink->SetSize(shrunkSize);
+        resampleShrink->SetOutputSpacing(shrunkSpacing);
+        resampleShrink->SetOutputOrigin(originalOrigin);
+        resampleShrink->SetOutputDirection(originalDirection);
+        resampleShrink->SetTransform(TransformType::New());
+        resampleShrink->SetInterpolator(InterpolatorType::New());
+        resampleShrink->SetDefaultPixelValue(0);
+        resampleShrink->Update();
+
+        FloatImageType::Pointer shrunkImage = resampleShrink->GetOutput();
+
+        // Create or resample mask
+        MaskImageType::Pointer shrunkMask;
+        if (mask) {
+            // Resample the provided mask
+            using MaskInterpolatorType = itk::NearestNeighborInterpolateImageFunction<
+                MaskImageType, double>;
+            using ResampleMaskType = itk::ResampleImageFilter<MaskImageType, MaskImageType>;
+
+            auto resampleMask = ResampleMaskType::New();
+            resampleMask->SetInput(mask);
+            resampleMask->SetSize(shrunkSize);
+            resampleMask->SetOutputSpacing(shrunkSpacing);
+            resampleMask->SetOutputOrigin(originalOrigin);
+            resampleMask->SetOutputDirection(originalDirection);
+            resampleMask->SetTransform(TransformType::New());
+            resampleMask->SetInterpolator(MaskInterpolatorType::New());
+            resampleMask->SetDefaultPixelValue(0);
+            resampleMask->Update();
+            shrunkMask = resampleMask->GetOutput();
+        } else {
+            // Generate mask using Otsu thresholding on the shrunk image
+            using OtsuFilterType = itk::OtsuThresholdImageFilter<
+                FloatImageType, MaskImageType>;
+            auto otsuFilter = OtsuFilterType::New();
+            otsuFilter->SetInput(shrunkImage);
+            otsuFilter->SetInsideValue(0);
+            otsuFilter->SetOutsideValue(1);
+            otsuFilter->Update();
+            shrunkMask = otsuFilter->GetOutput();
+        }
+
+        // Configure N4 bias field correction filter
+        using N4FilterType = itk::N4BiasFieldCorrectionImageFilter<
+            FloatImageType, MaskImageType, FloatImageType>;
+        auto n4Filter = N4FilterType::New();
+
+        n4Filter->SetInput(shrunkImage);
+        n4Filter->SetMaskImage(shrunkMask);
+
+        // Set fitting levels and iterations
+        N4FilterType::VariableSizeArrayType maxIterations(
+            params.numberOfFittingLevels);
+        for (int i = 0; i < params.numberOfFittingLevels; ++i) {
+            maxIterations[i] = static_cast<unsigned int>(
+                params.maxIterationsPerLevel[i]);
+        }
+        n4Filter->SetMaximumNumberOfIterations(maxIterations);
+
+        n4Filter->SetNumberOfFittingLevels(
+            static_cast<unsigned int>(params.numberOfFittingLevels));
+        n4Filter->SetConvergenceThreshold(params.convergenceThreshold);
+        n4Filter->SetSplineOrder(static_cast<unsigned int>(params.splineOrder));
+
+        // Set B-spline control points
+        N4FilterType::ArrayType numberOfControlPoints;
+        numberOfControlPoints.Fill(
+            static_cast<unsigned int>(params.numberOfControlPoints));
+        n4Filter->SetNumberOfControlPoints(numberOfControlPoints);
+
+        // Set Wiener filter noise if specified
+        if (params.wienerFilterNoise > 0.0) {
+            n4Filter->SetWienerFilterNoise(params.wienerFilterNoise);
+        }
+
+        n4Filter->SetBiasFieldFullWidthAtHalfMaximum(
+            params.biasFieldFullWidthAtHalfMaximum);
+
+        // Attach progress observer if callback is set
+        if (impl_->progressCallback) {
+            auto observer = N4ProgressObserver::New();
+            observer->setCallback(impl_->progressCallback);
+            n4Filter->AddObserver(itk::ProgressEvent(), observer);
+        }
+
+        n4Filter->Update();
+
+        // Get corrected shrunk image
+        FloatImageType::Pointer correctedShrunkImage = n4Filter->GetOutput();
+
+        // Calculate bias field on shrunk image: biasField = original / corrected
+        using DivideFilterType = itk::DivideImageFilter<
+            FloatImageType, FloatImageType, FloatImageType>;
+        auto divideForBias = DivideFilterType::New();
+        divideForBias->SetInput1(shrunkImage);
+        divideForBias->SetInput2(correctedShrunkImage);
+        divideForBias->Update();
+
+        FloatImageType::Pointer shrunkBiasField = divideForBias->GetOutput();
+
+        // Resample bias field to full resolution
+        auto resampleBias = ResampleFilterType::New();
+        resampleBias->SetInput(shrunkBiasField);
+        resampleBias->SetSize(originalSize);
+        resampleBias->SetOutputSpacing(originalSpacing);
+        resampleBias->SetOutputOrigin(originalOrigin);
+        resampleBias->SetOutputDirection(originalDirection);
+        resampleBias->SetTransform(TransformType::New());
+        resampleBias->SetInterpolator(InterpolatorType::New());
+        resampleBias->SetDefaultPixelValue(1.0);  // Default to no correction
+        resampleBias->Update();
+
+        FloatImageType::Pointer biasField = resampleBias->GetOutput();
+
+        // Apply bias correction to full resolution image
+        auto divideFilter = DivideFilterType::New();
+        divideFilter->SetInput1(floatImage);
+        divideFilter->SetInput2(biasField);
+        divideFilter->Update();
+
+        // Cast back to short for output
+        using CastToShortType = itk::CastImageFilter<FloatImageType, InputImageType>;
+        auto castToShort = CastToShortType::New();
+        castToShort->SetInput(divideFilter->GetOutput());
+        castToShort->Update();
+
+        Result result;
+        result.correctedImage = castToShort->GetOutput();
+        result.biasField = biasField;
+
+        return result;
+    }
+    catch (const itk::ExceptionObject& e) {
+        return std::unexpected(PreprocessingError{
+            PreprocessingError::Code::ProcessingFailed,
+            std::string("ITK exception: ") + e.GetDescription()
+        });
+    }
+    catch (const std::exception& e) {
+        return std::unexpected(PreprocessingError{
+            PreprocessingError::Code::InternalError,
+            std::string("Standard exception: ") + e.what()
+        });
+    }
+}
+
+double N4BiasCorrector::estimateProcessingTime(
+    const std::array<unsigned int, 3>& imageSize,
+    const Parameters& params
+) {
+    // Empirical estimation based on image size, shrink factor, and iterations
+    // N4 is computationally intensive due to B-spline fitting
+    constexpr double voxelsPerSecond = 5e5;  // Lower than diffusion due to complexity
+
+    const double shrunkVoxels =
+        (static_cast<double>(imageSize[0]) / params.shrinkFactor) *
+        (static_cast<double>(imageSize[1]) / params.shrinkFactor) *
+        (static_cast<double>(imageSize[2]) / params.shrinkFactor);
+
+    // Total iterations across all levels
+    int totalIterations = 0;
+    for (int iter : params.maxIterationsPerLevel) {
+        totalIterations += iter;
+    }
+
+    const double estimatedSeconds = (shrunkVoxels * totalIterations) / voxelsPerSecond;
+
+    return estimatedSeconds;
+}
+
+}  // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -370,3 +370,24 @@ target_include_directories(anisotropic_diffusion_filter_test PRIVATE
 )
 
 gtest_discover_tests(anisotropic_diffusion_filter_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for N4 Bias Corrector
+add_executable(n4_bias_corrector_test
+    unit/n4_bias_corrector_test.cpp
+)
+
+target_link_directories(n4_bias_corrector_test PRIVATE
+    /opt/homebrew/lib
+)
+
+target_link_libraries(n4_bias_corrector_test PRIVATE
+    preprocessing_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(n4_bias_corrector_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(n4_bias_corrector_test DISCOVERY_TIMEOUT 120)

--- a/tests/unit/n4_bias_corrector_test.cpp
+++ b/tests/unit/n4_bias_corrector_test.cpp
@@ -1,0 +1,464 @@
+#include "services/preprocessing/n4_bias_corrector.hpp"
+
+#include <gtest/gtest.h>
+#include <cmath>
+
+namespace dicom_viewer::services {
+namespace {
+
+class N4BiasCorrectorTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Create a simple test image (16x16x16) - small for fast tests
+        testImage_ = InputImageType::New();
+
+        InputImageType::SizeType size;
+        size[0] = 16;
+        size[1] = 16;
+        size[2] = 16;
+
+        InputImageType::IndexType start;
+        start.Fill(0);
+
+        InputImageType::RegionType region;
+        region.SetSize(size);
+        region.SetIndex(start);
+
+        testImage_->SetRegions(region);
+        testImage_->Allocate();
+        testImage_->FillBuffer(100);
+
+        // Set spacing (1mm x 1mm x 1mm)
+        InputImageType::SpacingType spacing;
+        spacing[0] = 1.0;
+        spacing[1] = 1.0;
+        spacing[2] = 1.0;
+        testImage_->SetSpacing(spacing);
+
+        // Simulate bias field artifact: gradual intensity increase along X axis
+        // This mimics real MRI bias field
+        for (int z = 0; z < 16; ++z) {
+            for (int y = 0; y < 16; ++y) {
+                for (int x = 0; x < 16; ++x) {
+                    InputImageType::IndexType idx = {x, y, z};
+                    // Bias increases from 0.5 to 1.5 along X
+                    double biasFactor = 0.5 + (static_cast<double>(x) / 15.0);
+                    short value = static_cast<short>(100 * biasFactor);
+                    testImage_->SetPixel(idx, value);
+                }
+            }
+        }
+
+        // Create a simple mask (center region)
+        testMask_ = MaskImageType::New();
+        testMask_->SetRegions(region);
+        testMask_->Allocate();
+        testMask_->FillBuffer(0);
+        testMask_->SetSpacing(spacing);
+
+        for (int z = 4; z < 12; ++z) {
+            for (int y = 4; y < 12; ++y) {
+                for (int x = 4; x < 12; ++x) {
+                    MaskImageType::IndexType idx = {x, y, z};
+                    testMask_->SetPixel(idx, 1);
+                }
+            }
+        }
+    }
+
+    using InputImageType = N4BiasCorrector::InputImageType;
+    using MaskImageType = N4BiasCorrector::MaskImageType;
+    using FloatImageType = N4BiasCorrector::FloatImageType;
+
+    InputImageType::Pointer testImage_;
+    MaskImageType::Pointer testMask_;
+};
+
+// =============================================================================
+// Parameters validation tests
+// =============================================================================
+
+TEST_F(N4BiasCorrectorTest, ParametersDefaultValid) {
+    N4BiasCorrector::Parameters params;
+
+    EXPECT_TRUE(params.isValid());
+    EXPECT_EQ(params.shrinkFactor, 4);
+    EXPECT_EQ(params.numberOfFittingLevels, 4);
+    EXPECT_EQ(params.maxIterationsPerLevel.size(), 4);
+    EXPECT_DOUBLE_EQ(params.convergenceThreshold, 0.001);
+}
+
+TEST_F(N4BiasCorrectorTest, ParametersShrinkFactorTooLow) {
+    N4BiasCorrector::Parameters params;
+    params.shrinkFactor = 0;
+
+    EXPECT_FALSE(params.isValid());
+}
+
+TEST_F(N4BiasCorrectorTest, ParametersShrinkFactorTooHigh) {
+    N4BiasCorrector::Parameters params;
+    params.shrinkFactor = 9;
+
+    EXPECT_FALSE(params.isValid());
+}
+
+TEST_F(N4BiasCorrectorTest, ParametersShrinkFactorAtBoundaries) {
+    N4BiasCorrector::Parameters params;
+
+    params.shrinkFactor = 1;  // Minimum
+    EXPECT_TRUE(params.isValid());
+
+    params.shrinkFactor = 8;  // Maximum
+    EXPECT_TRUE(params.isValid());
+}
+
+TEST_F(N4BiasCorrectorTest, ParametersFittingLevelsTooLow) {
+    N4BiasCorrector::Parameters params;
+    params.numberOfFittingLevels = 0;
+    params.maxIterationsPerLevel = {};
+
+    EXPECT_FALSE(params.isValid());
+}
+
+TEST_F(N4BiasCorrectorTest, ParametersFittingLevelsTooHigh) {
+    N4BiasCorrector::Parameters params;
+    params.numberOfFittingLevels = 9;
+    params.maxIterationsPerLevel = {50, 50, 50, 50, 50, 50, 50, 50, 50};
+
+    EXPECT_FALSE(params.isValid());
+}
+
+TEST_F(N4BiasCorrectorTest, ParametersIterationsMismatch) {
+    N4BiasCorrector::Parameters params;
+    params.numberOfFittingLevels = 4;
+    params.maxIterationsPerLevel = {50, 50};  // Only 2 elements, should be 4
+
+    EXPECT_FALSE(params.isValid());
+}
+
+TEST_F(N4BiasCorrectorTest, ParametersIterationsTooLow) {
+    N4BiasCorrector::Parameters params;
+    params.maxIterationsPerLevel = {0, 50, 50, 50};  // First element invalid
+
+    EXPECT_FALSE(params.isValid());
+}
+
+TEST_F(N4BiasCorrectorTest, ParametersIterationsTooHigh) {
+    N4BiasCorrector::Parameters params;
+    params.maxIterationsPerLevel = {50, 501, 50, 50};  // Second element too high
+
+    EXPECT_FALSE(params.isValid());
+}
+
+TEST_F(N4BiasCorrectorTest, ParametersConvergenceTooLow) {
+    N4BiasCorrector::Parameters params;
+    params.convergenceThreshold = 1e-8;  // Below 1e-7
+
+    EXPECT_FALSE(params.isValid());
+}
+
+TEST_F(N4BiasCorrectorTest, ParametersConvergenceTooHigh) {
+    N4BiasCorrector::Parameters params;
+    params.convergenceThreshold = 0.2;  // Above 1e-1
+
+    EXPECT_FALSE(params.isValid());
+}
+
+TEST_F(N4BiasCorrectorTest, ParametersConvergenceAtBoundaries) {
+    N4BiasCorrector::Parameters params;
+
+    params.convergenceThreshold = 1e-7;  // Minimum
+    EXPECT_TRUE(params.isValid());
+
+    params.convergenceThreshold = 1e-1;  // Maximum
+    EXPECT_TRUE(params.isValid());
+}
+
+TEST_F(N4BiasCorrectorTest, ParametersControlPointsTooLow) {
+    N4BiasCorrector::Parameters params;
+    params.numberOfControlPoints = 1;
+
+    EXPECT_FALSE(params.isValid());
+}
+
+TEST_F(N4BiasCorrectorTest, ParametersControlPointsTooHigh) {
+    N4BiasCorrector::Parameters params;
+    params.numberOfControlPoints = 33;
+
+    EXPECT_FALSE(params.isValid());
+}
+
+TEST_F(N4BiasCorrectorTest, ParametersSplineOrderTooLow) {
+    N4BiasCorrector::Parameters params;
+    params.splineOrder = 1;
+
+    EXPECT_FALSE(params.isValid());
+}
+
+TEST_F(N4BiasCorrectorTest, ParametersSplineOrderTooHigh) {
+    N4BiasCorrector::Parameters params;
+    params.splineOrder = 5;
+
+    EXPECT_FALSE(params.isValid());
+}
+
+TEST_F(N4BiasCorrectorTest, ParametersNegativeWienerNoise) {
+    N4BiasCorrector::Parameters params;
+    params.wienerFilterNoise = -0.1;
+
+    EXPECT_FALSE(params.isValid());
+}
+
+TEST_F(N4BiasCorrectorTest, ParametersInvalidBiasFWHM) {
+    N4BiasCorrector::Parameters params;
+    params.biasFieldFullWidthAtHalfMaximum = 0.0;
+
+    EXPECT_FALSE(params.isValid());
+}
+
+// =============================================================================
+// N4BiasCorrector apply tests
+// =============================================================================
+
+TEST_F(N4BiasCorrectorTest, ApplyNullInput) {
+    N4BiasCorrector corrector;
+
+    auto result = corrector.apply(nullptr);
+
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, PreprocessingError::Code::InvalidInput);
+}
+
+TEST_F(N4BiasCorrectorTest, ApplyInvalidParameters) {
+    N4BiasCorrector corrector;
+    N4BiasCorrector::Parameters params;
+    params.shrinkFactor = 0;  // Invalid
+
+    auto result = corrector.apply(testImage_, params);
+
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, PreprocessingError::Code::InvalidParameters);
+}
+
+TEST_F(N4BiasCorrectorTest, ApplyWithDefaultParameters) {
+    N4BiasCorrector corrector;
+
+    // Use minimal parameters for faster test
+    N4BiasCorrector::Parameters params;
+    params.shrinkFactor = 4;
+    params.numberOfFittingLevels = 1;
+    params.maxIterationsPerLevel = {2};  // Minimal iterations
+    params.convergenceThreshold = 0.01;
+
+    auto result = corrector.apply(testImage_, params);
+
+    ASSERT_TRUE(result.has_value());
+
+    auto& res = result.value();
+    ASSERT_NE(res.correctedImage, nullptr);
+    ASSERT_NE(res.biasField, nullptr);
+
+    // Check output dimensions match input
+    auto inputSize = testImage_->GetLargestPossibleRegion().GetSize();
+    auto outputSize = res.correctedImage->GetLargestPossibleRegion().GetSize();
+
+    EXPECT_EQ(inputSize[0], outputSize[0]);
+    EXPECT_EQ(inputSize[1], outputSize[1]);
+    EXPECT_EQ(inputSize[2], outputSize[2]);
+}
+
+TEST_F(N4BiasCorrectorTest, ApplyWithMask) {
+    N4BiasCorrector corrector;
+
+    N4BiasCorrector::Parameters params;
+    params.shrinkFactor = 4;
+    params.numberOfFittingLevels = 1;
+    params.maxIterationsPerLevel = {2};
+    params.convergenceThreshold = 0.01;
+
+    auto result = corrector.apply(testImage_, params, testMask_);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NE(result.value().correctedImage, nullptr);
+    EXPECT_NE(result.value().biasField, nullptr);
+}
+
+TEST_F(N4BiasCorrectorTest, ApplyPreservesImageProperties) {
+    N4BiasCorrector corrector;
+
+    N4BiasCorrector::Parameters params;
+    params.shrinkFactor = 4;
+    params.numberOfFittingLevels = 1;
+    params.maxIterationsPerLevel = {2};
+
+    auto result = corrector.apply(testImage_, params);
+    ASSERT_TRUE(result.has_value());
+
+    auto& correctedImage = result.value().correctedImage;
+
+    // Check spacing is preserved
+    auto inputSpacing = testImage_->GetSpacing();
+    auto outputSpacing = correctedImage->GetSpacing();
+
+    EXPECT_DOUBLE_EQ(inputSpacing[0], outputSpacing[0]);
+    EXPECT_DOUBLE_EQ(inputSpacing[1], outputSpacing[1]);
+    EXPECT_DOUBLE_EQ(inputSpacing[2], outputSpacing[2]);
+
+    // Check origin is preserved
+    auto inputOrigin = testImage_->GetOrigin();
+    auto outputOrigin = correctedImage->GetOrigin();
+
+    EXPECT_DOUBLE_EQ(inputOrigin[0], outputOrigin[0]);
+    EXPECT_DOUBLE_EQ(inputOrigin[1], outputOrigin[1]);
+    EXPECT_DOUBLE_EQ(inputOrigin[2], outputOrigin[2]);
+}
+
+TEST_F(N4BiasCorrectorTest, ApplyBiasFieldHasCorrectDimensions) {
+    N4BiasCorrector corrector;
+
+    N4BiasCorrector::Parameters params;
+    params.shrinkFactor = 4;
+    params.numberOfFittingLevels = 1;
+    params.maxIterationsPerLevel = {2};
+
+    auto result = corrector.apply(testImage_, params);
+    ASSERT_TRUE(result.has_value());
+
+    auto& biasField = result.value().biasField;
+
+    // Bias field should have same dimensions as input
+    auto inputSize = testImage_->GetLargestPossibleRegion().GetSize();
+    auto biasSize = biasField->GetLargestPossibleRegion().GetSize();
+
+    EXPECT_EQ(inputSize[0], biasSize[0]);
+    EXPECT_EQ(inputSize[1], biasSize[1]);
+    EXPECT_EQ(inputSize[2], biasSize[2]);
+}
+
+// =============================================================================
+// estimateProcessingTime tests
+// =============================================================================
+
+TEST_F(N4BiasCorrectorTest, EstimateProcessingTimeBasic) {
+    std::array<unsigned int, 3> imageSize = {256, 256, 100};
+    N4BiasCorrector::Parameters params;
+
+    double estimate = N4BiasCorrector::estimateProcessingTime(imageSize, params);
+
+    EXPECT_GT(estimate, 0.0);
+}
+
+TEST_F(N4BiasCorrectorTest, EstimateProcessingTimeScalesWithSize) {
+    N4BiasCorrector::Parameters params;
+
+    std::array<unsigned int, 3> smallSize = {64, 64, 64};
+    std::array<unsigned int, 3> largeSize = {256, 256, 256};
+
+    double smallEstimate = N4BiasCorrector::estimateProcessingTime(smallSize, params);
+    double largeEstimate = N4BiasCorrector::estimateProcessingTime(largeSize, params);
+
+    // Large image should take longer
+    EXPECT_GT(largeEstimate, smallEstimate);
+}
+
+TEST_F(N4BiasCorrectorTest, EstimateProcessingTimeScalesWithIterations) {
+    std::array<unsigned int, 3> imageSize = {128, 128, 128};
+
+    N4BiasCorrector::Parameters lowIter;
+    lowIter.maxIterationsPerLevel = {10, 10, 10, 10};
+
+    N4BiasCorrector::Parameters highIter;
+    highIter.maxIterationsPerLevel = {100, 100, 100, 100};
+
+    double lowEstimate = N4BiasCorrector::estimateProcessingTime(imageSize, lowIter);
+    double highEstimate = N4BiasCorrector::estimateProcessingTime(imageSize, highIter);
+
+    // More iterations should take longer
+    EXPECT_GT(highEstimate, lowEstimate);
+}
+
+TEST_F(N4BiasCorrectorTest, EstimateProcessingTimeWithShrinkFactor) {
+    std::array<unsigned int, 3> imageSize = {256, 256, 256};
+
+    N4BiasCorrector::Parameters lowShrink;
+    lowShrink.shrinkFactor = 2;
+
+    N4BiasCorrector::Parameters highShrink;
+    highShrink.shrinkFactor = 8;
+
+    double lowShrinkEstimate = N4BiasCorrector::estimateProcessingTime(
+        imageSize, lowShrink);
+    double highShrinkEstimate = N4BiasCorrector::estimateProcessingTime(
+        imageSize, highShrink);
+
+    // Higher shrink factor should be faster (lower estimate)
+    EXPECT_LT(highShrinkEstimate, lowShrinkEstimate);
+}
+
+// =============================================================================
+// Progress callback tests
+// =============================================================================
+
+TEST_F(N4BiasCorrectorTest, ProgressCallbackCanBeSet) {
+    N4BiasCorrector corrector;
+
+    bool callbackCalled = false;
+    double lastProgress = -1.0;
+
+    corrector.setProgressCallback([&](double progress) {
+        callbackCalled = true;
+        lastProgress = progress;
+    });
+
+    N4BiasCorrector::Parameters params;
+    params.shrinkFactor = 4;
+    params.numberOfFittingLevels = 1;
+    params.maxIterationsPerLevel = {5};
+
+    auto result = corrector.apply(testImage_, params);
+
+    // The callback may or may not be called depending on processing speed
+    // With very small test images, processing completes too fast for callback
+    EXPECT_TRUE(result.has_value());
+
+    // If callback was called, verify progress was valid
+    if (callbackCalled) {
+        EXPECT_GE(lastProgress, 0.0);
+        EXPECT_LE(lastProgress, 1.0);
+    }
+}
+
+// =============================================================================
+// Move semantics tests
+// =============================================================================
+
+TEST_F(N4BiasCorrectorTest, MoveConstruction) {
+    N4BiasCorrector corrector1;
+    N4BiasCorrector corrector2(std::move(corrector1));
+
+    N4BiasCorrector::Parameters params;
+    params.shrinkFactor = 4;
+    params.numberOfFittingLevels = 1;
+    params.maxIterationsPerLevel = {2};
+
+    auto result = corrector2.apply(testImage_, params);
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST_F(N4BiasCorrectorTest, MoveAssignment) {
+    N4BiasCorrector corrector1;
+    N4BiasCorrector corrector2;
+
+    corrector2 = std::move(corrector1);
+
+    N4BiasCorrector::Parameters params;
+    params.shrinkFactor = 4;
+    params.numberOfFittingLevels = 1;
+    params.maxIterationsPerLevel = {2};
+
+    auto result = corrector2.apply(testImage_, params);
+    EXPECT_TRUE(result.has_value());
+}
+
+}  // namespace
+}  // namespace dicom_viewer::services


### PR DESCRIPTION
## Summary
- Add `N4BiasCorrector` class for MRI intensity inhomogeneity correction
- Implement ITK's N4BiasFieldCorrectionImageFilter algorithm with configurable parameters
- Support automatic mask generation via Otsu thresholding or custom mask input
- Add 31 comprehensive unit tests for parameter validation and functionality

## Features
- Automatic bias field estimation with B-spline fitting
- Configurable shrink factor (1-8) for speed/quality tradeoff
- Multi-level fitting with adjustable iterations per level
- Output both corrected image and estimated bias field
- Progress callback support for UI integration

## Test plan
- [x] Parameter validation tests (shrink factor, fitting levels, iterations, convergence)
- [x] Apply tests with default and custom parameters
- [x] Apply tests with mask input
- [x] Image properties preservation tests
- [x] Bias field dimension verification
- [x] Processing time estimation tests
- [x] Move semantics tests
- [x] All 31 tests passing

Closes #34