### PR TITLE
feat(rendering): implement oblique reslicing for MPR views

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ add_library(render_service STATIC
     src/services/render/mpr_renderer.cpp
     src/services/render/mpr_coordinate_transformer.cpp
     src/services/render/transfer_function.cpp
+    src/services/render/oblique_reslice_renderer.cpp
 )
 
 target_link_libraries(render_service PUBLIC

--- a/include/services/render/oblique_reslice_renderer.hpp
+++ b/include/services/render/oblique_reslice_renderer.hpp
@@ -1,0 +1,342 @@
+#pragma once
+
+#include <array>
+#include <functional>
+#include <memory>
+#include <optional>
+
+#include <vtkSmartPointer.h>
+#include <vtkImageData.h>
+#include <vtkRenderer.h>
+#include <vtkMatrix4x4.h>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief 3D point in world coordinates
+ */
+struct Point3D {
+    double x = 0.0;
+    double y = 0.0;
+    double z = 0.0;
+
+    Point3D() = default;
+    Point3D(double x_, double y_, double z_) : x(x_), y(y_), z(z_) {}
+};
+
+/**
+ * @brief 3D vector for direction/normal
+ */
+struct Vector3D {
+    double x = 0.0;
+    double y = 0.0;
+    double z = 1.0;
+
+    Vector3D() = default;
+    Vector3D(double x_, double y_, double z_) : x(x_), y(y_), z(z_) {}
+
+    [[nodiscard]] double length() const noexcept;
+    [[nodiscard]] Vector3D normalized() const noexcept;
+};
+
+/**
+ * @brief Oblique plane definition using Euler angles or geometric primitives
+ */
+struct ObliquePlaneDefinition {
+    // Rotation angles in degrees (Euler angles around X, Y, Z axes)
+    double rotationX = 0.0;
+    double rotationY = 0.0;
+    double rotationZ = 0.0;
+
+    // Center point of the plane
+    Point3D center;
+
+    // Slice offset along the normal direction
+    double sliceOffset = 0.0;
+};
+
+/**
+ * @brief Interpolation modes for reslicing
+ */
+enum class InterpolationMode {
+    NearestNeighbor,
+    Linear,
+    Cubic
+};
+
+/**
+ * @brief Options for oblique reslicing output
+ */
+struct ObliqueResliceOptions {
+    InterpolationMode interpolation = InterpolationMode::Linear;
+    std::array<int, 2> outputDimensions = {512, 512};
+    double outputSpacing = -1.0;  // -1 = auto (based on input spacing)
+    double backgroundValue = -1000.0;  // HU for air
+};
+
+/**
+ * @brief Callback for plane orientation changes
+ */
+using PlaneChangedCallback = std::function<void(const ObliquePlaneDefinition& plane)>;
+
+/**
+ * @brief Callback for slice offset changes
+ */
+using SliceChangedCallback = std::function<void(double offset)>;
+
+/**
+ * @brief Oblique reslicing renderer for arbitrary angle MPR views
+ *
+ * Enables visualization of anatomical structures that don't align with
+ * standard axial/coronal/sagittal planes. Essential for:
+ * - Visualizing vessels at their true cross-section
+ * - Aligning views with anatomical landmarks
+ * - Cardiac imaging (short-axis, long-axis views)
+ * - Spine imaging (parallel to disc spaces)
+ *
+ * @trace SRS-FR-010
+ */
+class ObliqueResliceRenderer {
+public:
+    using ImageType = vtkSmartPointer<vtkImageData>;
+
+    ObliqueResliceRenderer();
+    ~ObliqueResliceRenderer();
+
+    // Non-copyable, movable
+    ObliqueResliceRenderer(const ObliqueResliceRenderer&) = delete;
+    ObliqueResliceRenderer& operator=(const ObliqueResliceRenderer&) = delete;
+    ObliqueResliceRenderer(ObliqueResliceRenderer&&) noexcept;
+    ObliqueResliceRenderer& operator=(ObliqueResliceRenderer&&) noexcept;
+
+    // ==================== Input Configuration ====================
+
+    /**
+     * @brief Set the input volume data
+     * @param imageData VTK image data (3D volume)
+     */
+    void setInputData(ImageType imageData);
+
+    /**
+     * @brief Get current input data
+     * @return VTK image data or nullptr
+     */
+    [[nodiscard]] ImageType getInputData() const;
+
+    // ==================== Plane Definition Methods ====================
+
+    /**
+     * @brief Set plane orientation by Euler rotation angles
+     * @param rotX Rotation around X axis in degrees
+     * @param rotY Rotation around Y axis in degrees
+     * @param rotZ Rotation around Z axis in degrees
+     */
+    void setPlaneByRotation(double rotX, double rotY, double rotZ);
+
+    /**
+     * @brief Set plane by three points in space
+     *
+     * Defines a plane that passes through all three points.
+     * The normal is computed as (p2-p1) x (p3-p1).
+     *
+     * @param p1 First point
+     * @param p2 Second point
+     * @param p3 Third point
+     */
+    void setPlaneByThreePoints(const Point3D& p1, const Point3D& p2, const Point3D& p3);
+
+    /**
+     * @brief Set plane by normal vector and center point
+     * @param normal Normal vector of the plane
+     * @param center Center point of the plane
+     */
+    void setPlaneByNormal(const Vector3D& normal, const Point3D& center);
+
+    /**
+     * @brief Set center point of the plane
+     * @param center Center point in world coordinates
+     */
+    void setCenter(const Point3D& center);
+
+    /**
+     * @brief Get current center point
+     * @return Center point
+     */
+    [[nodiscard]] Point3D getCenter() const;
+
+    // ==================== Slice Navigation ====================
+
+    /**
+     * @brief Set slice offset along the normal direction
+     * @param offset Offset in mm from the center plane
+     */
+    void setSliceOffset(double offset);
+
+    /**
+     * @brief Get current slice offset
+     * @return Offset in mm
+     */
+    [[nodiscard]] double getSliceOffset() const;
+
+    /**
+     * @brief Get valid range of slice offsets
+     * @return [min, max] offset range in mm
+     */
+    [[nodiscard]] std::pair<double, double> getSliceRange() const;
+
+    /**
+     * @brief Scroll by a number of slices
+     * @param delta Number of slices to scroll (positive = forward along normal)
+     */
+    void scrollSlice(int delta);
+
+    // ==================== Plane Query ====================
+
+    /**
+     * @brief Get current plane definition
+     * @return Current oblique plane parameters
+     */
+    [[nodiscard]] ObliquePlaneDefinition getCurrentPlane() const;
+
+    /**
+     * @brief Get the current reslice transformation matrix
+     * @return 4x4 transformation matrix
+     */
+    [[nodiscard]] vtkSmartPointer<vtkMatrix4x4> getResliceMatrix() const;
+
+    /**
+     * @brief Get the plane normal vector
+     * @return Normal vector in world coordinates
+     */
+    [[nodiscard]] Vector3D getPlaneNormal() const;
+
+    // ==================== Interactive Manipulation ====================
+
+    /**
+     * @brief Start interactive rotation from a mouse position
+     * @param x Screen X coordinate
+     * @param y Screen Y coordinate
+     */
+    void startInteractiveRotation(int x, int y);
+
+    /**
+     * @brief Update interactive rotation with current mouse position
+     * @param x Screen X coordinate
+     * @param y Screen Y coordinate
+     */
+    void updateInteractiveRotation(int x, int y);
+
+    /**
+     * @brief End interactive rotation
+     */
+    void endInteractiveRotation();
+
+    /**
+     * @brief Check if currently in interactive rotation mode
+     * @return true if rotating
+     */
+    [[nodiscard]] bool isInteractiveRotationActive() const;
+
+    // ==================== Preset Planes ====================
+
+    /**
+     * @brief Reset to standard axial plane (XY, looking down Z)
+     */
+    void setAxial();
+
+    /**
+     * @brief Reset to standard coronal plane (XZ, looking down Y)
+     */
+    void setCoronal();
+
+    /**
+     * @brief Reset to standard sagittal plane (YZ, looking down X)
+     */
+    void setSagittal();
+
+    // ==================== Rendering ====================
+
+    /**
+     * @brief Set the VTK renderer for display
+     * @param renderer VTK renderer
+     */
+    void setRenderer(vtkRenderer* renderer);
+
+    /**
+     * @brief Get current VTK renderer
+     * @return VTK renderer or nullptr
+     */
+    [[nodiscard]] vtkRenderer* getRenderer() const;
+
+    /**
+     * @brief Set reslice options
+     * @param options Reslice configuration
+     */
+    void setOptions(const ObliqueResliceOptions& options);
+
+    /**
+     * @brief Get current reslice options
+     * @return Current options
+     */
+    [[nodiscard]] ObliqueResliceOptions getOptions() const;
+
+    /**
+     * @brief Set window/level for display
+     * @param width Window width
+     * @param center Window center (level)
+     */
+    void setWindowLevel(double width, double center);
+
+    /**
+     * @brief Get current window/level
+     * @return {width, center}
+     */
+    [[nodiscard]] std::pair<double, double> getWindowLevel() const;
+
+    /**
+     * @brief Update the rendering pipeline
+     */
+    void update();
+
+    /**
+     * @brief Reset view to center of volume with standard orientation
+     */
+    void resetView();
+
+    // ==================== Coordinate Transforms ====================
+
+    /**
+     * @brief Convert screen coordinates to world coordinates on the plane
+     * @param screenX Screen X coordinate
+     * @param screenY Screen Y coordinate
+     * @return World coordinates, or nullopt if invalid
+     */
+    [[nodiscard]] std::optional<Point3D> screenToWorld(int screenX, int screenY) const;
+
+    /**
+     * @brief Convert world coordinates to screen coordinates
+     * @param world World point
+     * @return Screen coordinates {x, y}, or nullopt if not visible
+     */
+    [[nodiscard]] std::optional<std::array<int, 2>> worldToScreen(const Point3D& world) const;
+
+    // ==================== Callbacks ====================
+
+    /**
+     * @brief Register callback for plane orientation changes
+     * @param callback Function to call when plane changes
+     */
+    void setPlaneChangedCallback(PlaneChangedCallback callback);
+
+    /**
+     * @brief Register callback for slice offset changes
+     * @param callback Function to call when slice changes
+     */
+    void setSliceChangedCallback(SliceChangedCallback callback);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::services

--- a/src/services/render/oblique_reslice_renderer.cpp
+++ b/src/services/render/oblique_reslice_renderer.cpp
@@ -1,0 +1,612 @@
+#include "services/render/oblique_reslice_renderer.hpp"
+
+#include <vtkImageReslice.h>
+#include <vtkImageActor.h>
+#include <vtkImageMapper3D.h>
+#include <vtkImageMapToColors.h>
+#include <vtkLookupTable.h>
+#include <vtkRenderer.h>
+#include <vtkCamera.h>
+#include <vtkMatrix4x4.h>
+#include <vtkTransform.h>
+#include <vtkNew.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace dicom_viewer::services {
+
+// ==================== Vector3D Implementation ====================
+
+double Vector3D::length() const noexcept {
+    return std::sqrt(x * x + y * y + z * z);
+}
+
+Vector3D Vector3D::normalized() const noexcept {
+    double len = length();
+    if (len < 1e-10) {
+        return Vector3D{0.0, 0.0, 1.0};
+    }
+    return Vector3D{x / len, y / len, z / len};
+}
+
+// ==================== Implementation Class ====================
+
+class ObliqueResliceRenderer::Impl {
+public:
+    // Input data
+    ImageType inputData;
+
+    // Current plane definition
+    ObliquePlaneDefinition planeDef;
+
+    // VTK pipeline components
+    vtkSmartPointer<vtkImageReslice> reslice;
+    vtkSmartPointer<vtkImageMapToColors> colorMapper;
+    vtkSmartPointer<vtkLookupTable> lookupTable;
+    vtkSmartPointer<vtkImageActor> imageActor;
+    vtkRenderer* renderer = nullptr;
+
+    // Options
+    ObliqueResliceOptions options;
+
+    // Window/Level
+    double windowWidth = 400.0;
+    double windowCenter = 40.0;
+
+    // Volume bounds
+    std::array<double, 6> bounds = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    std::array<double, 3> spacing = {1.0, 1.0, 1.0};
+
+    // Interactive rotation state
+    bool interactiveRotationActive = false;
+    int startX = 0;
+    int startY = 0;
+    double startRotX = 0.0;
+    double startRotY = 0.0;
+    double startRotZ = 0.0;
+
+    // Callbacks
+    PlaneChangedCallback planeChangedCallback;
+    SliceChangedCallback sliceChangedCallback;
+
+    Impl() {
+        // Initialize VTK pipeline
+        reslice = vtkSmartPointer<vtkImageReslice>::New();
+        reslice->SetOutputDimensionality(2);
+        reslice->SetInterpolationModeToLinear();
+        reslice->SetBackgroundLevel(-1000.0);
+
+        lookupTable = vtkSmartPointer<vtkLookupTable>::New();
+        lookupTable->SetTableRange(0, 1);
+        lookupTable->SetSaturationRange(0, 0);
+        lookupTable->SetHueRange(0, 0);
+        lookupTable->SetValueRange(0, 1);
+        lookupTable->Build();
+
+        colorMapper = vtkSmartPointer<vtkImageMapToColors>::New();
+        colorMapper->SetLookupTable(lookupTable);
+        colorMapper->SetInputConnection(reslice->GetOutputPort());
+
+        imageActor = vtkSmartPointer<vtkImageActor>::New();
+        imageActor->GetMapper()->SetInputConnection(colorMapper->GetOutputPort());
+    }
+
+    void updateResliceMatrix() {
+        if (!inputData) {
+            return;
+        }
+
+        auto matrix = vtkSmartPointer<vtkMatrix4x4>::New();
+        matrix->Identity();
+
+        // Get center point (use volume center if not set)
+        double cx = planeDef.center.x;
+        double cy = planeDef.center.y;
+        double cz = planeDef.center.z;
+
+        if (cx == 0.0 && cy == 0.0 && cz == 0.0) {
+            double* center = inputData->GetCenter();
+            cx = center[0];
+            cy = center[1];
+            cz = center[2];
+        }
+
+        // Build transformation: translate to center, rotate, translate back
+        auto transform = vtkSmartPointer<vtkTransform>::New();
+        transform->Identity();
+
+        // Apply rotations in XYZ order
+        transform->RotateX(planeDef.rotationX);
+        transform->RotateY(planeDef.rotationY);
+        transform->RotateZ(planeDef.rotationZ);
+
+        // Get rotation matrix
+        vtkMatrix4x4* rotMatrix = transform->GetMatrix();
+
+        // Compute normal for slice offset
+        double normal[3] = {
+            rotMatrix->GetElement(0, 2),
+            rotMatrix->GetElement(1, 2),
+            rotMatrix->GetElement(2, 2)
+        };
+
+        // Apply slice offset along normal
+        double offsetX = cx + planeDef.sliceOffset * normal[0];
+        double offsetY = cy + planeDef.sliceOffset * normal[1];
+        double offsetZ = cz + planeDef.sliceOffset * normal[2];
+
+        // Set up reslice matrix
+        // Row 0: X axis of the output image
+        matrix->SetElement(0, 0, rotMatrix->GetElement(0, 0));
+        matrix->SetElement(0, 1, rotMatrix->GetElement(0, 1));
+        matrix->SetElement(0, 2, rotMatrix->GetElement(0, 2));
+
+        // Row 1: Y axis of the output image
+        matrix->SetElement(1, 0, rotMatrix->GetElement(1, 0));
+        matrix->SetElement(1, 1, rotMatrix->GetElement(1, 1));
+        matrix->SetElement(1, 2, rotMatrix->GetElement(1, 2));
+
+        // Row 2: Normal (Z axis / slice direction)
+        matrix->SetElement(2, 0, rotMatrix->GetElement(2, 0));
+        matrix->SetElement(2, 1, rotMatrix->GetElement(2, 1));
+        matrix->SetElement(2, 2, rotMatrix->GetElement(2, 2));
+
+        // Translation (slice position)
+        matrix->SetElement(0, 3, offsetX);
+        matrix->SetElement(1, 3, offsetY);
+        matrix->SetElement(2, 3, offsetZ);
+
+        reslice->SetResliceAxes(matrix);
+        reslice->Modified();
+    }
+
+    void updateWindowLevel() {
+        double lower = windowCenter - windowWidth / 2.0;
+        double upper = windowCenter + windowWidth / 2.0;
+
+        lookupTable->SetTableRange(lower, upper);
+        lookupTable->Build();
+        colorMapper->Modified();
+    }
+
+    void updateInterpolation() {
+        switch (options.interpolation) {
+            case InterpolationMode::NearestNeighbor:
+                reslice->SetInterpolationModeToNearestNeighbor();
+                break;
+            case InterpolationMode::Linear:
+                reslice->SetInterpolationModeToLinear();
+                break;
+            case InterpolationMode::Cubic:
+                reslice->SetInterpolationModeToCubic();
+                break;
+        }
+        reslice->SetBackgroundLevel(options.backgroundValue);
+    }
+
+    void setupCamera() {
+        if (!renderer || !inputData) {
+            return;
+        }
+
+        auto camera = renderer->GetActiveCamera();
+        camera->ParallelProjectionOn();
+
+        double* center = inputData->GetCenter();
+        double maxDim = std::max({
+            bounds[1] - bounds[0],
+            bounds[3] - bounds[2],
+            bounds[5] - bounds[4]
+        });
+
+        // Position camera based on current rotation
+        auto transform = vtkSmartPointer<vtkTransform>::New();
+        transform->RotateX(planeDef.rotationX);
+        transform->RotateY(planeDef.rotationY);
+        transform->RotateZ(planeDef.rotationZ);
+
+        double viewDir[3] = {0, 0, 1};
+        double upDir[3] = {0, 1, 0};
+        transform->TransformVector(viewDir, viewDir);
+        transform->TransformVector(upDir, upDir);
+
+        double distance = maxDim * 2.0;
+        camera->SetPosition(
+            center[0] - viewDir[0] * distance,
+            center[1] - viewDir[1] * distance,
+            center[2] - viewDir[2] * distance
+        );
+        camera->SetFocalPoint(center[0], center[1], center[2]);
+        camera->SetViewUp(upDir[0], upDir[1], upDir[2]);
+        camera->SetParallelScale(maxDim / 2.0 * 1.1);
+
+        renderer->ResetCameraClippingRange();
+    }
+
+    double computeSliceRange() const {
+        if (!inputData) {
+            return 0.0;
+        }
+
+        // Compute diagonal of the bounding box
+        double dx = bounds[1] - bounds[0];
+        double dy = bounds[3] - bounds[2];
+        double dz = bounds[5] - bounds[4];
+        return std::sqrt(dx * dx + dy * dy + dz * dz) / 2.0;
+    }
+
+    void notifyPlaneChanged() {
+        if (planeChangedCallback) {
+            planeChangedCallback(planeDef);
+        }
+    }
+
+    void notifySliceChanged() {
+        if (sliceChangedCallback) {
+            sliceChangedCallback(planeDef.sliceOffset);
+        }
+    }
+};
+
+// ==================== ObliqueResliceRenderer Implementation ====================
+
+ObliqueResliceRenderer::ObliqueResliceRenderer()
+    : impl_(std::make_unique<Impl>()) {}
+
+ObliqueResliceRenderer::~ObliqueResliceRenderer() = default;
+
+ObliqueResliceRenderer::ObliqueResliceRenderer(ObliqueResliceRenderer&&) noexcept = default;
+ObliqueResliceRenderer& ObliqueResliceRenderer::operator=(ObliqueResliceRenderer&&) noexcept = default;
+
+void ObliqueResliceRenderer::setInputData(ImageType imageData) {
+    impl_->inputData = imageData;
+
+    if (imageData) {
+        imageData->GetBounds(impl_->bounds.data());
+        imageData->GetSpacing(impl_->spacing.data());
+        impl_->reslice->SetInputData(imageData);
+
+        // Set default center to volume center
+        double* center = imageData->GetCenter();
+        impl_->planeDef.center = Point3D{center[0], center[1], center[2]};
+
+        impl_->updateResliceMatrix();
+        impl_->updateWindowLevel();
+    }
+}
+
+ObliqueResliceRenderer::ImageType ObliqueResliceRenderer::getInputData() const {
+    return impl_->inputData;
+}
+
+void ObliqueResliceRenderer::setPlaneByRotation(double rotX, double rotY, double rotZ) {
+    impl_->planeDef.rotationX = rotX;
+    impl_->planeDef.rotationY = rotY;
+    impl_->planeDef.rotationZ = rotZ;
+
+    impl_->updateResliceMatrix();
+    impl_->setupCamera();
+    impl_->notifyPlaneChanged();
+}
+
+void ObliqueResliceRenderer::setPlaneByThreePoints(
+    const Point3D& p1, const Point3D& p2, const Point3D& p3) {
+
+    // Compute vectors from p1 to p2 and p1 to p3
+    double v1[3] = {p2.x - p1.x, p2.y - p1.y, p2.z - p1.z};
+    double v2[3] = {p3.x - p1.x, p3.y - p1.y, p3.z - p1.z};
+
+    // Compute normal as cross product v1 x v2
+    Vector3D normal{
+        v1[1] * v2[2] - v1[2] * v2[1],
+        v1[2] * v2[0] - v1[0] * v2[2],
+        v1[0] * v2[1] - v1[1] * v2[0]
+    };
+    normal = normal.normalized();
+
+    // Compute center as centroid
+    Point3D center{
+        (p1.x + p2.x + p3.x) / 3.0,
+        (p1.y + p2.y + p3.y) / 3.0,
+        (p1.z + p2.z + p3.z) / 3.0
+    };
+
+    setPlaneByNormal(normal, center);
+}
+
+void ObliqueResliceRenderer::setPlaneByNormal(const Vector3D& normal, const Point3D& center) {
+    Vector3D n = normal.normalized();
+    impl_->planeDef.center = center;
+
+    // Convert normal to Euler angles
+    // Assuming normal is the Z-axis of the rotated coordinate system
+
+    // rotationY = atan2(nx, nz)
+    double rotY = std::atan2(n.x, n.z) * 180.0 / M_PI;
+
+    // rotationX = -asin(ny)
+    double rotX = -std::asin(std::clamp(n.y, -1.0, 1.0)) * 180.0 / M_PI;
+
+    // rotationZ typically stays at 0 unless in-plane rotation is needed
+    double rotZ = 0.0;
+
+    impl_->planeDef.rotationX = rotX;
+    impl_->planeDef.rotationY = rotY;
+    impl_->planeDef.rotationZ = rotZ;
+
+    impl_->updateResliceMatrix();
+    impl_->setupCamera();
+    impl_->notifyPlaneChanged();
+}
+
+void ObliqueResliceRenderer::setCenter(const Point3D& center) {
+    impl_->planeDef.center = center;
+    impl_->updateResliceMatrix();
+    impl_->notifyPlaneChanged();
+}
+
+Point3D ObliqueResliceRenderer::getCenter() const {
+    return impl_->planeDef.center;
+}
+
+void ObliqueResliceRenderer::setSliceOffset(double offset) {
+    double maxRange = impl_->computeSliceRange();
+    offset = std::clamp(offset, -maxRange, maxRange);
+
+    impl_->planeDef.sliceOffset = offset;
+    impl_->updateResliceMatrix();
+    impl_->notifySliceChanged();
+}
+
+double ObliqueResliceRenderer::getSliceOffset() const {
+    return impl_->planeDef.sliceOffset;
+}
+
+std::pair<double, double> ObliqueResliceRenderer::getSliceRange() const {
+    double maxRange = impl_->computeSliceRange();
+    return {-maxRange, maxRange};
+}
+
+void ObliqueResliceRenderer::scrollSlice(int delta) {
+    // Use average spacing as scroll increment
+    double avgSpacing = (impl_->spacing[0] + impl_->spacing[1] + impl_->spacing[2]) / 3.0;
+    double newOffset = impl_->planeDef.sliceOffset + delta * avgSpacing;
+    setSliceOffset(newOffset);
+}
+
+ObliquePlaneDefinition ObliqueResliceRenderer::getCurrentPlane() const {
+    return impl_->planeDef;
+}
+
+vtkSmartPointer<vtkMatrix4x4> ObliqueResliceRenderer::getResliceMatrix() const {
+    return impl_->reslice->GetResliceAxes();
+}
+
+Vector3D ObliqueResliceRenderer::getPlaneNormal() const {
+    auto transform = vtkSmartPointer<vtkTransform>::New();
+    transform->RotateX(impl_->planeDef.rotationX);
+    transform->RotateY(impl_->planeDef.rotationY);
+    transform->RotateZ(impl_->planeDef.rotationZ);
+
+    double normal[3] = {0, 0, 1};
+    transform->TransformVector(normal, normal);
+
+    return Vector3D{normal[0], normal[1], normal[2]};
+}
+
+void ObliqueResliceRenderer::startInteractiveRotation(int x, int y) {
+    impl_->interactiveRotationActive = true;
+    impl_->startX = x;
+    impl_->startY = y;
+    impl_->startRotX = impl_->planeDef.rotationX;
+    impl_->startRotY = impl_->planeDef.rotationY;
+    impl_->startRotZ = impl_->planeDef.rotationZ;
+}
+
+void ObliqueResliceRenderer::updateInteractiveRotation(int x, int y) {
+    if (!impl_->interactiveRotationActive) {
+        return;
+    }
+
+    // Compute delta from start position
+    int deltaX = x - impl_->startX;
+    int deltaY = y - impl_->startY;
+
+    // Convert pixel movement to rotation (0.5 degrees per pixel)
+    double rotationSensitivity = 0.5;
+    double newRotY = impl_->startRotY + deltaX * rotationSensitivity;
+    double newRotX = impl_->startRotX + deltaY * rotationSensitivity;
+
+    // Clamp X rotation to avoid gimbal lock issues
+    newRotX = std::clamp(newRotX, -89.0, 89.0);
+
+    impl_->planeDef.rotationX = newRotX;
+    impl_->planeDef.rotationY = newRotY;
+
+    impl_->updateResliceMatrix();
+    impl_->setupCamera();
+    impl_->notifyPlaneChanged();
+}
+
+void ObliqueResliceRenderer::endInteractiveRotation() {
+    impl_->interactiveRotationActive = false;
+}
+
+bool ObliqueResliceRenderer::isInteractiveRotationActive() const {
+    return impl_->interactiveRotationActive;
+}
+
+void ObliqueResliceRenderer::setAxial() {
+    impl_->planeDef.rotationX = 0.0;
+    impl_->planeDef.rotationY = 0.0;
+    impl_->planeDef.rotationZ = 0.0;
+    impl_->planeDef.sliceOffset = 0.0;
+
+    impl_->updateResliceMatrix();
+    impl_->setupCamera();
+    impl_->notifyPlaneChanged();
+}
+
+void ObliqueResliceRenderer::setCoronal() {
+    impl_->planeDef.rotationX = -90.0;
+    impl_->planeDef.rotationY = 0.0;
+    impl_->planeDef.rotationZ = 0.0;
+    impl_->planeDef.sliceOffset = 0.0;
+
+    impl_->updateResliceMatrix();
+    impl_->setupCamera();
+    impl_->notifyPlaneChanged();
+}
+
+void ObliqueResliceRenderer::setSagittal() {
+    impl_->planeDef.rotationX = 0.0;
+    impl_->planeDef.rotationY = 90.0;
+    impl_->planeDef.rotationZ = 0.0;
+    impl_->planeDef.sliceOffset = 0.0;
+
+    impl_->updateResliceMatrix();
+    impl_->setupCamera();
+    impl_->notifyPlaneChanged();
+}
+
+void ObliqueResliceRenderer::setRenderer(vtkRenderer* renderer) {
+    // Remove actor from old renderer
+    if (impl_->renderer && impl_->imageActor) {
+        impl_->renderer->RemoveActor(impl_->imageActor);
+    }
+
+    impl_->renderer = renderer;
+
+    // Add actor to new renderer
+    if (renderer && impl_->imageActor) {
+        renderer->AddActor(impl_->imageActor);
+        impl_->setupCamera();
+    }
+}
+
+vtkRenderer* ObliqueResliceRenderer::getRenderer() const {
+    return impl_->renderer;
+}
+
+void ObliqueResliceRenderer::setOptions(const ObliqueResliceOptions& options) {
+    impl_->options = options;
+    impl_->updateInterpolation();
+
+    if (options.outputSpacing > 0) {
+        impl_->reslice->SetOutputSpacing(
+            options.outputSpacing, options.outputSpacing, 1.0);
+    }
+}
+
+ObliqueResliceOptions ObliqueResliceRenderer::getOptions() const {
+    return impl_->options;
+}
+
+void ObliqueResliceRenderer::setWindowLevel(double width, double center) {
+    impl_->windowWidth = width;
+    impl_->windowCenter = center;
+    impl_->updateWindowLevel();
+}
+
+std::pair<double, double> ObliqueResliceRenderer::getWindowLevel() const {
+    return {impl_->windowWidth, impl_->windowCenter};
+}
+
+void ObliqueResliceRenderer::update() {
+    if (impl_->reslice) {
+        impl_->reslice->Update();
+    }
+    if (impl_->colorMapper) {
+        impl_->colorMapper->Update();
+    }
+    if (impl_->renderer) {
+        impl_->renderer->Modified();
+    }
+}
+
+void ObliqueResliceRenderer::resetView() {
+    if (!impl_->inputData) {
+        return;
+    }
+
+    double* center = impl_->inputData->GetCenter();
+    impl_->planeDef.center = Point3D{center[0], center[1], center[2]};
+    impl_->planeDef.rotationX = 0.0;
+    impl_->planeDef.rotationY = 0.0;
+    impl_->planeDef.rotationZ = 0.0;
+    impl_->planeDef.sliceOffset = 0.0;
+
+    impl_->updateResliceMatrix();
+    impl_->updateWindowLevel();
+    impl_->setupCamera();
+    impl_->notifyPlaneChanged();
+}
+
+std::optional<Point3D> ObliqueResliceRenderer::screenToWorld(int screenX, int screenY) const {
+    if (!impl_->renderer || !impl_->inputData) {
+        return std::nullopt;
+    }
+
+    // Get the reslice matrix and use it to transform screen coords
+    auto matrix = impl_->reslice->GetResliceAxes();
+    if (!matrix) {
+        return std::nullopt;
+    }
+
+    // Get renderer dimensions
+    int* size = impl_->renderer->GetSize();
+    if (size[0] <= 0 || size[1] <= 0) {
+        return std::nullopt;
+    }
+
+    // Convert screen to normalized coordinates
+    double normX = (2.0 * screenX / size[0]) - 1.0;
+    double normY = (2.0 * screenY / size[1]) - 1.0;
+
+    // Get camera parallel scale for coordinate mapping
+    auto camera = impl_->renderer->GetActiveCamera();
+    double scale = camera->GetParallelScale();
+
+    // Map to world coordinates on the plane
+    double planeX = normX * scale;
+    double planeY = normY * scale;
+
+    // Transform using reslice matrix
+    double point[4] = {planeX, planeY, 0.0, 1.0};
+    double result[4];
+    matrix->MultiplyPoint(point, result);
+
+    return Point3D{result[0], result[1], result[2]};
+}
+
+std::optional<std::array<int, 2>> ObliqueResliceRenderer::worldToScreen(
+    const Point3D& world) const {
+
+    if (!impl_->renderer) {
+        return std::nullopt;
+    }
+
+    // Use VTK's world to display coordinate conversion
+    double worldCoords[4] = {world.x, world.y, world.z, 1.0};
+    double displayCoords[3];
+
+    impl_->renderer->SetWorldPoint(worldCoords);
+    impl_->renderer->WorldToDisplay();
+    impl_->renderer->GetDisplayPoint(displayCoords);
+
+    return std::array<int, 2>{
+        static_cast<int>(displayCoords[0]),
+        static_cast<int>(displayCoords[1])
+    };
+}
+
+void ObliqueResliceRenderer::setPlaneChangedCallback(PlaneChangedCallback callback) {
+    impl_->planeChangedCallback = std::move(callback);
+}
+
+void ObliqueResliceRenderer::setSliceChangedCallback(SliceChangedCallback callback) {
+    impl_->sliceChangedCallback = std::move(callback);
+}
+
+} // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -559,3 +559,29 @@ target_include_directories(measurement_serializer_test PRIVATE
 )
 
 gtest_discover_tests(measurement_serializer_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for Oblique Reslice Renderer
+add_executable(oblique_reslice_renderer_test
+    unit/oblique_reslice_renderer_test.cpp
+)
+
+target_link_directories(oblique_reslice_renderer_test PRIVATE
+    /opt/homebrew/lib
+)
+
+target_link_libraries(oblique_reslice_renderer_test PRIVATE
+    render_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(oblique_reslice_renderer_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+vtk_module_autoinit(
+    TARGETS oblique_reslice_renderer_test
+    MODULES ${VTK_LIBRARIES}
+)
+
+gtest_discover_tests(oblique_reslice_renderer_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/oblique_reslice_renderer_test.cpp
+++ b/tests/unit/oblique_reslice_renderer_test.cpp
@@ -1,0 +1,537 @@
+#include <gtest/gtest.h>
+
+#include "services/render/oblique_reslice_renderer.hpp"
+
+#include <vtkImageData.h>
+#include <vtkSmartPointer.h>
+
+#include <cmath>
+
+using namespace dicom_viewer::services;
+
+class ObliqueResliceRendererTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        renderer = std::make_unique<ObliqueResliceRenderer>();
+    }
+
+    void TearDown() override {
+        renderer.reset();
+    }
+
+    vtkSmartPointer<vtkImageData> createTestVolume(int dims = 64) {
+        auto imageData = vtkSmartPointer<vtkImageData>::New();
+        imageData->SetDimensions(dims, dims, dims);
+        imageData->SetSpacing(1.0, 1.0, 1.0);
+        imageData->SetOrigin(0.0, 0.0, 0.0);
+        imageData->AllocateScalars(VTK_SHORT, 1);
+
+        // Fill with gradient test data
+        short* ptr = static_cast<short*>(imageData->GetScalarPointer());
+        for (int z = 0; z < dims; ++z) {
+            for (int y = 0; y < dims; ++y) {
+                for (int x = 0; x < dims; ++x) {
+                    int idx = z * dims * dims + y * dims + x;
+                    ptr[idx] = static_cast<short>((x + y + z) % 1000);
+                }
+            }
+        }
+
+        return imageData;
+    }
+
+    std::unique_ptr<ObliqueResliceRenderer> renderer;
+};
+
+// ==================== Construction Tests ====================
+
+TEST_F(ObliqueResliceRendererTest, DefaultConstruction) {
+    EXPECT_NE(renderer, nullptr);
+}
+
+TEST_F(ObliqueResliceRendererTest, MoveConstructor) {
+    ObliqueResliceRenderer moved(std::move(*renderer));
+    EXPECT_EQ(moved.getInputData(), nullptr);
+}
+
+TEST_F(ObliqueResliceRendererTest, MoveAssignment) {
+    ObliqueResliceRenderer other;
+    other = std::move(*renderer);
+    EXPECT_EQ(other.getInputData(), nullptr);
+}
+
+// ==================== Input Data Tests ====================
+
+TEST_F(ObliqueResliceRendererTest, SetInputDataAcceptsValidVolume) {
+    auto volume = createTestVolume();
+    EXPECT_NO_THROW(renderer->setInputData(volume));
+    EXPECT_EQ(renderer->getInputData(), volume);
+}
+
+TEST_F(ObliqueResliceRendererTest, SetInputDataAcceptsNullptr) {
+    EXPECT_NO_THROW(renderer->setInputData(nullptr));
+    EXPECT_EQ(renderer->getInputData(), nullptr);
+}
+
+// ==================== Plane Definition by Rotation Tests ====================
+
+TEST_F(ObliqueResliceRendererTest, SetPlaneByRotationZeroAngles) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    EXPECT_NO_THROW(renderer->setPlaneByRotation(0.0, 0.0, 0.0));
+
+    auto plane = renderer->getCurrentPlane();
+    EXPECT_DOUBLE_EQ(plane.rotationX, 0.0);
+    EXPECT_DOUBLE_EQ(plane.rotationY, 0.0);
+    EXPECT_DOUBLE_EQ(plane.rotationZ, 0.0);
+}
+
+TEST_F(ObliqueResliceRendererTest, SetPlaneByRotation45Degrees) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    renderer->setPlaneByRotation(45.0, 0.0, 0.0);
+
+    auto plane = renderer->getCurrentPlane();
+    EXPECT_DOUBLE_EQ(plane.rotationX, 45.0);
+    EXPECT_DOUBLE_EQ(plane.rotationY, 0.0);
+    EXPECT_DOUBLE_EQ(plane.rotationZ, 0.0);
+}
+
+TEST_F(ObliqueResliceRendererTest, SetPlaneByRotationCombined) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    renderer->setPlaneByRotation(15.0, -8.5, 0.0);
+
+    auto plane = renderer->getCurrentPlane();
+    EXPECT_DOUBLE_EQ(plane.rotationX, 15.0);
+    EXPECT_DOUBLE_EQ(plane.rotationY, -8.5);
+    EXPECT_DOUBLE_EQ(plane.rotationZ, 0.0);
+}
+
+// ==================== Plane Definition by Three Points Tests ====================
+
+TEST_F(ObliqueResliceRendererTest, SetPlaneByThreePointsXYPlane) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    // Three points defining XY plane (Z=0)
+    Point3D p1{0.0, 0.0, 0.0};
+    Point3D p2{1.0, 0.0, 0.0};
+    Point3D p3{0.0, 1.0, 0.0};
+
+    EXPECT_NO_THROW(renderer->setPlaneByThreePoints(p1, p2, p3));
+
+    // Normal should be approximately (0, 0, 1)
+    auto normal = renderer->getPlaneNormal();
+    EXPECT_NEAR(normal.z, 1.0, 0.01);
+    EXPECT_NEAR(std::abs(normal.x), 0.0, 0.01);
+    EXPECT_NEAR(std::abs(normal.y), 0.0, 0.01);
+}
+
+TEST_F(ObliqueResliceRendererTest, SetPlaneByThreePointsXZPlane) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    // Three points defining XZ plane (Y=0)
+    Point3D p1{0.0, 0.0, 0.0};
+    Point3D p2{1.0, 0.0, 0.0};
+    Point3D p3{0.0, 0.0, 1.0};
+
+    EXPECT_NO_THROW(renderer->setPlaneByThreePoints(p1, p2, p3));
+
+    // Normal should be approximately (0, -1, 0)
+    auto normal = renderer->getPlaneNormal();
+    EXPECT_NEAR(std::abs(normal.y), 1.0, 0.01);
+}
+
+// ==================== Plane Definition by Normal Tests ====================
+
+TEST_F(ObliqueResliceRendererTest, SetPlaneByNormalZAxis) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    Vector3D normal{0.0, 0.0, 1.0};
+    Point3D center{32.0, 32.0, 32.0};
+
+    EXPECT_NO_THROW(renderer->setPlaneByNormal(normal, center));
+
+    auto resultNormal = renderer->getPlaneNormal();
+    EXPECT_NEAR(resultNormal.z, 1.0, 0.01);
+}
+
+TEST_F(ObliqueResliceRendererTest, SetPlaneByNormalDiagonal) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    // Normalized diagonal vector
+    double inv_sqrt3 = 1.0 / std::sqrt(3.0);
+    Vector3D normal{inv_sqrt3, inv_sqrt3, inv_sqrt3};
+    Point3D center{32.0, 32.0, 32.0};
+
+    EXPECT_NO_THROW(renderer->setPlaneByNormal(normal, center));
+
+    auto resultNormal = renderer->getPlaneNormal();
+    double length = resultNormal.length();
+    EXPECT_NEAR(length, 1.0, 0.01);
+}
+
+// ==================== Center Point Tests ====================
+
+TEST_F(ObliqueResliceRendererTest, SetAndGetCenter) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    Point3D center{10.0, 20.0, 30.0};
+    renderer->setCenter(center);
+
+    auto result = renderer->getCenter();
+    EXPECT_DOUBLE_EQ(result.x, 10.0);
+    EXPECT_DOUBLE_EQ(result.y, 20.0);
+    EXPECT_DOUBLE_EQ(result.z, 30.0);
+}
+
+// ==================== Slice Navigation Tests ====================
+
+TEST_F(ObliqueResliceRendererTest, GetSliceRangeWithoutData) {
+    auto [min, max] = renderer->getSliceRange();
+    EXPECT_DOUBLE_EQ(min, 0.0);
+    EXPECT_DOUBLE_EQ(max, 0.0);
+}
+
+TEST_F(ObliqueResliceRendererTest, GetSliceRangeWithData) {
+    auto volume = createTestVolume(64);
+    renderer->setInputData(volume);
+
+    auto [min, max] = renderer->getSliceRange();
+    // Range should be approximately half the diagonal
+    EXPECT_LT(min, 0.0);
+    EXPECT_GT(max, 0.0);
+    EXPECT_DOUBLE_EQ(min, -max);  // Symmetric range
+}
+
+TEST_F(ObliqueResliceRendererTest, SetSliceOffsetValid) {
+    auto volume = createTestVolume(64);
+    renderer->setInputData(volume);
+
+    renderer->setSliceOffset(10.0);
+    EXPECT_DOUBLE_EQ(renderer->getSliceOffset(), 10.0);
+}
+
+TEST_F(ObliqueResliceRendererTest, SetSliceOffsetClampsToRange) {
+    auto volume = createTestVolume(64);
+    renderer->setInputData(volume);
+
+    auto [min, max] = renderer->getSliceRange();
+
+    // Try to set beyond max
+    renderer->setSliceOffset(max + 100.0);
+    EXPECT_LE(renderer->getSliceOffset(), max);
+
+    // Try to set beyond min
+    renderer->setSliceOffset(min - 100.0);
+    EXPECT_GE(renderer->getSliceOffset(), min);
+}
+
+TEST_F(ObliqueResliceRendererTest, ScrollSliceForward) {
+    auto volume = createTestVolume(64);
+    renderer->setInputData(volume);
+
+    renderer->setSliceOffset(0.0);
+    double initial = renderer->getSliceOffset();
+
+    renderer->scrollSlice(5);
+    EXPECT_GT(renderer->getSliceOffset(), initial);
+}
+
+TEST_F(ObliqueResliceRendererTest, ScrollSliceBackward) {
+    auto volume = createTestVolume(64);
+    renderer->setInputData(volume);
+
+    renderer->setSliceOffset(10.0);
+    double initial = renderer->getSliceOffset();
+
+    renderer->scrollSlice(-5);
+    EXPECT_LT(renderer->getSliceOffset(), initial);
+}
+
+// ==================== Preset Planes Tests ====================
+
+TEST_F(ObliqueResliceRendererTest, SetAxial) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    EXPECT_NO_THROW(renderer->setAxial());
+
+    auto plane = renderer->getCurrentPlane();
+    EXPECT_DOUBLE_EQ(plane.rotationX, 0.0);
+    EXPECT_DOUBLE_EQ(plane.rotationY, 0.0);
+    EXPECT_DOUBLE_EQ(plane.rotationZ, 0.0);
+}
+
+TEST_F(ObliqueResliceRendererTest, SetCoronal) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    EXPECT_NO_THROW(renderer->setCoronal());
+
+    auto plane = renderer->getCurrentPlane();
+    EXPECT_DOUBLE_EQ(plane.rotationX, -90.0);
+}
+
+TEST_F(ObliqueResliceRendererTest, SetSagittal) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    EXPECT_NO_THROW(renderer->setSagittal());
+
+    auto plane = renderer->getCurrentPlane();
+    EXPECT_DOUBLE_EQ(plane.rotationY, 90.0);
+}
+
+// ==================== Interactive Rotation Tests ====================
+
+TEST_F(ObliqueResliceRendererTest, InteractiveRotationNotActiveByDefault) {
+    EXPECT_FALSE(renderer->isInteractiveRotationActive());
+}
+
+TEST_F(ObliqueResliceRendererTest, StartInteractiveRotation) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    renderer->startInteractiveRotation(100, 100);
+    EXPECT_TRUE(renderer->isInteractiveRotationActive());
+}
+
+TEST_F(ObliqueResliceRendererTest, EndInteractiveRotation) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    renderer->startInteractiveRotation(100, 100);
+    renderer->endInteractiveRotation();
+    EXPECT_FALSE(renderer->isInteractiveRotationActive());
+}
+
+TEST_F(ObliqueResliceRendererTest, UpdateInteractiveRotation) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    renderer->setPlaneByRotation(0.0, 0.0, 0.0);
+    renderer->startInteractiveRotation(100, 100);
+
+    // Move 20 pixels to the right (should change Y rotation)
+    renderer->updateInteractiveRotation(120, 100);
+
+    auto plane = renderer->getCurrentPlane();
+    EXPECT_NE(plane.rotationY, 0.0);
+
+    renderer->endInteractiveRotation();
+}
+
+// ==================== Window/Level Tests ====================
+
+TEST_F(ObliqueResliceRendererTest, SetWindowLevelValidValues) {
+    EXPECT_NO_THROW(renderer->setWindowLevel(400.0, 40.0));
+
+    auto [width, center] = renderer->getWindowLevel();
+    EXPECT_DOUBLE_EQ(width, 400.0);
+    EXPECT_DOUBLE_EQ(center, 40.0);
+}
+
+TEST_F(ObliqueResliceRendererTest, SetWindowLevelNegativeCenter) {
+    EXPECT_NO_THROW(renderer->setWindowLevel(1500.0, -600.0));
+
+    auto [width, center] = renderer->getWindowLevel();
+    EXPECT_DOUBLE_EQ(width, 1500.0);
+    EXPECT_DOUBLE_EQ(center, -600.0);
+}
+
+// ==================== Options Tests ====================
+
+TEST_F(ObliqueResliceRendererTest, SetAndGetOptions) {
+    ObliqueResliceOptions options;
+    options.interpolation = InterpolationMode::Cubic;
+    options.outputDimensions = {256, 256};
+    options.backgroundValue = -2000.0;
+
+    renderer->setOptions(options);
+
+    auto result = renderer->getOptions();
+    EXPECT_EQ(result.interpolation, InterpolationMode::Cubic);
+    EXPECT_EQ(result.outputDimensions[0], 256);
+    EXPECT_EQ(result.outputDimensions[1], 256);
+    EXPECT_DOUBLE_EQ(result.backgroundValue, -2000.0);
+}
+
+// ==================== Reslice Matrix Tests ====================
+
+TEST_F(ObliqueResliceRendererTest, GetResliceMatrixNotNull) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    auto matrix = renderer->getResliceMatrix();
+    EXPECT_NE(matrix, nullptr);
+}
+
+TEST_F(ObliqueResliceRendererTest, GetPlaneNormalZAxisForAxial) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+    renderer->setAxial();
+
+    auto normal = renderer->getPlaneNormal();
+    EXPECT_NEAR(normal.x, 0.0, 0.01);
+    EXPECT_NEAR(normal.y, 0.0, 0.01);
+    EXPECT_NEAR(normal.z, 1.0, 0.01);
+}
+
+// ==================== Update and Reset Tests ====================
+
+TEST_F(ObliqueResliceRendererTest, UpdateDoesNotThrow) {
+    EXPECT_NO_THROW(renderer->update());
+}
+
+TEST_F(ObliqueResliceRendererTest, UpdateWithData) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+    EXPECT_NO_THROW(renderer->update());
+}
+
+TEST_F(ObliqueResliceRendererTest, ResetViewWithoutData) {
+    EXPECT_NO_THROW(renderer->resetView());
+}
+
+TEST_F(ObliqueResliceRendererTest, ResetViewCentersAndResetsRotation) {
+    auto volume = createTestVolume(64);
+    renderer->setInputData(volume);
+
+    // Change rotation and offset
+    renderer->setPlaneByRotation(45.0, 30.0, 0.0);
+    renderer->setSliceOffset(20.0);
+
+    // Reset should restore defaults
+    renderer->resetView();
+
+    auto plane = renderer->getCurrentPlane();
+    EXPECT_DOUBLE_EQ(plane.rotationX, 0.0);
+    EXPECT_DOUBLE_EQ(plane.rotationY, 0.0);
+    EXPECT_DOUBLE_EQ(plane.rotationZ, 0.0);
+    EXPECT_DOUBLE_EQ(plane.sliceOffset, 0.0);
+}
+
+// ==================== Callback Tests ====================
+
+TEST_F(ObliqueResliceRendererTest, PlaneChangedCallback) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    bool callbackCalled = false;
+    ObliquePlaneDefinition receivedPlane;
+
+    renderer->setPlaneChangedCallback([&](const ObliquePlaneDefinition& plane) {
+        callbackCalled = true;
+        receivedPlane = plane;
+    });
+
+    renderer->setPlaneByRotation(30.0, 0.0, 0.0);
+
+    EXPECT_TRUE(callbackCalled);
+    EXPECT_DOUBLE_EQ(receivedPlane.rotationX, 30.0);
+}
+
+TEST_F(ObliqueResliceRendererTest, SliceChangedCallback) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    bool callbackCalled = false;
+    double receivedOffset = 0.0;
+
+    renderer->setSliceChangedCallback([&](double offset) {
+        callbackCalled = true;
+        receivedOffset = offset;
+    });
+
+    renderer->setSliceOffset(15.0);
+
+    EXPECT_TRUE(callbackCalled);
+    EXPECT_DOUBLE_EQ(receivedOffset, 15.0);
+}
+
+// ==================== Vector3D Tests ====================
+
+TEST_F(ObliqueResliceRendererTest, Vector3DLength) {
+    Vector3D v{3.0, 4.0, 0.0};
+    EXPECT_DOUBLE_EQ(v.length(), 5.0);
+}
+
+TEST_F(ObliqueResliceRendererTest, Vector3DNormalized) {
+    Vector3D v{3.0, 4.0, 0.0};
+    auto normalized = v.normalized();
+
+    EXPECT_NEAR(normalized.length(), 1.0, 0.0001);
+    EXPECT_DOUBLE_EQ(normalized.x, 0.6);
+    EXPECT_DOUBLE_EQ(normalized.y, 0.8);
+}
+
+TEST_F(ObliqueResliceRendererTest, Vector3DNormalizedZeroVector) {
+    Vector3D v{0.0, 0.0, 0.0};
+    auto normalized = v.normalized();
+
+    // Should return default unit vector
+    EXPECT_NEAR(normalized.length(), 1.0, 0.0001);
+}
+
+// ==================== Renderer Assignment Tests ====================
+
+TEST_F(ObliqueResliceRendererTest, GetRendererReturnsNullByDefault) {
+    EXPECT_EQ(renderer->getRenderer(), nullptr);
+}
+
+// ==================== Anisotropic Spacing Tests ====================
+
+TEST_F(ObliqueResliceRendererTest, AnisotropicSpacing) {
+    auto imageData = vtkSmartPointer<vtkImageData>::New();
+    imageData->SetDimensions(64, 64, 32);
+    imageData->SetSpacing(0.5, 0.5, 2.0);  // Different Z spacing
+    imageData->SetOrigin(0.0, 0.0, 0.0);
+    imageData->AllocateScalars(VTK_SHORT, 1);
+
+    renderer->setInputData(imageData);
+
+    // Slice range should account for anisotropic spacing
+    auto [min, max] = renderer->getSliceRange();
+    EXPECT_GT(max, 0.0);
+}
+
+// ==================== Edge Cases ====================
+
+TEST_F(ObliqueResliceRendererTest, RotationNear90Degrees) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    // Should not cause gimbal lock issues
+    EXPECT_NO_THROW(renderer->setPlaneByRotation(89.0, 0.0, 0.0));
+
+    auto plane = renderer->getCurrentPlane();
+    EXPECT_DOUBLE_EQ(plane.rotationX, 89.0);
+}
+
+TEST_F(ObliqueResliceRendererTest, LargeRotationValues) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    // Large rotation values should work
+    EXPECT_NO_THROW(renderer->setPlaneByRotation(0.0, 180.0, 0.0));
+}
+
+TEST_F(ObliqueResliceRendererTest, SmallVolume) {
+    auto imageData = vtkSmartPointer<vtkImageData>::New();
+    imageData->SetDimensions(4, 4, 4);
+    imageData->SetSpacing(1.0, 1.0, 1.0);
+    imageData->SetOrigin(0.0, 0.0, 0.0);
+    imageData->AllocateScalars(VTK_SHORT, 1);
+
+    EXPECT_NO_THROW(renderer->setInputData(imageData));
+    EXPECT_NO_THROW(renderer->setPlaneByRotation(45.0, 45.0, 0.0));
+}


### PR DESCRIPTION
## Summary
- Implement `ObliqueResliceRenderer` class for arbitrary angle MPR visualization
- Support multiple plane definition methods (rotation angles, three points, normal vector)
- Add interactive rotation with mouse drag and preset plane shortcuts
- Include comprehensive unit tests (50+ test cases)

## Technical Details
- Uses VTK `vtkImageReslice` with custom transformation matrices
- Supports interpolation modes: nearest neighbor, linear, cubic
- Window/level adjustment and coordinate transformation utilities
- Callbacks for plane and slice change notifications

## Test Plan
- [ ] Unit tests pass for all plane definition methods
- [ ] Interactive rotation works smoothly
- [ ] Preset planes (axial, coronal, sagittal) match standard MPR views
- [ ] Slice navigation and range clamping work correctly
- [ ] Window/level adjustment displays correctly

Closes #86