### PR TITLE
feat(rendering): implement thick slab MPR rendering (MIP/MinIP/Average)

### DIFF
--- a/include/services/mpr_renderer.hpp
+++ b/include/services/mpr_renderer.hpp
@@ -142,9 +142,50 @@ public:
     /**
      * @brief Set thick slab mode
      * @param mode Slab rendering mode
-     * @param thickness Slab thickness in mm
+     * @param thickness Slab thickness in mm (1-100mm range)
      */
     void setSlabMode(SlabMode mode, double thickness = 1.0);
+
+    /**
+     * @brief Get current slab mode
+     * @return Current slab mode
+     */
+    [[nodiscard]] SlabMode getSlabMode() const;
+
+    /**
+     * @brief Get current slab thickness
+     * @return Slab thickness in mm
+     */
+    [[nodiscard]] double getSlabThickness() const;
+
+    /**
+     * @brief Set slab mode for a specific plane
+     * @param plane Target plane
+     * @param mode Slab mode
+     * @param thickness Slab thickness in mm
+     */
+    void setPlaneSlabMode(MPRPlane plane, SlabMode mode, double thickness = 1.0);
+
+    /**
+     * @brief Get slab mode for a specific plane
+     * @param plane Target plane
+     * @return Slab mode for the plane
+     */
+    [[nodiscard]] SlabMode getPlaneSlabMode(MPRPlane plane) const;
+
+    /**
+     * @brief Get slab thickness for a specific plane
+     * @param plane Target plane
+     * @return Slab thickness in mm
+     */
+    [[nodiscard]] double getPlaneSlabThickness(MPRPlane plane) const;
+
+    /**
+     * @brief Get effective slice count for current slab settings
+     * @param plane Target plane
+     * @return Number of slices used in slab
+     */
+    [[nodiscard]] int getEffectiveSliceCount(MPRPlane plane) const;
 
     /**
      * @brief Register callback for slice position changes

--- a/include/ui/mpr_view_widget.hpp
+++ b/include/ui/mpr_view_widget.hpp
@@ -171,6 +171,56 @@ public:
      */
     [[nodiscard]] services::MPRPlane getActivePlane() const;
 
+    // ==================== Thick Slab Rendering Interface ====================
+
+    /**
+     * @brief Set thick slab mode for all planes
+     * @param mode Slab rendering mode (None, MIP, MinIP, Average)
+     * @param thickness Slab thickness in mm (1-100mm)
+     */
+    void setSlabMode(services::SlabMode mode, double thickness = 1.0);
+
+    /**
+     * @brief Get current slab mode
+     * @return Current slab mode
+     */
+    [[nodiscard]] services::SlabMode getSlabMode() const;
+
+    /**
+     * @brief Get current slab thickness
+     * @return Slab thickness in mm
+     */
+    [[nodiscard]] double getSlabThickness() const;
+
+    /**
+     * @brief Set slab mode for a specific plane
+     * @param plane Target plane
+     * @param mode Slab mode
+     * @param thickness Slab thickness in mm
+     */
+    void setPlaneSlabMode(services::MPRPlane plane, services::SlabMode mode, double thickness = 1.0);
+
+    /**
+     * @brief Get slab mode for a specific plane
+     * @param plane Target plane
+     * @return Slab mode
+     */
+    [[nodiscard]] services::SlabMode getPlaneSlabMode(services::MPRPlane plane) const;
+
+    /**
+     * @brief Get slab thickness for a specific plane
+     * @param plane Target plane
+     * @return Slab thickness in mm
+     */
+    [[nodiscard]] double getPlaneSlabThickness(services::MPRPlane plane) const;
+
+    /**
+     * @brief Get effective slice count for a plane
+     * @param plane Target plane
+     * @return Number of slices in current slab
+     */
+    [[nodiscard]] int getEffectiveSliceCount(services::MPRPlane plane) const;
+
 signals:
     /// Emitted when crosshair position changes (world coordinates)
     void crosshairPositionChanged(double x, double y, double z);
@@ -186,6 +236,9 @@ signals:
 
     /// Emitted when slice position changes
     void slicePositionChanged(services::MPRPlane plane, double position);
+
+    /// Emitted when slab mode changes
+    void slabModeChanged(services::SlabMode mode, double thickness);
 
 public slots:
     /// Set crosshair position from external source

