### PR TITLE
feat(export): implement DICOM Structured Report (SR) generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,22 +287,31 @@ add_library(export_service STATIC
     src/services/export/data_exporter.cpp
     src/services/export/measurement_serializer.cpp
     src/services/export/mesh_exporter.cpp
+    src/services/export/dicom_sr_writer.cpp
 )
 
 target_include_directories(export_service PUBLIC
     ${CMAKE_SOURCE_DIR}/include
+    ${DCMTK_INCLUDE_DIRS}
+)
+
+target_link_directories(export_service PUBLIC
+    ${DCMTK_LIBRARY_DIRS}
+    /opt/homebrew/lib
 )
 
 target_link_libraries(export_service PUBLIC
     dicom_viewer_core
     measurement_service
     segmentation_service
+    pacs_service
     Qt6::Core
     Qt6::Widgets
     Qt6::Gui
     Qt6::PrintSupport
     nlohmann_json::nlohmann_json
     ${VTK_LIBRARIES}
+    ${DCMTK_LIBRARIES}
 )
 
 # Controller library

--- a/include/services/export/dicom_sr_writer.hpp
+++ b/include/services/export/dicom_sr_writer.hpp
@@ -1,0 +1,442 @@
+#pragma once
+
+#include "services/dicom_echo_scu.hpp"
+#include "services/measurement/measurement_types.hpp"
+#include "services/measurement/volume_calculator.hpp"
+#include "services/pacs_config.hpp"
+
+#include <QString>
+
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Error information for DICOM SR operations
+ *
+ * @trace SRS-FR-047
+ */
+struct SRError {
+    enum class Code {
+        Success,
+        InvalidData,
+        EncodingFailed,
+        FileAccessDenied,
+        PacsConnectionFailed,
+        PacsStoreFailed,
+        ValidationFailed,
+        InternalError
+    };
+
+    Code code = Code::Success;
+    std::string message;
+
+    [[nodiscard]] bool isSuccess() const noexcept {
+        return code == Code::Success;
+    }
+
+    [[nodiscard]] std::string toString() const {
+        switch (code) {
+            case Code::Success: return "Success";
+            case Code::InvalidData: return "Invalid data: " + message;
+            case Code::EncodingFailed: return "Encoding failed: " + message;
+            case Code::FileAccessDenied: return "File access denied: " + message;
+            case Code::PacsConnectionFailed: return "PACS connection failed: " + message;
+            case Code::PacsStoreFailed: return "PACS store failed: " + message;
+            case Code::ValidationFailed: return "Validation failed: " + message;
+            case Code::InternalError: return "Internal error: " + message;
+        }
+        return "Unknown error";
+    }
+};
+
+/**
+ * @brief DICOM code triplet (value, scheme, meaning)
+ */
+struct DicomCode {
+    std::string value;       ///< Code value (e.g., "122712")
+    std::string scheme;      ///< Coding scheme designator (e.g., "DCM", "SCT", "UCUM")
+    std::string meaning;     ///< Code meaning (e.g., "Length")
+
+    [[nodiscard]] bool isValid() const noexcept {
+        return !value.empty() && !scheme.empty() && !meaning.empty();
+    }
+};
+
+/**
+ * @brief Standard DICOM SR codes for measurement reports
+ *
+ * Provides commonly used codes from CID tables for TID 1500 reports.
+ */
+namespace SRCodes {
+    // CID 7469 - Measurement Types
+    inline const DicomCode Length{"122712", "DCM", "Length"};
+    inline const DicomCode Area{"42798000", "SCT", "Area"};
+    inline const DicomCode Volume{"118565006", "SCT", "Volume"};
+    inline const DicomCode Angle{"1483009", "SCT", "Angle"};
+    inline const DicomCode Mean{"373098007", "SCT", "Mean"};
+    inline const DicomCode StandardDeviation{"386136009", "SCT", "Standard Deviation"};
+    inline const DicomCode Minimum{"255605001", "SCT", "Minimum"};
+    inline const DicomCode Maximum{"56851009", "SCT", "Maximum"};
+
+    // CID 7470 - Measurement Units
+    inline const DicomCode Millimeter{"mm", "UCUM", "mm"};
+    inline const DicomCode SquareMillimeter{"mm2", "UCUM", "mm2"};
+    inline const DicomCode CubicMillimeter{"mm3", "UCUM", "mm3"};
+    inline const DicomCode CubicCentimeter{"cm3", "UCUM", "cm3"};
+    inline const DicomCode Degree{"deg", "UCUM", "deg"};
+    inline const DicomCode HounsfieldUnit{"[hnsf'U]", "UCUM", "Hounsfield unit"};
+
+    // CID 6147 - Common Anatomic Regions (subset)
+    inline const DicomCode Liver{"10200004", "SCT", "Liver"};
+    inline const DicomCode Lung{"39607008", "SCT", "Lung structure"};
+    inline const DicomCode Kidney{"64033007", "SCT", "Kidney structure"};
+    inline const DicomCode Brain{"12738006", "SCT", "Brain structure"};
+    inline const DicomCode Heart{"80891009", "SCT", "Heart structure"};
+    inline const DicomCode Spine{"421060004", "SCT", "Spinal column"};
+    inline const DicomCode Abdomen{"818983003", "SCT", "Abdomen"};
+    inline const DicomCode Chest{"51185008", "SCT", "Thoracic structure"};
+    inline const DicomCode Pelvis{"12921003", "SCT", "Pelvis"};
+
+    // Document titles
+    inline const DicomCode ImagingMeasurementReport{"126000", "DCM", "Imaging Measurement Report"};
+}
+
+/**
+ * @brief Patient information for SR document
+ */
+struct SRPatientInfo {
+    std::string patientId;
+    std::string patientName;
+    std::string patientBirthDate;  ///< Format: YYYYMMDD
+    std::string patientSex;        ///< M, F, or O
+};
+
+/**
+ * @brief Study information for SR document
+ */
+struct SRStudyInfo {
+    std::string studyInstanceUid;
+    std::string studyDate;         ///< Format: YYYYMMDD
+    std::string studyTime;         ///< Format: HHMMSS
+    std::string studyDescription;
+    std::string accessionNumber;
+    std::string referringPhysicianName;
+};
+
+/**
+ * @brief Series information for SR document
+ */
+struct SRSeriesInfo {
+    std::string seriesInstanceUid;
+    std::string modality;          ///< Original modality (CT, MR, etc.)
+    std::string seriesDescription;
+};
+
+/**
+ * @brief Single measurement entry for SR content
+ */
+struct SRMeasurement {
+    /// Measurement type (distance, area, volume, angle)
+    enum class Type {
+        Distance,
+        Area,
+        Volume,
+        Angle,
+        ROIStatistic
+    };
+
+    Type type = Type::Distance;
+
+    /// Measurement value
+    double value = 0.0;
+
+    /// Unit code
+    DicomCode unit;
+
+    /// Measurement label/name
+    std::string label;
+
+    /// Spatial coordinates in world space (mm)
+    std::vector<Point3D> coordinates;
+
+    /// Optional anatomic region
+    std::optional<DicomCode> findingSite;
+
+    /// Tracking identifier for this measurement
+    std::string trackingId;
+
+    /// Optional comment
+    std::string comment;
+
+    /// Referenced SOP Instance UID (source image)
+    std::string referencedSopInstanceUid;
+
+    /// Referenced frame number (for multi-frame images)
+    std::optional<int> referencedFrameNumber;
+};
+
+/**
+ * @brief ROI statistics for inclusion in SR
+ */
+struct SRROIStatistics {
+    std::string label;
+    double mean = 0.0;
+    double stdDev = 0.0;
+    double min = 0.0;
+    double max = 0.0;
+    double areaMm2 = 0.0;
+    std::optional<DicomCode> findingSite;
+    std::string referencedSopInstanceUid;
+};
+
+/**
+ * @brief Complete content for SR document
+ */
+struct SRContent {
+    /// Patient information
+    SRPatientInfo patient;
+
+    /// Study information
+    SRStudyInfo study;
+
+    /// Series information
+    SRSeriesInfo series;
+
+    /// Distance measurements
+    std::vector<DistanceMeasurement> distances;
+
+    /// Angle measurements
+    std::vector<AngleMeasurement> angles;
+
+    /// Area measurements
+    std::vector<AreaMeasurement> areas;
+
+    /// Volume results
+    std::vector<VolumeResult> volumes;
+
+    /// ROI statistics
+    std::vector<SRROIStatistics> roiStatistics;
+
+    /// Referenced SOP Instance UIDs (source images)
+    std::vector<std::string> referencedSopInstanceUids;
+
+    /// Operator/author name
+    std::string operatorName;
+
+    /// Institution name
+    std::string institutionName;
+
+    /// Performed date/time
+    std::chrono::system_clock::time_point performedDateTime;
+};
+
+/**
+ * @brief Result of SR validation
+ */
+struct SRValidationResult {
+    bool valid = false;
+    std::vector<std::string> errors;
+    std::vector<std::string> warnings;
+
+    [[nodiscard]] bool hasErrors() const noexcept {
+        return !errors.empty();
+    }
+
+    [[nodiscard]] bool hasWarnings() const noexcept {
+        return !warnings.empty();
+    }
+};
+
+/**
+ * @brief Result of successful SR creation
+ */
+struct SRCreationResult {
+    /// Generated SOP Instance UID for the SR
+    std::string sopInstanceUid;
+
+    /// Generated Series Instance UID for the SR series
+    std::string seriesInstanceUid;
+
+    /// Path to saved file (if saved locally)
+    std::optional<std::filesystem::path> filePath;
+
+    /// Number of measurements included
+    size_t measurementCount = 0;
+};
+
+/**
+ * @brief Options for SR generation
+ */
+struct SRWriterOptions {
+    /// Include patient information in SR
+    bool includePatientInfo = true;
+
+    /// Include study information in SR
+    bool includeStudyInfo = true;
+
+    /// Include spatial coordinates (SCOORD3D)
+    bool includeSpatialCoordinates = true;
+
+    /// Include ROI statistics if available
+    bool includeROIStatistics = true;
+
+    /// Series description for the SR series
+    QString seriesDescription = "Measurement Report";
+
+    /// Series number for the SR series
+    int seriesNumber = 999;
+
+    /// Instance number
+    int instanceNumber = 1;
+
+    /// Manufacturer name
+    QString manufacturer = "DICOM Viewer";
+
+    /// Software version
+    QString softwareVersion = "0.3.0";
+};
+
+/**
+ * @brief DICOM Structured Report (SR) Writer
+ *
+ * Generates DICOM Structured Reports containing measurement results
+ * following the TID 1500 (Measurement Report) template. The generated
+ * SR documents can be saved to file or stored directly to PACS.
+ *
+ * Supported content:
+ * - Distance measurements with 3D coordinates
+ * - Angle measurements
+ * - Area measurements with ROI statistics
+ * - Volume measurements
+ *
+ * @example
+ * @code
+ * DicomSRWriter writer;
+ *
+ * SRContent content;
+ * content.patient = {...};
+ * content.study = {...};
+ * content.distances = distanceMeasurements;
+ * content.volumes = volumeResults;
+ *
+ * auto result = writer.createSR(content);
+ * if (result) {
+ *     writer.saveToFile(*result, "/path/to/output.dcm");
+ *
+ *     // Or store to PACS
+ *     PacsServerConfig pacsConfig{...};
+ *     writer.storeToPacs(*result, pacsConfig);
+ * }
+ * @endcode
+ *
+ * @trace SRS-FR-047
+ */
+class DicomSRWriter {
+public:
+    /// Callback for progress updates
+    using ProgressCallback = std::function<void(double progress, const QString& status)>;
+
+    // Standard SOP Class UIDs
+    static constexpr const char* COMPREHENSIVE_SR_SOP_CLASS = "1.2.840.10008.5.1.4.1.1.88.33";
+    static constexpr const char* ENHANCED_SR_SOP_CLASS = "1.2.840.10008.5.1.4.1.1.88.22";
+
+    DicomSRWriter();
+    ~DicomSRWriter();
+
+    // Non-copyable, movable
+    DicomSRWriter(const DicomSRWriter&) = delete;
+    DicomSRWriter& operator=(const DicomSRWriter&) = delete;
+    DicomSRWriter(DicomSRWriter&&) noexcept;
+    DicomSRWriter& operator=(DicomSRWriter&&) noexcept;
+
+    /**
+     * @brief Set progress callback
+     * @param callback Function called with progress (0.0-1.0) and status message
+     */
+    void setProgressCallback(ProgressCallback callback);
+
+    /**
+     * @brief Create DICOM Structured Report from content
+     *
+     * Generates a DICOM SR document following TID 1500 template with
+     * all provided measurements encoded as structured content.
+     *
+     * @param content SR content including measurements and metadata
+     * @param options Generation options
+     * @return Creation result on success, error on failure
+     */
+    [[nodiscard]] std::expected<SRCreationResult, SRError> createSR(
+        const SRContent& content,
+        const SRWriterOptions& options = {}) const;
+
+    /**
+     * @brief Save SR document to file
+     *
+     * @param content SR content to save
+     * @param outputPath Output file path (.dcm)
+     * @param options Generation options
+     * @return Success or error
+     */
+    [[nodiscard]] std::expected<SRCreationResult, SRError> saveToFile(
+        const SRContent& content,
+        const std::filesystem::path& outputPath,
+        const SRWriterOptions& options = {}) const;
+
+    /**
+     * @brief Store SR document to PACS via C-STORE
+     *
+     * Creates the SR document and sends it to the specified PACS server
+     * using DICOM C-STORE operation.
+     *
+     * @param content SR content to store
+     * @param pacsConfig PACS server configuration
+     * @param options Generation options
+     * @return Success or error
+     */
+    [[nodiscard]] std::expected<SRCreationResult, SRError> storeToPacs(
+        const SRContent& content,
+        const PacsServerConfig& pacsConfig,
+        const SRWriterOptions& options = {}) const;
+
+    /**
+     * @brief Validate SR content before creation
+     *
+     * Checks if the provided content is valid for SR generation.
+     *
+     * @param content SR content to validate
+     * @return Validation result with errors and warnings
+     */
+    [[nodiscard]] SRValidationResult validate(const SRContent& content) const;
+
+    /**
+     * @brief Generate a new unique DICOM UID
+     * @return New UID string
+     */
+    [[nodiscard]] static std::string generateUid();
+
+    /**
+     * @brief Get supported SOP classes for SR
+     * @return List of supported SOP Class UIDs
+     */
+    [[nodiscard]] static std::vector<std::string> getSupportedSopClasses();
+
+    /**
+     * @brief Get available anatomic region codes
+     * @return List of common anatomic region codes
+     */
+    [[nodiscard]] static std::vector<DicomCode> getAnatomicRegionCodes();
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace dicom_viewer::services

--- a/src/services/export/dicom_sr_writer.cpp
+++ b/src/services/export/dicom_sr_writer.cpp
@@ -1,0 +1,1097 @@
+#include "services/export/dicom_sr_writer.hpp"
+
+#include <QDateTime>
+#include <QString>
+
+#include <atomic>
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <mutex>
+#include <sstream>
+
+// DCMTK headers
+#include <dcmtk/config/osconfig.h>
+#include <dcmtk/dcmdata/dcdeftag.h>
+#include <dcmtk/dcmdata/dcfilefo.h>
+#include <dcmtk/dcmdata/dcmetinf.h>
+#include <dcmtk/dcmdata/dcuid.h>
+#include <dcmtk/dcmnet/assoc.h>
+#include <dcmtk/dcmnet/dimse.h>
+#include <dcmtk/dcmnet/diutil.h>
+#include <dcmtk/dcmsr/dsrdoc.h>
+#include <dcmtk/dcmsr/dsrcodtn.h>
+#include <dcmtk/dcmsr/dsrnumtn.h>
+#include <dcmtk/dcmsr/dsrscotn.h>
+#include <dcmtk/dcmsr/dsrsc3tn.h>
+#include <dcmtk/dcmsr/dsrtextn.h>
+#include <dcmtk/dcmsr/dsruidtn.h>
+
+#include <spdlog/spdlog.h>
+
+namespace dicom_viewer::services {
+
+namespace {
+
+std::string formatDateTime(const std::chrono::system_clock::time_point& tp,
+                          const char* format) {
+    auto time = std::chrono::system_clock::to_time_t(tp);
+    std::tm tm{};
+#ifdef _WIN32
+    localtime_s(&tm, &time);
+#else
+    localtime_r(&time, &tm);
+#endif
+    std::ostringstream oss;
+    oss << std::put_time(&tm, format);
+    return oss.str();
+}
+
+DSRCodedEntryValue toDsrCode(const DicomCode& code) {
+    return DSRCodedEntryValue(
+        code.value.c_str(),
+        code.scheme.c_str(),
+        code.meaning.c_str()
+    );
+}
+
+void setDatasetString(DcmDataset* dataset, const DcmTag& tag, const std::string& value) {
+    if (!value.empty()) {
+        dataset->putAndInsertString(tag, value.c_str());
+    }
+}
+
+}  // namespace
+
+class DicomSRWriter::Impl {
+public:
+    Impl() = default;
+    ~Impl() = default;
+
+    ProgressCallback progressCallback;
+
+    void reportProgress(double progress, const QString& status) const {
+        if (progressCallback) {
+            progressCallback(progress, status);
+        }
+        spdlog::debug("SR Writer: {} ({:.1f}%)", status.toStdString(), progress * 100.0);
+    }
+
+    std::expected<SRCreationResult, SRError> createSR(
+        const SRContent& content,
+        const SRWriterOptions& options) const {
+
+        reportProgress(0.0, "Creating SR document...");
+
+        // Create SR document
+        DSRDocument doc;
+
+        // Set document type to Comprehensive SR
+        if (doc.createNewDocument(DSRTypes::DT_ComprehensiveSR).bad()) {
+            return std::unexpected(SRError{
+                SRError::Code::InternalError,
+                "Failed to create SR document"
+            });
+        }
+
+        reportProgress(0.1, "Setting patient information...");
+
+        // Set patient information using DSRDocument methods
+        if (options.includePatientInfo) {
+            doc.setPatientName(content.patient.patientName.c_str());
+            doc.setPatientID(content.patient.patientId.c_str());
+            doc.setPatientBirthDate(content.patient.patientBirthDate.c_str());
+            doc.setPatientSex(content.patient.patientSex.c_str());
+        }
+
+        reportProgress(0.2, "Setting study information...");
+
+        // Set study information using DSRDocument methods
+        if (options.includeStudyInfo) {
+            doc.setStudyDate(content.study.studyDate.c_str());
+            doc.setStudyTime(content.study.studyTime.c_str());
+            doc.setStudyDescription(content.study.studyDescription.c_str());
+            doc.setAccessionNumber(content.study.accessionNumber.c_str());
+            doc.setReferringPhysicianName(content.study.referringPhysicianName.c_str());
+        }
+
+        // Generate new UIDs for the SR
+        char uidBuffer[128];
+        std::string srSeriesUid = dcmGenerateUniqueIdentifier(uidBuffer, SITE_SERIES_UID_ROOT);
+        std::string srSopUid = dcmGenerateUniqueIdentifier(uidBuffer, SITE_INSTANCE_UID_ROOT);
+
+        // Set series information
+        doc.setSeriesDescription(options.seriesDescription.toStdString().c_str());
+        doc.setSeriesNumber(std::to_string(options.seriesNumber).c_str());
+
+        // Set instance information
+        doc.setInstanceNumber(std::to_string(options.instanceNumber).c_str());
+
+        // Set manufacturer information
+        doc.setManufacturer(options.manufacturer.toStdString().c_str());
+
+        // Set content date/time
+        std::string contentDate = formatDateTime(content.performedDateTime, "%Y%m%d");
+        std::string contentTime = formatDateTime(content.performedDateTime, "%H%M%S");
+        doc.setContentDate(contentDate.c_str());
+        doc.setContentTime(contentTime.c_str());
+
+        reportProgress(0.3, "Building content tree...");
+
+        // Get the document tree for content manipulation
+        DSRDocumentTree& tree = doc.getTree();
+
+        // Set document title (root container)
+        tree.addContentItem(DSRTypes::RT_isRoot, DSRTypes::VT_Container);
+        tree.getCurrentContentItem().setConceptName(
+            toDsrCode(SRCodes::ImagingMeasurementReport)
+        );
+
+        reportProgress(0.4, "Adding measurements...");
+
+        size_t totalMeasurements = 0;
+
+        // Add distance measurements
+        if (!content.distances.empty()) {
+            addMeasurementContainer(tree, "Distance Measurements");
+
+            for (const auto& dist : content.distances) {
+                addDistanceMeasurement(tree, dist, options.includeSpatialCoordinates);
+                ++totalMeasurements;
+            }
+
+            tree.goUp();  // Back to root
+        }
+
+        reportProgress(0.5, "Adding angle measurements...");
+
+        // Add angle measurements
+        if (!content.angles.empty()) {
+            addMeasurementContainer(tree, "Angle Measurements");
+
+            for (const auto& angle : content.angles) {
+                addAngleMeasurement(tree, angle, options.includeSpatialCoordinates);
+                ++totalMeasurements;
+            }
+
+            tree.goUp();  // Back to root
+        }
+
+        reportProgress(0.6, "Adding area measurements...");
+
+        // Add area measurements
+        if (!content.areas.empty()) {
+            addMeasurementContainer(tree, "Area Measurements");
+
+            for (const auto& area : content.areas) {
+                addAreaMeasurement(tree, area, options.includeSpatialCoordinates);
+                ++totalMeasurements;
+            }
+
+            tree.goUp();  // Back to root
+        }
+
+        reportProgress(0.7, "Adding volume measurements...");
+
+        // Add volume measurements
+        if (!content.volumes.empty()) {
+            addMeasurementContainer(tree, "Volume Measurements");
+
+            for (const auto& vol : content.volumes) {
+                addVolumeMeasurement(tree, vol);
+                ++totalMeasurements;
+            }
+
+            tree.goUp();  // Back to root
+        }
+
+        reportProgress(0.8, "Adding ROI statistics...");
+
+        // Add ROI statistics if requested
+        if (options.includeROIStatistics && !content.roiStatistics.empty()) {
+            addMeasurementContainer(tree, "ROI Statistics");
+
+            for (const auto& stats : content.roiStatistics) {
+                addROIStatistics(tree, stats);
+                ++totalMeasurements;
+            }
+
+            tree.goUp();  // Back to root
+        }
+
+        reportProgress(0.9, "Finalizing document...");
+
+        // Add referenced images
+        for (const auto& refSopUid : content.referencedSopInstanceUids) {
+            tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_UIDRef);
+            tree.getCurrentContentItem().setConceptName(
+                DSRCodedEntryValue("121232", "DCM", "Referenced SOP Instance UID")
+            );
+            tree.getCurrentContentItem().setStringValue(refSopUid.c_str());
+            tree.goUp();
+        }
+
+        reportProgress(1.0, "SR document created successfully");
+
+        spdlog::info("Created DICOM SR with {} measurements, SOP Instance UID: {}",
+                     totalMeasurements, srSopUid);
+
+        return SRCreationResult{
+            .sopInstanceUid = srSopUid,
+            .seriesInstanceUid = srSeriesUid,
+            .filePath = std::nullopt,
+            .measurementCount = totalMeasurements
+        };
+    }
+
+    std::expected<SRCreationResult, SRError> saveToFile(
+        const SRContent& content,
+        const std::filesystem::path& outputPath,
+        const SRWriterOptions& options) const {
+
+        // Validate output path
+        auto parentPath = outputPath.parent_path();
+        if (!parentPath.empty() && !std::filesystem::exists(parentPath)) {
+            return std::unexpected(SRError{
+                SRError::Code::FileAccessDenied,
+                "Output directory does not exist: " + parentPath.string()
+            });
+        }
+
+        reportProgress(0.0, "Creating SR for file export...");
+
+        // Create the SR document
+        DSRDocument doc;
+        if (doc.createNewDocument(DSRTypes::DT_ComprehensiveSR).bad()) {
+            return std::unexpected(SRError{
+                SRError::Code::InternalError,
+                "Failed to create SR document"
+            });
+        }
+
+        // Populate the document
+        if (options.includePatientInfo) {
+            doc.setPatientName(content.patient.patientName.c_str());
+            doc.setPatientID(content.patient.patientId.c_str());
+            doc.setPatientBirthDate(content.patient.patientBirthDate.c_str());
+            doc.setPatientSex(content.patient.patientSex.c_str());
+        }
+
+        if (options.includeStudyInfo) {
+            doc.setStudyDate(content.study.studyDate.c_str());
+            doc.setStudyTime(content.study.studyTime.c_str());
+            doc.setStudyDescription(content.study.studyDescription.c_str());
+            doc.setAccessionNumber(content.study.accessionNumber.c_str());
+        }
+
+        char uidBuffer[128];
+        std::string srSeriesUid = dcmGenerateUniqueIdentifier(uidBuffer, SITE_SERIES_UID_ROOT);
+        std::string srSopUid = dcmGenerateUniqueIdentifier(uidBuffer, SITE_INSTANCE_UID_ROOT);
+
+        doc.setSeriesDescription(options.seriesDescription.toStdString().c_str());
+        doc.setSeriesNumber(std::to_string(options.seriesNumber).c_str());
+        doc.setInstanceNumber(std::to_string(options.instanceNumber).c_str());
+        doc.setManufacturer(options.manufacturer.toStdString().c_str());
+
+        std::string contentDate = formatDateTime(content.performedDateTime, "%Y%m%d");
+        std::string contentTime = formatDateTime(content.performedDateTime, "%H%M%S");
+        doc.setContentDate(contentDate.c_str());
+        doc.setContentTime(contentTime.c_str());
+
+        reportProgress(0.3, "Building content tree...");
+
+        DSRDocumentTree& tree = doc.getTree();
+        tree.addContentItem(DSRTypes::RT_isRoot, DSRTypes::VT_Container);
+        tree.getCurrentContentItem().setConceptName(
+            toDsrCode(SRCodes::ImagingMeasurementReport)
+        );
+
+        size_t totalMeasurements = 0;
+
+        // Add all measurements
+        if (!content.distances.empty()) {
+            addMeasurementContainer(tree, "Distance Measurements");
+            for (const auto& dist : content.distances) {
+                addDistanceMeasurement(tree, dist, options.includeSpatialCoordinates);
+                ++totalMeasurements;
+            }
+            tree.goUp();
+        }
+
+        if (!content.angles.empty()) {
+            addMeasurementContainer(tree, "Angle Measurements");
+            for (const auto& angle : content.angles) {
+                addAngleMeasurement(tree, angle, options.includeSpatialCoordinates);
+                ++totalMeasurements;
+            }
+            tree.goUp();
+        }
+
+        if (!content.areas.empty()) {
+            addMeasurementContainer(tree, "Area Measurements");
+            for (const auto& area : content.areas) {
+                addAreaMeasurement(tree, area, options.includeSpatialCoordinates);
+                ++totalMeasurements;
+            }
+            tree.goUp();
+        }
+
+        if (!content.volumes.empty()) {
+            addMeasurementContainer(tree, "Volume Measurements");
+            for (const auto& vol : content.volumes) {
+                addVolumeMeasurement(tree, vol);
+                ++totalMeasurements;
+            }
+            tree.goUp();
+        }
+
+        if (options.includeROIStatistics && !content.roiStatistics.empty()) {
+            addMeasurementContainer(tree, "ROI Statistics");
+            for (const auto& stats : content.roiStatistics) {
+                addROIStatistics(tree, stats);
+                ++totalMeasurements;
+            }
+            tree.goUp();
+        }
+
+        reportProgress(0.7, "Writing to DICOM file...");
+
+        // Write to DICOM file
+        DcmFileFormat fileFormat;
+        DcmDataset* dataset = fileFormat.getDataset();
+
+        OFCondition status = doc.write(*dataset);
+        if (status.bad()) {
+            return std::unexpected(SRError{
+                SRError::Code::EncodingFailed,
+                std::string("Failed to write SR document: ") + status.text()
+            });
+        }
+
+        // Set UIDs in the dataset (these are not automatically set by DSRDocument)
+        setDatasetString(dataset, DCM_StudyInstanceUID, content.study.studyInstanceUid);
+        setDatasetString(dataset, DCM_SeriesInstanceUID, srSeriesUid);
+        setDatasetString(dataset, DCM_SOPInstanceUID, srSopUid);
+        setDatasetString(dataset, DCM_SOPClassUID, UID_ComprehensiveSRStorage);
+        setDatasetString(dataset, DCM_Modality, "SR");
+
+        // Set additional metadata
+        setDatasetString(dataset, DCM_InstitutionName, content.institutionName);
+        setDatasetString(dataset, DCM_OperatorsName, content.operatorName);
+        setDatasetString(dataset, DCM_SoftwareVersions, options.softwareVersion.toStdString());
+
+        // Set meta header
+        fileFormat.getMetaInfo()->putAndInsertString(DCM_MediaStorageSOPClassUID, UID_ComprehensiveSRStorage);
+        fileFormat.getMetaInfo()->putAndInsertString(DCM_MediaStorageSOPInstanceUID, srSopUid.c_str());
+        fileFormat.getMetaInfo()->putAndInsertString(DCM_TransferSyntaxUID, UID_LittleEndianExplicitTransferSyntax);
+
+        status = fileFormat.saveFile(
+            outputPath.string().c_str(),
+            EXS_LittleEndianExplicit
+        );
+
+        if (status.bad()) {
+            return std::unexpected(SRError{
+                SRError::Code::FileAccessDenied,
+                std::string("Failed to save file: ") + status.text()
+            });
+        }
+
+        reportProgress(1.0, "SR file saved successfully");
+
+        spdlog::info("Saved DICOM SR to: {}", outputPath.string());
+
+        return SRCreationResult{
+            .sopInstanceUid = srSopUid,
+            .seriesInstanceUid = srSeriesUid,
+            .filePath = outputPath,
+            .measurementCount = totalMeasurements
+        };
+    }
+
+    std::expected<SRCreationResult, SRError> storeToPacs(
+        const SRContent& content,
+        const PacsServerConfig& pacsConfig,
+        const SRWriterOptions& options) const {
+
+        if (!pacsConfig.isValid()) {
+            return std::unexpected(SRError{
+                SRError::Code::PacsConnectionFailed,
+                "Invalid PACS configuration"
+            });
+        }
+
+        reportProgress(0.0, "Creating SR for PACS storage...");
+
+        // Create the SR document
+        DSRDocument doc;
+        if (doc.createNewDocument(DSRTypes::DT_ComprehensiveSR).bad()) {
+            return std::unexpected(SRError{
+                SRError::Code::InternalError,
+                "Failed to create SR document"
+            });
+        }
+
+        // Populate document
+        if (options.includePatientInfo) {
+            doc.setPatientName(content.patient.patientName.c_str());
+            doc.setPatientID(content.patient.patientId.c_str());
+            doc.setPatientBirthDate(content.patient.patientBirthDate.c_str());
+            doc.setPatientSex(content.patient.patientSex.c_str());
+        }
+
+        if (options.includeStudyInfo) {
+            doc.setStudyDate(content.study.studyDate.c_str());
+            doc.setStudyTime(content.study.studyTime.c_str());
+            doc.setStudyDescription(content.study.studyDescription.c_str());
+            doc.setAccessionNumber(content.study.accessionNumber.c_str());
+        }
+
+        char uidBuffer[128];
+        std::string srSeriesUid = dcmGenerateUniqueIdentifier(uidBuffer, SITE_SERIES_UID_ROOT);
+        std::string srSopUid = dcmGenerateUniqueIdentifier(uidBuffer, SITE_INSTANCE_UID_ROOT);
+
+        doc.setSeriesDescription(options.seriesDescription.toStdString().c_str());
+        doc.setSeriesNumber(std::to_string(options.seriesNumber).c_str());
+        doc.setInstanceNumber(std::to_string(options.instanceNumber).c_str());
+        doc.setManufacturer(options.manufacturer.toStdString().c_str());
+
+        std::string contentDate = formatDateTime(content.performedDateTime, "%Y%m%d");
+        std::string contentTime = formatDateTime(content.performedDateTime, "%H%M%S");
+        doc.setContentDate(contentDate.c_str());
+        doc.setContentTime(contentTime.c_str());
+
+        DSRDocumentTree& tree = doc.getTree();
+        tree.addContentItem(DSRTypes::RT_isRoot, DSRTypes::VT_Container);
+        tree.getCurrentContentItem().setConceptName(
+            toDsrCode(SRCodes::ImagingMeasurementReport)
+        );
+
+        size_t totalMeasurements = 0;
+
+        if (!content.distances.empty()) {
+            addMeasurementContainer(tree, "Distance Measurements");
+            for (const auto& dist : content.distances) {
+                addDistanceMeasurement(tree, dist, options.includeSpatialCoordinates);
+                ++totalMeasurements;
+            }
+            tree.goUp();
+        }
+
+        if (!content.angles.empty()) {
+            addMeasurementContainer(tree, "Angle Measurements");
+            for (const auto& angle : content.angles) {
+                addAngleMeasurement(tree, angle, options.includeSpatialCoordinates);
+                ++totalMeasurements;
+            }
+            tree.goUp();
+        }
+
+        if (!content.areas.empty()) {
+            addMeasurementContainer(tree, "Area Measurements");
+            for (const auto& area : content.areas) {
+                addAreaMeasurement(tree, area, options.includeSpatialCoordinates);
+                ++totalMeasurements;
+            }
+            tree.goUp();
+        }
+
+        if (!content.volumes.empty()) {
+            addMeasurementContainer(tree, "Volume Measurements");
+            for (const auto& vol : content.volumes) {
+                addVolumeMeasurement(tree, vol);
+                ++totalMeasurements;
+            }
+            tree.goUp();
+        }
+
+        if (options.includeROIStatistics && !content.roiStatistics.empty()) {
+            addMeasurementContainer(tree, "ROI Statistics");
+            for (const auto& stats : content.roiStatistics) {
+                addROIStatistics(tree, stats);
+                ++totalMeasurements;
+            }
+            tree.goUp();
+        }
+
+        reportProgress(0.4, "Preparing for PACS transfer...");
+
+        // Create DICOM file format for transfer
+        DcmFileFormat fileFormat;
+        DcmDataset* dataset = fileFormat.getDataset();
+
+        OFCondition status = doc.write(*dataset);
+        if (status.bad()) {
+            return std::unexpected(SRError{
+                SRError::Code::EncodingFailed,
+                std::string("Failed to encode SR document: ") + status.text()
+            });
+        }
+
+        // Set UIDs in the dataset
+        setDatasetString(dataset, DCM_StudyInstanceUID, content.study.studyInstanceUid);
+        setDatasetString(dataset, DCM_SeriesInstanceUID, srSeriesUid);
+        setDatasetString(dataset, DCM_SOPInstanceUID, srSopUid);
+        setDatasetString(dataset, DCM_SOPClassUID, UID_ComprehensiveSRStorage);
+        setDatasetString(dataset, DCM_Modality, "SR");
+
+        reportProgress(0.5, "Connecting to PACS...");
+
+        // Initialize network
+        T_ASC_Network* network = nullptr;
+        OFCondition cond = ASC_initializeNetwork(
+            NET_REQUESTOR,
+            0,
+            static_cast<int>(pacsConfig.connectionTimeout.count()),
+            &network
+        );
+
+        if (cond.bad()) {
+            return std::unexpected(SRError{
+                SRError::Code::PacsConnectionFailed,
+                std::string("Failed to initialize network: ") + cond.text()
+            });
+        }
+
+        // Create association parameters
+        T_ASC_Parameters* params = nullptr;
+        cond = ASC_createAssociationParameters(&params, pacsConfig.maxPduSize);
+        if (cond.bad()) {
+            ASC_dropNetwork(&network);
+            return std::unexpected(SRError{
+                SRError::Code::PacsConnectionFailed,
+                std::string("Failed to create association parameters: ") + cond.text()
+            });
+        }
+
+        ASC_setAPTitles(
+            params,
+            pacsConfig.callingAeTitle.c_str(),
+            pacsConfig.calledAeTitle.c_str(),
+            nullptr
+        );
+
+        std::string peerAddress = pacsConfig.hostname + ":" + std::to_string(pacsConfig.port);
+        ASC_setPresentationAddresses(
+            params,
+            OFStandard::getHostName().c_str(),
+            peerAddress.c_str()
+        );
+
+        // Add Comprehensive SR Storage presentation context
+        const char* transferSyntaxes[] = {
+            UID_LittleEndianExplicitTransferSyntax,
+            UID_BigEndianExplicitTransferSyntax,
+            UID_LittleEndianImplicitTransferSyntax
+        };
+
+        cond = ASC_addPresentationContext(
+            params,
+            1,
+            UID_ComprehensiveSRStorage,
+            transferSyntaxes,
+            3
+        );
+
+        if (cond.bad()) {
+            ASC_destroyAssociationParameters(&params);
+            ASC_dropNetwork(&network);
+            return std::unexpected(SRError{
+                SRError::Code::PacsConnectionFailed,
+                std::string("Failed to add presentation context: ") + cond.text()
+            });
+        }
+
+        reportProgress(0.6, "Establishing association...");
+
+        // Create association
+        T_ASC_Association* assoc = nullptr;
+        cond = ASC_requestAssociation(network, params, &assoc);
+        if (cond.bad()) {
+            ASC_destroyAssociationParameters(&params);
+            ASC_dropNetwork(&network);
+            return std::unexpected(SRError{
+                SRError::Code::PacsConnectionFailed,
+                std::string("Failed to establish association: ") + cond.text()
+            });
+        }
+
+        // Check if SR Storage was accepted
+        T_ASC_PresentationContextID presId = ASC_findAcceptedPresentationContextID(
+            assoc, UID_ComprehensiveSRStorage
+        );
+
+        if (presId == 0) {
+            ASC_releaseAssociation(assoc);
+            ASC_destroyAssociation(&assoc);
+            ASC_dropNetwork(&network);
+            return std::unexpected(SRError{
+                SRError::Code::PacsConnectionFailed,
+                "Comprehensive SR Storage not accepted by PACS"
+            });
+        }
+
+        reportProgress(0.7, "Sending SR to PACS...");
+
+        // Prepare C-STORE request
+        T_DIMSE_C_StoreRQ req;
+        memset(&req, 0, sizeof(req));
+        req.MessageID = assoc->nextMsgID++;
+        strncpy(req.AffectedSOPClassUID, UID_ComprehensiveSRStorage, sizeof(req.AffectedSOPClassUID) - 1);
+        strncpy(req.AffectedSOPInstanceUID, srSopUid.c_str(), sizeof(req.AffectedSOPInstanceUID) - 1);
+        req.DataSetType = DIMSE_DATASET_PRESENT;
+        req.Priority = DIMSE_PRIORITY_MEDIUM;
+
+        T_DIMSE_C_StoreRSP rsp;
+        DcmDataset* statusDetail = nullptr;
+
+        cond = DIMSE_storeUser(
+            assoc,
+            presId,
+            &req,
+            nullptr,  // no file name
+            dataset,
+            nullptr,  // no progress callback
+            nullptr,  // no callback data
+            DIMSE_BLOCKING,
+            static_cast<int>(pacsConfig.dimseTimeout.count()),
+            &rsp,
+            &statusDetail
+        );
+
+        delete statusDetail;
+
+        // Clean up association
+        ASC_releaseAssociation(assoc);
+        ASC_destroyAssociation(&assoc);
+        ASC_dropNetwork(&network);
+
+        if (cond.bad()) {
+            return std::unexpected(SRError{
+                SRError::Code::PacsStoreFailed,
+                std::string("C-STORE failed: ") + cond.text()
+            });
+        }
+
+        if (rsp.DimseStatus != STATUS_Success) {
+            return std::unexpected(SRError{
+                SRError::Code::PacsStoreFailed,
+                "C-STORE returned status: " + std::to_string(rsp.DimseStatus)
+            });
+        }
+
+        reportProgress(1.0, "SR stored to PACS successfully");
+
+        spdlog::info("Stored DICOM SR to PACS: {} (SOP Instance UID: {})",
+                     pacsConfig.calledAeTitle, srSopUid);
+
+        return SRCreationResult{
+            .sopInstanceUid = srSopUid,
+            .seriesInstanceUid = srSeriesUid,
+            .filePath = std::nullopt,
+            .measurementCount = totalMeasurements
+        };
+    }
+
+    SRValidationResult validate(const SRContent& content) const {
+        SRValidationResult result;
+        result.valid = true;
+
+        // Check patient info
+        if (content.patient.patientId.empty()) {
+            result.warnings.push_back("Patient ID is empty");
+        }
+
+        if (content.patient.patientName.empty()) {
+            result.warnings.push_back("Patient name is empty");
+        }
+
+        // Check study info
+        if (content.study.studyInstanceUid.empty()) {
+            result.errors.push_back("Study Instance UID is required");
+            result.valid = false;
+        }
+
+        // Check for content
+        bool hasContent = !content.distances.empty() ||
+                          !content.angles.empty() ||
+                          !content.areas.empty() ||
+                          !content.volumes.empty() ||
+                          !content.roiStatistics.empty();
+
+        if (!hasContent) {
+            result.errors.push_back("No measurements or content provided");
+            result.valid = false;
+        }
+
+        // Validate measurements
+        for (const auto& dist : content.distances) {
+            if (dist.distanceMm < 0) {
+                result.errors.push_back("Distance measurement has negative value: " + dist.label);
+                result.valid = false;
+            }
+        }
+
+        for (const auto& angle : content.angles) {
+            if (angle.angleDegrees < 0 || angle.angleDegrees > 360) {
+                result.warnings.push_back("Angle measurement outside expected range: " + angle.label);
+            }
+        }
+
+        for (const auto& area : content.areas) {
+            if (area.areaMm2 < 0) {
+                result.errors.push_back("Area measurement has negative value: " + area.label);
+                result.valid = false;
+            }
+        }
+
+        for (const auto& vol : content.volumes) {
+            if (vol.volumeMm3 < 0) {
+                result.errors.push_back("Volume measurement has negative value: " + vol.labelName);
+                result.valid = false;
+            }
+        }
+
+        return result;
+    }
+
+private:
+    void addMeasurementContainer(DSRDocumentTree& tree, const std::string& title) const {
+        tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_Container);
+        tree.getCurrentContentItem().setConceptName(
+            DSRCodedEntryValue("125007", "DCM", title.c_str())
+        );
+        tree.goDown();  // Enter the container
+    }
+
+    void addDistanceMeasurement(DSRDocumentTree& tree,
+                               const DistanceMeasurement& dist,
+                               bool includeSpatialCoords) const {
+        // Add measurement container
+        tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_Container);
+        tree.getCurrentContentItem().setConceptName(
+            DSRCodedEntryValue("125309", "DCM", "Measurement Group")
+        );
+        tree.goDown();
+
+        // Add tracking identifier
+        if (!dist.label.empty()) {
+            tree.addContentItem(DSRTypes::RT_hasObsContext, DSRTypes::VT_Text);
+            tree.getCurrentContentItem().setConceptName(
+                DSRCodedEntryValue("112039", "DCM", "Tracking Identifier")
+            );
+            tree.getCurrentContentItem().setStringValue(dist.label.c_str());
+        }
+
+        // Add numeric measurement
+        tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_Num);
+        tree.getCurrentContentItem().setConceptName(toDsrCode(SRCodes::Length));
+
+        DSRNumericMeasurementValue numValue(
+            std::to_string(dist.distanceMm).c_str(),
+            toDsrCode(SRCodes::Millimeter)
+        );
+        tree.getCurrentContentItem().setNumericValue(numValue);
+
+        // Add spatial coordinates if requested
+        if (includeSpatialCoords) {
+            // Point 1
+            tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_SCoord3D);
+            tree.getCurrentContentItem().setConceptName(
+                DSRCodedEntryValue("111030", "DCM", "Image Region")
+            );
+
+            DSRSpatialCoordinates3DValue scoord3d(DSRTypes::GT3_Point);
+            scoord3d.getGraphicDataList().addItem(
+                static_cast<Float64>(dist.point1[0]),
+                static_cast<Float64>(dist.point1[1]),
+                static_cast<Float64>(dist.point1[2])
+            );
+            tree.getCurrentContentItem().setSpatialCoordinates3D(scoord3d);
+
+            // Point 2
+            tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_SCoord3D);
+            tree.getCurrentContentItem().setConceptName(
+                DSRCodedEntryValue("111030", "DCM", "Image Region")
+            );
+
+            DSRSpatialCoordinates3DValue scoord3d2(DSRTypes::GT3_Point);
+            scoord3d2.getGraphicDataList().addItem(
+                static_cast<Float64>(dist.point2[0]),
+                static_cast<Float64>(dist.point2[1]),
+                static_cast<Float64>(dist.point2[2])
+            );
+            tree.getCurrentContentItem().setSpatialCoordinates3D(scoord3d2);
+        }
+
+        tree.goUp();  // Back to parent
+    }
+
+    void addAngleMeasurement(DSRDocumentTree& tree,
+                            const AngleMeasurement& angle,
+                            bool includeSpatialCoords) const {
+        tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_Container);
+        tree.getCurrentContentItem().setConceptName(
+            DSRCodedEntryValue("125309", "DCM", "Measurement Group")
+        );
+        tree.goDown();
+
+        if (!angle.label.empty()) {
+            tree.addContentItem(DSRTypes::RT_hasObsContext, DSRTypes::VT_Text);
+            tree.getCurrentContentItem().setConceptName(
+                DSRCodedEntryValue("112039", "DCM", "Tracking Identifier")
+            );
+            tree.getCurrentContentItem().setStringValue(angle.label.c_str());
+        }
+
+        tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_Num);
+        tree.getCurrentContentItem().setConceptName(toDsrCode(SRCodes::Angle));
+
+        DSRNumericMeasurementValue numValue(
+            std::to_string(angle.angleDegrees).c_str(),
+            toDsrCode(SRCodes::Degree)
+        );
+        tree.getCurrentContentItem().setNumericValue(numValue);
+
+        if (includeSpatialCoords) {
+            // Vertex point
+            tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_SCoord3D);
+            tree.getCurrentContentItem().setConceptName(
+                DSRCodedEntryValue("111030", "DCM", "Image Region")
+            );
+
+            DSRSpatialCoordinates3DValue scoord3d(DSRTypes::GT3_Point);
+            scoord3d.getGraphicDataList().addItem(
+                static_cast<Float64>(angle.vertex[0]),
+                static_cast<Float64>(angle.vertex[1]),
+                static_cast<Float64>(angle.vertex[2])
+            );
+            tree.getCurrentContentItem().setSpatialCoordinates3D(scoord3d);
+        }
+
+        tree.goUp();
+    }
+
+    void addAreaMeasurement(DSRDocumentTree& tree,
+                           const AreaMeasurement& area,
+                           bool includeSpatialCoords) const {
+        tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_Container);
+        tree.getCurrentContentItem().setConceptName(
+            DSRCodedEntryValue("125309", "DCM", "Measurement Group")
+        );
+        tree.goDown();
+
+        if (!area.label.empty()) {
+            tree.addContentItem(DSRTypes::RT_hasObsContext, DSRTypes::VT_Text);
+            tree.getCurrentContentItem().setConceptName(
+                DSRCodedEntryValue("112039", "DCM", "Tracking Identifier")
+            );
+            tree.getCurrentContentItem().setStringValue(area.label.c_str());
+        }
+
+        tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_Num);
+        tree.getCurrentContentItem().setConceptName(toDsrCode(SRCodes::Area));
+
+        DSRNumericMeasurementValue numValue(
+            std::to_string(area.areaMm2).c_str(),
+            toDsrCode(SRCodes::SquareMillimeter)
+        );
+        tree.getCurrentContentItem().setNumericValue(numValue);
+
+        if (includeSpatialCoords && !area.points.empty()) {
+            tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_SCoord3D);
+            tree.getCurrentContentItem().setConceptName(
+                DSRCodedEntryValue("111030", "DCM", "Image Region")
+            );
+
+            DSRSpatialCoordinates3DValue scoord3d(DSRTypes::GT3_Polygon);
+            for (const auto& pt : area.points) {
+                scoord3d.getGraphicDataList().addItem(
+                    static_cast<Float64>(pt[0]),
+                    static_cast<Float64>(pt[1]),
+                    static_cast<Float64>(pt[2])
+                );
+            }
+            tree.getCurrentContentItem().setSpatialCoordinates3D(scoord3d);
+        }
+
+        tree.goUp();
+    }
+
+    void addVolumeMeasurement(DSRDocumentTree& tree,
+                             const VolumeResult& vol) const {
+        tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_Container);
+        tree.getCurrentContentItem().setConceptName(
+            DSRCodedEntryValue("125309", "DCM", "Measurement Group")
+        );
+        tree.goDown();
+
+        if (!vol.labelName.empty()) {
+            tree.addContentItem(DSRTypes::RT_hasObsContext, DSRTypes::VT_Text);
+            tree.getCurrentContentItem().setConceptName(
+                DSRCodedEntryValue("112039", "DCM", "Tracking Identifier")
+            );
+            tree.getCurrentContentItem().setStringValue(vol.labelName.c_str());
+        }
+
+        // Volume in cubic centimeters
+        tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_Num);
+        tree.getCurrentContentItem().setConceptName(toDsrCode(SRCodes::Volume));
+
+        double volumeCm3 = vol.volumeMm3 / 1000.0;  // Convert mm3 to cm3
+        DSRNumericMeasurementValue numValue(
+            std::to_string(volumeCm3).c_str(),
+            toDsrCode(SRCodes::CubicCentimeter)
+        );
+        tree.getCurrentContentItem().setNumericValue(numValue);
+
+        // Surface area if available
+        if (vol.surfaceAreaMm2.has_value() && vol.surfaceAreaMm2.value() > 0) {
+            tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_Num);
+            tree.getCurrentContentItem().setConceptName(
+                DSRCodedEntryValue("118565009", "SCT", "Surface Area")
+            );
+
+            DSRNumericMeasurementValue surfaceValue(
+                std::to_string(vol.surfaceAreaMm2.value()).c_str(),
+                toDsrCode(SRCodes::SquareMillimeter)
+            );
+            tree.getCurrentContentItem().setNumericValue(surfaceValue);
+        }
+
+        tree.goUp();
+    }
+
+    void addROIStatistics(DSRDocumentTree& tree,
+                         const SRROIStatistics& stats) const {
+        tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_Container);
+        tree.getCurrentContentItem().setConceptName(
+            DSRCodedEntryValue("125309", "DCM", "Measurement Group")
+        );
+        tree.goDown();
+
+        if (!stats.label.empty()) {
+            tree.addContentItem(DSRTypes::RT_hasObsContext, DSRTypes::VT_Text);
+            tree.getCurrentContentItem().setConceptName(
+                DSRCodedEntryValue("112039", "DCM", "Tracking Identifier")
+            );
+            tree.getCurrentContentItem().setStringValue(stats.label.c_str());
+        }
+
+        // Mean
+        tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_Num);
+        tree.getCurrentContentItem().setConceptName(toDsrCode(SRCodes::Mean));
+        DSRNumericMeasurementValue meanValue(
+            std::to_string(stats.mean).c_str(),
+            toDsrCode(SRCodes::HounsfieldUnit)
+        );
+        tree.getCurrentContentItem().setNumericValue(meanValue);
+
+        // Standard deviation
+        tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_Num);
+        tree.getCurrentContentItem().setConceptName(toDsrCode(SRCodes::StandardDeviation));
+        DSRNumericMeasurementValue stdValue(
+            std::to_string(stats.stdDev).c_str(),
+            toDsrCode(SRCodes::HounsfieldUnit)
+        );
+        tree.getCurrentContentItem().setNumericValue(stdValue);
+
+        // Minimum
+        tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_Num);
+        tree.getCurrentContentItem().setConceptName(toDsrCode(SRCodes::Minimum));
+        DSRNumericMeasurementValue minValue(
+            std::to_string(stats.min).c_str(),
+            toDsrCode(SRCodes::HounsfieldUnit)
+        );
+        tree.getCurrentContentItem().setNumericValue(minValue);
+
+        // Maximum
+        tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_Num);
+        tree.getCurrentContentItem().setConceptName(toDsrCode(SRCodes::Maximum));
+        DSRNumericMeasurementValue maxValue(
+            std::to_string(stats.max).c_str(),
+            toDsrCode(SRCodes::HounsfieldUnit)
+        );
+        tree.getCurrentContentItem().setNumericValue(maxValue);
+
+        // Area
+        if (stats.areaMm2 > 0) {
+            tree.addContentItem(DSRTypes::RT_contains, DSRTypes::VT_Num);
+            tree.getCurrentContentItem().setConceptName(toDsrCode(SRCodes::Area));
+            DSRNumericMeasurementValue areaValue(
+                std::to_string(stats.areaMm2).c_str(),
+                toDsrCode(SRCodes::SquareMillimeter)
+            );
+            tree.getCurrentContentItem().setNumericValue(areaValue);
+        }
+
+        tree.goUp();
+    }
+};
+
+// Public interface implementation
+
+DicomSRWriter::DicomSRWriter()
+    : impl_(std::make_unique<Impl>()) {
+}
+
+DicomSRWriter::~DicomSRWriter() = default;
+
+DicomSRWriter::DicomSRWriter(DicomSRWriter&&) noexcept = default;
+DicomSRWriter& DicomSRWriter::operator=(DicomSRWriter&&) noexcept = default;
+
+void DicomSRWriter::setProgressCallback(ProgressCallback callback) {
+    impl_->progressCallback = std::move(callback);
+}
+
+std::expected<SRCreationResult, SRError> DicomSRWriter::createSR(
+    const SRContent& content,
+    const SRWriterOptions& options) const {
+    return impl_->createSR(content, options);
+}
+
+std::expected<SRCreationResult, SRError> DicomSRWriter::saveToFile(
+    const SRContent& content,
+    const std::filesystem::path& outputPath,
+    const SRWriterOptions& options) const {
+    return impl_->saveToFile(content, outputPath, options);
+}
+
+std::expected<SRCreationResult, SRError> DicomSRWriter::storeToPacs(
+    const SRContent& content,
+    const PacsServerConfig& pacsConfig,
+    const SRWriterOptions& options) const {
+    return impl_->storeToPacs(content, pacsConfig, options);
+}
+
+SRValidationResult DicomSRWriter::validate(const SRContent& content) const {
+    return impl_->validate(content);
+}
+
+std::string DicomSRWriter::generateUid() {
+    char buffer[128];
+    return dcmGenerateUniqueIdentifier(buffer, SITE_INSTANCE_UID_ROOT);
+}
+
+std::vector<std::string> DicomSRWriter::getSupportedSopClasses() {
+    return {
+        COMPREHENSIVE_SR_SOP_CLASS,
+        ENHANCED_SR_SOP_CLASS
+    };
+}
+
+std::vector<DicomCode> DicomSRWriter::getAnatomicRegionCodes() {
+    return {
+        SRCodes::Liver,
+        SRCodes::Lung,
+        SRCodes::Kidney,
+        SRCodes::Brain,
+        SRCodes::Heart,
+        SRCodes::Spine,
+        SRCodes::Abdomen,
+        SRCodes::Chest,
+        SRCodes::Pelvis
+    };
+}
+
+}  // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -614,3 +614,28 @@ vtk_module_autoinit(
 )
 
 gtest_discover_tests(mesh_exporter_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for DICOM SR Writer
+add_executable(dicom_sr_writer_test
+    unit/dicom_sr_writer_test.cpp
+)
+
+target_link_directories(dicom_sr_writer_test PRIVATE
+    /opt/homebrew/lib
+)
+
+target_link_libraries(dicom_sr_writer_test PRIVATE
+    export_service
+    pacs_service
+    Qt6::Core
+    Qt6::Widgets
+    Qt6::Gui
+    Qt6::Test
+    GTest::gtest
+)
+
+target_include_directories(dicom_sr_writer_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(dicom_sr_writer_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/dicom_sr_writer_test.cpp
+++ b/tests/unit/dicom_sr_writer_test.cpp
@@ -1,0 +1,544 @@
+#include "services/export/dicom_sr_writer.hpp"
+
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+
+namespace dicom_viewer::services {
+namespace {
+
+class DicomSRWriterTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Create temporary test directory
+        testDir_ = std::filesystem::temp_directory_path() / "dicom_sr_writer_test";
+        std::filesystem::create_directories(testDir_);
+
+        // Create sample content
+        sampleContent_ = createSampleContent();
+    }
+
+    void TearDown() override {
+        // Clean up test directory
+        if (std::filesystem::exists(testDir_)) {
+            std::filesystem::remove_all(testDir_);
+        }
+    }
+
+    SRContent createSampleContent() {
+        SRContent content;
+
+        // Patient info
+        content.patient.patientId = "TEST_PAT_001";
+        content.patient.patientName = "Test^Patient";
+        content.patient.patientBirthDate = "19800101";
+        content.patient.patientSex = "M";
+
+        // Study info
+        content.study.studyInstanceUid = "1.2.840.113619.2.55.3.123456789.1";
+        content.study.studyDate = "20260119";
+        content.study.studyTime = "120000";
+        content.study.studyDescription = "CT Chest";
+        content.study.accessionNumber = "ACC123456";
+        content.study.referringPhysicianName = "Dr^Smith";
+
+        // Series info
+        content.series.seriesInstanceUid = "1.2.840.113619.2.55.3.123456789.2";
+        content.series.modality = "CT";
+        content.series.seriesDescription = "Axial Images";
+
+        // Operator info
+        content.operatorName = "Test Operator";
+        content.institutionName = "Test Hospital";
+        content.performedDateTime = std::chrono::system_clock::now();
+
+        return content;
+    }
+
+    void addSampleDistances(SRContent& content) {
+        DistanceMeasurement dist1;
+        dist1.id = 1;
+        dist1.label = "Lesion Diameter";
+        dist1.point1 = {100.0, 100.0, 50.0};
+        dist1.point2 = {130.0, 100.0, 50.0};
+        dist1.distanceMm = 30.0;
+        dist1.visible = true;
+        dist1.sliceIndex = 50;
+
+        DistanceMeasurement dist2;
+        dist2.id = 2;
+        dist2.label = "Reference Distance";
+        dist2.point1 = {200.0, 150.0, 75.0};
+        dist2.point2 = {200.0, 200.0, 75.0};
+        dist2.distanceMm = 50.0;
+        dist2.visible = true;
+        dist2.sliceIndex = 75;
+
+        content.distances.push_back(dist1);
+        content.distances.push_back(dist2);
+    }
+
+    void addSampleAngles(SRContent& content) {
+        AngleMeasurement angle1;
+        angle1.id = 1;
+        angle1.label = "Vertebral Angle";
+        angle1.vertex = {150.0, 200.0, 100.0};
+        angle1.point1 = {100.0, 150.0, 100.0};
+        angle1.point2 = {200.0, 150.0, 100.0};
+        angle1.angleDegrees = 45.5;
+        angle1.visible = true;
+        angle1.sliceIndex = 100;
+
+        content.angles.push_back(angle1);
+    }
+
+    void addSampleAreas(SRContent& content) {
+        AreaMeasurement area1;
+        area1.id = 1;
+        area1.label = "Tumor Region";
+        area1.type = RoiType::Ellipse;
+        area1.points = {{100.0, 100.0, 50.0}, {120.0, 100.0, 50.0},
+                        {120.0, 120.0, 50.0}, {100.0, 120.0, 50.0}};
+        area1.areaMm2 = 400.0;
+        area1.areaCm2 = 0.04;
+        area1.perimeterMm = 80.0;
+        area1.centroid = {110.0, 110.0, 50.0};
+        area1.visible = true;
+        area1.sliceIndex = 50;
+
+        content.areas.push_back(area1);
+    }
+
+    void addSampleVolumes(SRContent& content) {
+        VolumeResult vol1;
+        vol1.labelId = 1;
+        vol1.labelName = "Liver";
+        vol1.voxelCount = 1500000;
+        vol1.volumeMm3 = 1500000.0;  // 1500 cm3
+        vol1.volumeCm3 = 1500.0;
+        vol1.volumeML = 1500.0;
+        vol1.surfaceAreaMm2 = 120000.0;
+
+        VolumeResult vol2;
+        vol2.labelId = 2;
+        vol2.labelName = "Tumor";
+        vol2.voxelCount = 50000;
+        vol2.volumeMm3 = 50000.0;  // 50 cm3
+        vol2.volumeCm3 = 50.0;
+        vol2.volumeML = 50.0;
+        vol2.surfaceAreaMm2 = 8500.0;
+
+        content.volumes.push_back(vol1);
+        content.volumes.push_back(vol2);
+    }
+
+    void addSampleROIStatistics(SRContent& content) {
+        SRROIStatistics stats1;
+        stats1.label = "Lesion ROI";
+        stats1.mean = 45.2;
+        stats1.stdDev = 12.5;
+        stats1.min = -50.0;
+        stats1.max = 120.0;
+        stats1.areaMm2 = 250.0;
+
+        content.roiStatistics.push_back(stats1);
+    }
+
+    std::filesystem::path testDir_;
+    SRContent sampleContent_;
+};
+
+// =============================================================================
+// Validation Tests
+// =============================================================================
+
+TEST_F(DicomSRWriterTest, ValidateEmptyContent) {
+    DicomSRWriter writer;
+
+    SRContent emptyContent;
+    emptyContent.study.studyInstanceUid = "1.2.3.4.5";  // Required field
+
+    auto result = writer.validate(emptyContent);
+
+    EXPECT_FALSE(result.valid);
+    EXPECT_FALSE(result.errors.empty());
+}
+
+TEST_F(DicomSRWriterTest, ValidateMissingStudyUid) {
+    DicomSRWriter writer;
+
+    SRContent content = sampleContent_;
+    content.study.studyInstanceUid = "";
+    addSampleDistances(content);
+
+    auto result = writer.validate(content);
+
+    EXPECT_FALSE(result.valid);
+    EXPECT_TRUE(result.hasErrors());
+}
+
+TEST_F(DicomSRWriterTest, ValidateValidContentWithDistances) {
+    DicomSRWriter writer;
+
+    SRContent content = sampleContent_;
+    addSampleDistances(content);
+
+    auto result = writer.validate(content);
+
+    EXPECT_TRUE(result.valid);
+    EXPECT_FALSE(result.hasErrors());
+}
+
+TEST_F(DicomSRWriterTest, ValidateNegativeDistance) {
+    DicomSRWriter writer;
+
+    SRContent content = sampleContent_;
+    DistanceMeasurement dist;
+    dist.distanceMm = -10.0;
+    dist.label = "Invalid Distance";
+    content.distances.push_back(dist);
+
+    auto result = writer.validate(content);
+
+    EXPECT_FALSE(result.valid);
+    EXPECT_TRUE(result.hasErrors());
+}
+
+TEST_F(DicomSRWriterTest, ValidateMissingPatientInfo) {
+    DicomSRWriter writer;
+
+    SRContent content = sampleContent_;
+    content.patient.patientId = "";
+    content.patient.patientName = "";
+    addSampleDistances(content);
+
+    auto result = writer.validate(content);
+
+    // Should have warnings but still be valid
+    EXPECT_TRUE(result.valid);
+    EXPECT_TRUE(result.hasWarnings());
+}
+
+// =============================================================================
+// SR Creation Tests
+// =============================================================================
+
+TEST_F(DicomSRWriterTest, CreateSRWithDistances) {
+    DicomSRWriter writer;
+
+    SRContent content = sampleContent_;
+    addSampleDistances(content);
+
+    auto result = writer.createSR(content);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FALSE(result->sopInstanceUid.empty());
+    EXPECT_FALSE(result->seriesInstanceUid.empty());
+    EXPECT_EQ(result->measurementCount, 2);
+}
+
+TEST_F(DicomSRWriterTest, CreateSRWithAngles) {
+    DicomSRWriter writer;
+
+    SRContent content = sampleContent_;
+    addSampleAngles(content);
+
+    auto result = writer.createSR(content);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->measurementCount, 1);
+}
+
+TEST_F(DicomSRWriterTest, CreateSRWithAreas) {
+    DicomSRWriter writer;
+
+    SRContent content = sampleContent_;
+    addSampleAreas(content);
+
+    auto result = writer.createSR(content);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->measurementCount, 1);
+}
+
+TEST_F(DicomSRWriterTest, CreateSRWithVolumes) {
+    DicomSRWriter writer;
+
+    SRContent content = sampleContent_;
+    addSampleVolumes(content);
+
+    auto result = writer.createSR(content);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->measurementCount, 2);
+}
+
+TEST_F(DicomSRWriterTest, CreateSRWithAllMeasurements) {
+    DicomSRWriter writer;
+
+    SRContent content = sampleContent_;
+    addSampleDistances(content);
+    addSampleAngles(content);
+    addSampleAreas(content);
+    addSampleVolumes(content);
+    addSampleROIStatistics(content);
+
+    auto result = writer.createSR(content);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->measurementCount, 7);  // 2 + 1 + 1 + 2 + 1
+}
+
+TEST_F(DicomSRWriterTest, CreateSRGeneratesUniqueUids) {
+    DicomSRWriter writer;
+
+    SRContent content = sampleContent_;
+    addSampleDistances(content);
+
+    auto result1 = writer.createSR(content);
+    auto result2 = writer.createSR(content);
+
+    ASSERT_TRUE(result1.has_value());
+    ASSERT_TRUE(result2.has_value());
+
+    // UIDs should be different for each creation
+    EXPECT_NE(result1->sopInstanceUid, result2->sopInstanceUid);
+    EXPECT_NE(result1->seriesInstanceUid, result2->seriesInstanceUid);
+}
+
+// =============================================================================
+// File Save Tests
+// =============================================================================
+
+TEST_F(DicomSRWriterTest, SaveToFileSuccess) {
+    DicomSRWriter writer;
+
+    SRContent content = sampleContent_;
+    addSampleDistances(content);
+
+    auto outputPath = testDir_ / "test_sr.dcm";
+    auto result = writer.saveToFile(content, outputPath);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(std::filesystem::exists(outputPath));
+    EXPECT_GT(std::filesystem::file_size(outputPath), 0);
+    EXPECT_TRUE(result->filePath.has_value());
+    EXPECT_EQ(result->filePath.value(), outputPath);
+}
+
+TEST_F(DicomSRWriterTest, SaveToFileWithAllMeasurements) {
+    DicomSRWriter writer;
+
+    SRContent content = sampleContent_;
+    addSampleDistances(content);
+    addSampleAngles(content);
+    addSampleAreas(content);
+    addSampleVolumes(content);
+    addSampleROIStatistics(content);
+
+    auto outputPath = testDir_ / "full_report.dcm";
+    auto result = writer.saveToFile(content, outputPath);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(std::filesystem::exists(outputPath));
+    EXPECT_EQ(result->measurementCount, 7);
+}
+
+TEST_F(DicomSRWriterTest, SaveToFileInvalidDirectory) {
+    DicomSRWriter writer;
+
+    SRContent content = sampleContent_;
+    addSampleDistances(content);
+
+    auto outputPath = std::filesystem::path("/nonexistent/directory/test.dcm");
+    auto result = writer.saveToFile(content, outputPath);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SRError::Code::FileAccessDenied);
+}
+
+TEST_F(DicomSRWriterTest, SaveToFileWithCustomOptions) {
+    DicomSRWriter writer;
+
+    SRContent content = sampleContent_;
+    addSampleDistances(content);
+
+    SRWriterOptions options;
+    options.seriesDescription = "Custom Measurement Report";
+    options.seriesNumber = 100;
+    options.manufacturer = "Test Manufacturer";
+
+    auto outputPath = testDir_ / "custom_options.dcm";
+    auto result = writer.saveToFile(content, outputPath, options);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(std::filesystem::exists(outputPath));
+}
+
+TEST_F(DicomSRWriterTest, SaveToFileWithoutSpatialCoordinates) {
+    DicomSRWriter writer;
+
+    SRContent content = sampleContent_;
+    addSampleDistances(content);
+
+    SRWriterOptions options;
+    options.includeSpatialCoordinates = false;
+
+    auto outputPath = testDir_ / "no_coords.dcm";
+    auto result = writer.saveToFile(content, outputPath, options);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(std::filesystem::exists(outputPath));
+}
+
+// =============================================================================
+// Progress Callback Tests
+// =============================================================================
+
+TEST_F(DicomSRWriterTest, ProgressCallbackCalled) {
+    DicomSRWriter writer;
+
+    std::vector<double> progressValues;
+    writer.setProgressCallback([&progressValues](double progress, const QString&) {
+        progressValues.push_back(progress);
+    });
+
+    SRContent content = sampleContent_;
+    addSampleDistances(content);
+
+    auto result = writer.createSR(content);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FALSE(progressValues.empty());
+
+    // Progress should start at 0 and end at 1
+    EXPECT_DOUBLE_EQ(progressValues.front(), 0.0);
+    EXPECT_DOUBLE_EQ(progressValues.back(), 1.0);
+
+    // Progress should be monotonically increasing
+    for (size_t i = 1; i < progressValues.size(); ++i) {
+        EXPECT_GE(progressValues[i], progressValues[i - 1]);
+    }
+}
+
+// =============================================================================
+// Utility Method Tests
+// =============================================================================
+
+TEST_F(DicomSRWriterTest, GenerateUidIsUnique) {
+    std::string uid1 = DicomSRWriter::generateUid();
+    std::string uid2 = DicomSRWriter::generateUid();
+
+    EXPECT_FALSE(uid1.empty());
+    EXPECT_FALSE(uid2.empty());
+    EXPECT_NE(uid1, uid2);
+}
+
+TEST_F(DicomSRWriterTest, GenerateUidIsValidDicomUid) {
+    std::string uid = DicomSRWriter::generateUid();
+
+    // DICOM UID should only contain digits and dots
+    for (char c : uid) {
+        EXPECT_TRUE(std::isdigit(c) || c == '.');
+    }
+
+    // DICOM UID should not start or end with a dot
+    EXPECT_NE(uid.front(), '.');
+    EXPECT_NE(uid.back(), '.');
+
+    // DICOM UID max length is 64 characters
+    EXPECT_LE(uid.length(), 64);
+}
+
+TEST_F(DicomSRWriterTest, GetSupportedSopClasses) {
+    auto sopClasses = DicomSRWriter::getSupportedSopClasses();
+
+    EXPECT_FALSE(sopClasses.empty());
+    EXPECT_GE(sopClasses.size(), 2);
+
+    // Should include Comprehensive SR
+    bool hasComprehensiveSR = false;
+    for (const auto& sopClass : sopClasses) {
+        if (sopClass == DicomSRWriter::COMPREHENSIVE_SR_SOP_CLASS) {
+            hasComprehensiveSR = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(hasComprehensiveSR);
+}
+
+TEST_F(DicomSRWriterTest, GetAnatomicRegionCodes) {
+    auto codes = DicomSRWriter::getAnatomicRegionCodes();
+
+    EXPECT_FALSE(codes.empty());
+
+    // Check that all codes are valid
+    for (const auto& code : codes) {
+        EXPECT_TRUE(code.isValid());
+        EXPECT_FALSE(code.value.empty());
+        EXPECT_FALSE(code.scheme.empty());
+        EXPECT_FALSE(code.meaning.empty());
+    }
+}
+
+// =============================================================================
+// Error Handling Tests
+// =============================================================================
+
+TEST_F(DicomSRWriterTest, SRErrorToString) {
+    SRError error;
+    error.code = SRError::Code::InvalidData;
+    error.message = "Test error message";
+
+    std::string str = error.toString();
+
+    EXPECT_FALSE(str.empty());
+    EXPECT_TRUE(str.find("Invalid data") != std::string::npos);
+    EXPECT_TRUE(str.find("Test error message") != std::string::npos);
+}
+
+TEST_F(DicomSRWriterTest, DicomCodeValidation) {
+    DicomCode validCode{"122712", "DCM", "Length"};
+    EXPECT_TRUE(validCode.isValid());
+
+    DicomCode emptyValue{"", "DCM", "Length"};
+    EXPECT_FALSE(emptyValue.isValid());
+
+    DicomCode emptyScheme{"122712", "", "Length"};
+    EXPECT_FALSE(emptyScheme.isValid());
+
+    DicomCode emptyMeaning{"122712", "DCM", ""};
+    EXPECT_FALSE(emptyMeaning.isValid());
+}
+
+// =============================================================================
+// SRValidationResult Tests
+// =============================================================================
+
+TEST_F(DicomSRWriterTest, ValidationResultMethods) {
+    SRValidationResult result;
+    result.valid = true;
+
+    EXPECT_FALSE(result.hasErrors());
+    EXPECT_FALSE(result.hasWarnings());
+
+    result.errors.push_back("Error 1");
+    EXPECT_TRUE(result.hasErrors());
+
+    result.warnings.push_back("Warning 1");
+    EXPECT_TRUE(result.hasWarnings());
+}
+
+}  // namespace
+}  // namespace dicom_viewer::services
+
+// Main function for Qt-based tests
+int main(int argc, char** argv) {
+    QCoreApplication app(argc, argv);
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

Implements DicomSRWriter class for creating DICOM Structured Reports following the TID 1500 (Measurement Report) template.

### Key Features
- Create SR documents with distance, angle, area, and volume measurements
- Support for ROI statistics (mean, stddev, min, max)
- Spatial coordinates (SCOORD3D) for 3D measurement localization
- PACS C-STORE integration for direct upload to PACS servers
- File export capability for local storage
- Comprehensive validation of SR content
- Progress callback for UI integration

### Implementation Details
- Uses DCMTK dcmsr module for SR document creation
- Follows existing export service patterns (Pimpl idiom, std::expected)
- Standard DICOM codes (SNOMED CT, UCUM) for measurements

### Files Changed
- `include/services/export/dicom_sr_writer.hpp` - Header with types and class interface
- `src/services/export/dicom_sr_writer.cpp` - Full implementation
- `tests/unit/dicom_sr_writer_test.cpp` - 24 unit tests
- `CMakeLists.txt` - Added to export_service library
- `tests/CMakeLists.txt` - Added test target

## Test Plan
- [x] All 24 unit tests pass
- [x] Build succeeds without warnings
- [ ] Manual verification with real DICOM data (optional)
- [ ] PACS C-STORE test with actual server (optional)

## Related Issues
Closes #85

🤖 Generated with [Claude Code](https://claude.ai/code)