--- a/src/ui/widgets/mpr_view_widget.cpp
+++ b/src/ui/widgets/mpr_view_widget.cpp
@@ -472,6 +472,39 @@ services::MPRPlane MPRViewWidget::getActivePlane() const {
     return impl_->activePlane;
 }
 
+// ==================== Thick Slab Rendering Implementation ====================
+
+void MPRViewWidget::setSlabMode(services::SlabMode mode, double thickness) {
+    impl_->mprRenderer->setSlabMode(mode, thickness);
+    impl_->updateAllViews();
+    emit slabModeChanged(mode, thickness);
+}
+
+services::SlabMode MPRViewWidget::getSlabMode() const {
+    return impl_->mprRenderer->getSlabMode();
+}
+
+double MPRViewWidget::getSlabThickness() const {
+    return impl_->mprRenderer->getSlabThickness();
+}
+
+void MPRViewWidget::setPlaneSlabMode(services::MPRPlane plane, services::SlabMode mode, double thickness) {
+    impl_->mprRenderer->setPlaneSlabMode(plane, mode, thickness);
+    impl_->updateView(plane);
+}
+
+services::SlabMode MPRViewWidget::getPlaneSlabMode(services::MPRPlane plane) const {
+    return impl_->mprRenderer->getPlaneSlabMode(plane);
+}
+
+double MPRViewWidget::getPlaneSlabThickness(services::MPRPlane plane) const {
+    return impl_->mprRenderer->getPlaneSlabThickness(plane);
+}
+
+int MPRViewWidget::getEffectiveSliceCount(services::MPRPlane plane) const {
+    return impl_->mprRenderer->getEffectiveSliceCount(plane);
+}
+
 void MPRViewWidget::setCrosshairPosition(double x, double y, double z) {
     impl_->mprRenderer->setCrosshairPosition(x, y, z);
 


### PR DESCRIPTION
Closes #87

## Summary
- Fix spacing calculation bug in `updateSlabMode()` that incorrectly used `spacing[i % 3]` instead of per-plane spacing based on slice direction (Axial→Z, Coronal→Y, Sagittal→X)
- Add getter methods `getSlabMode()`, `getSlabThickness()` for querying current settings
- Add plane-specific slab configuration (`setPlaneSlabMode()`, `getPlaneSlabMode()`, `getPlaneSlabThickness()`)
- Add `getEffectiveSliceCount()` to query actual slice count based on spacing and thickness
- Add slab mode interface to `MPRViewWidget` for UI integration with `slabModeChanged` signal
- Add 18 new comprehensive unit tests for thick slab functionality

## Key Features
- **MIP** (Maximum Intensity Projection) - Vessel visualization for CT Angiography
- **MinIP** (Minimum Intensity Projection) - Airway/bronchi visualization for lung CT
- **AverageIP** - Noise reduction for general overview
- Configurable thickness (1-100mm range with clamping)
- Per-plane independent slab settings
- Correct handling of anisotropic spacing

## API Changes

### MPRRenderer (new methods)
```cpp
SlabMode getSlabMode() const;
double getSlabThickness() const;
void setPlaneSlabMode(MPRPlane plane, SlabMode mode, double thickness);
SlabMode getPlaneSlabMode(MPRPlane plane) const;
double getPlaneSlabThickness(MPRPlane plane) const;
int getEffectiveSliceCount(MPRPlane plane) const;
```

### MPRViewWidget (new methods)
```cpp
void setSlabMode(SlabMode mode, double thickness);
SlabMode getSlabMode() const;
double getSlabThickness() const;
void setPlaneSlabMode(MPRPlane plane, SlabMode mode, double thickness);
SlabMode getPlaneSlabMode(MPRPlane plane) const;
double getPlaneSlabThickness(MPRPlane plane) const;
int getEffectiveSliceCount(MPRPlane plane) const;
// Signal: void slabModeChanged(SlabMode mode, double thickness);
```

## Test Plan
- [x] Unit tests for slab mode getter/setter
- [x] Unit tests for thickness clamping (1-100mm)
- [x] Unit tests for plane-specific slab settings
- [x] Unit tests for effective slice count calculation
- [x] Unit tests for anisotropic spacing handling
- [x] Build verification (render_service, mpr_renderer_test)