### PR TITLE
feat(segmentation): implement Watershed segmentation algorithm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,8 @@ find_package(ITK REQUIRED COMPONENTS
     ITKVtkGlue
     ITKLevelSets
     ITKDistanceMap
+    ITKWatersheds
+    ITKConnectedComponents
 )
 
 # DCMTK for DICOM network operations
@@ -244,6 +246,7 @@ add_library(segmentation_service STATIC
     src/services/segmentation/region_growing_segmenter.cpp
     src/services/segmentation/level_set_segmenter.cpp
     src/services/segmentation/slice_interpolator.cpp
+    src/services/segmentation/watershed_segmenter.cpp
     src/services/segmentation/manual_segmentation_controller.cpp
     src/services/segmentation/label_manager.cpp
     src/services/segmentation/morphological_processor.cpp

--- a/include/services/segmentation/watershed_segmenter.hpp
+++ b/include/services/segmentation/watershed_segmenter.hpp
@@ -1,0 +1,260 @@
+#pragma once
+
+#include <array>
+#include <expected>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <itkImage.h>
+#include <itkSmartPointer.h>
+
+namespace dicom_viewer::services {
+
+struct SegmentationError;
+
+/**
+ * @brief Information about a segmented region
+ */
+struct RegionInfo {
+    /// Unique label identifier
+    unsigned long label = 0;
+
+    /// Number of voxels in the region
+    size_t voxelCount = 0;
+
+    /// Centroid coordinates (x, y, z)
+    std::array<double, 3> centroid = {0.0, 0.0, 0.0};
+};
+
+/**
+ * @brief Parameters for Watershed segmentation
+ */
+struct WatershedParameters {
+    /// Flood level (0.0 - 1.0), controls number of output regions
+    double level = 0.1;
+
+    /// Minimum basin depth threshold (0.0 - 1.0)
+    double threshold = 0.01;
+
+    /// Gaussian smoothing sigma before gradient computation
+    double gradientSigma = 1.0;
+
+    /// Use marker-based watershed (requires external markers)
+    bool useMarkers = false;
+
+    /// Minimum region size in voxels (regions smaller are merged)
+    int minimumRegionSize = 100;
+
+    /// Merge small regions into neighbors
+    bool mergeSmallRegions = true;
+
+    /**
+     * @brief Validate parameters
+     * @return true if parameters are valid
+     */
+    [[nodiscard]] bool isValid() const noexcept {
+        return level >= 0.0 && level <= 1.0 &&
+               threshold >= 0.0 && threshold <= 1.0 &&
+               gradientSigma > 0.0 &&
+               minimumRegionSize >= 0;
+    }
+};
+
+/**
+ * @brief Result of Watershed segmentation
+ */
+struct WatershedResult {
+    /// Label map with unique IDs per region
+    using LabelMapType = itk::Image<unsigned long, 3>;
+    LabelMapType::Pointer labelMap;
+
+    /// Number of distinct regions
+    size_t regionCount = 0;
+
+    /// Information about each region
+    std::vector<RegionInfo> regions;
+};
+
+/**
+ * @brief Watershed segmentation for image partitioning
+ *
+ * Implements Watershed segmentation algorithm for partitioning images into
+ * distinct regions based on topographical interpretation of gradient magnitude.
+ * Useful for cell/tissue separation and organ boundary detection.
+ *
+ * Supported modes:
+ * - Automatic Watershed: Uses gradient magnitude and flooding level
+ * - Marker-based Watershed: Uses user-provided markers for controlled segmentation
+ *
+ * @example
+ * @code
+ * WatershedSegmenter segmenter;
+ *
+ * // Automatic watershed
+ * WatershedParameters params;
+ * params.level = 0.1;
+ * params.threshold = 0.01;
+ *
+ * auto result = segmenter.segment(ctImage, params);
+ * if (result) {
+ *     auto labelMap = result->labelMap;
+ *     size_t regions = result->regionCount;
+ * }
+ *
+ * // Marker-based watershed
+ * auto markers = createMarkerImage();  // User-defined markers
+ * auto markerResult = segmenter.segmentWithMarkers(ctImage, markers, params);
+ * @endcode
+ *
+ * @trace SRS-FR-027
+ */
+class WatershedSegmenter {
+public:
+    /// Input image type (typically CT or MRI)
+    using ImageType = itk::Image<short, 3>;
+
+    /// Float image type for intermediate processing
+    using FloatImageType = itk::Image<float, 3>;
+
+    /// Label map type with unique region IDs
+    using LabelMapType = itk::Image<unsigned long, 3>;
+
+    /// Binary mask type for single region extraction
+    using BinaryMaskType = itk::Image<unsigned char, 3>;
+
+    /// Progress callback (0.0 to 1.0)
+    using ProgressCallback = std::function<void(double progress)>;
+
+    WatershedSegmenter() = default;
+    ~WatershedSegmenter() = default;
+
+    // Copyable and movable
+    WatershedSegmenter(const WatershedSegmenter&) = default;
+    WatershedSegmenter& operator=(const WatershedSegmenter&) = default;
+    WatershedSegmenter(WatershedSegmenter&&) noexcept = default;
+    WatershedSegmenter& operator=(WatershedSegmenter&&) noexcept = default;
+
+    /**
+     * @brief Apply automatic Watershed segmentation
+     *
+     * Computes gradient magnitude and applies watershed transform to partition
+     * the image into distinct regions. The level parameter controls the number
+     * of output regions - higher values produce fewer regions.
+     *
+     * @param input Input 3D image
+     * @param params Watershed parameters including level and threshold
+     * @return Watershed result with label map and region info on success
+     */
+    [[nodiscard]] std::expected<WatershedResult, SegmentationError>
+    segment(
+        ImageType::Pointer input,
+        const WatershedParameters& params
+    ) const;
+
+    /**
+     * @brief Apply marker-based Watershed segmentation
+     *
+     * Uses user-provided marker image to guide the segmentation. Each unique
+     * marker value defines a separate catchment basin. This provides more
+     * control over the segmentation result.
+     *
+     * @param input Input 3D image
+     * @param markers Marker image with unique labels for each seed region
+     * @param params Watershed parameters
+     * @return Watershed result with label map and region info on success
+     */
+    [[nodiscard]] std::expected<WatershedResult, SegmentationError>
+    segmentWithMarkers(
+        ImageType::Pointer input,
+        LabelMapType::Pointer markers,
+        const WatershedParameters& params
+    ) const;
+
+    /**
+     * @brief Extract a single region as binary mask
+     *
+     * @param labelMap Label map from watershed segmentation
+     * @param regionLabel Label value of the region to extract
+     * @return Binary mask for the specified region
+     */
+    [[nodiscard]] std::expected<BinaryMaskType::Pointer, SegmentationError>
+    extractRegion(
+        LabelMapType::Pointer labelMap,
+        unsigned long regionLabel
+    ) const;
+
+    /**
+     * @brief Set progress callback for long operations
+     * @param callback Progress callback function
+     */
+    void setProgressCallback(ProgressCallback callback);
+
+private:
+    /**
+     * @brief Compute gradient magnitude image
+     *
+     * Applies Gaussian smoothing followed by gradient magnitude filter.
+     *
+     * @param input Input image
+     * @param sigma Gaussian smoothing sigma
+     * @return Gradient magnitude image
+     */
+    [[nodiscard]] FloatImageType::Pointer computeGradientMagnitude(
+        ImageType::Pointer input,
+        double sigma
+    ) const;
+
+    /**
+     * @brief Apply watershed transform to gradient image
+     *
+     * @param gradient Gradient magnitude image
+     * @param level Flood level (0.0 - 1.0)
+     * @param threshold Minimum basin depth
+     * @return Label map from watershed
+     */
+    [[nodiscard]] LabelMapType::Pointer applyWatershed(
+        FloatImageType::Pointer gradient,
+        double level,
+        double threshold
+    ) const;
+
+    /**
+     * @brief Apply morphological watershed with markers
+     *
+     * @param gradient Gradient magnitude image
+     * @param markers Marker image
+     * @return Label map from watershed
+     */
+    [[nodiscard]] LabelMapType::Pointer applyMarkerWatershed(
+        FloatImageType::Pointer gradient,
+        LabelMapType::Pointer markers
+    ) const;
+
+    /**
+     * @brief Remove small regions and relabel
+     *
+     * @param labelMap Input label map
+     * @param minimumSize Minimum region size in voxels
+     * @return Cleaned and relabeled map
+     */
+    [[nodiscard]] LabelMapType::Pointer removeSmallRegions(
+        LabelMapType::Pointer labelMap,
+        int minimumSize
+    ) const;
+
+    /**
+     * @brief Compute region statistics
+     *
+     * @param labelMap Label map
+     * @return Vector of RegionInfo for each region
+     */
+    [[nodiscard]] std::vector<RegionInfo> computeRegionStatistics(
+        LabelMapType::Pointer labelMap
+    ) const;
+
+    ProgressCallback progressCallback_;
+};
+
+}  // namespace dicom_viewer::services

--- a/src/services/segmentation/watershed_segmenter.cpp
+++ b/src/services/segmentation/watershed_segmenter.cpp
@@ -1,0 +1,398 @@
+#include "services/segmentation/watershed_segmenter.hpp"
+#include "services/segmentation/threshold_segmenter.hpp"
+#include "core/logging.hpp"
+
+#include <itkWatershedImageFilter.h>
+#include <itkMorphologicalWatershedImageFilter.h>
+#include <itkMorphologicalWatershedFromMarkersImageFilter.h>
+#include <itkGradientMagnitudeRecursiveGaussianImageFilter.h>
+#include <itkRelabelComponentImageFilter.h>
+#include <itkBinaryThresholdImageFilter.h>
+#include <itkCastImageFilter.h>
+#include <itkImageRegionIterator.h>
+#include <itkImageRegionConstIterator.h>
+#include <itkCommand.h>
+
+#include <unordered_map>
+
+namespace dicom_viewer::services {
+
+namespace {
+auto& getLogger() {
+    static auto logger = logging::LoggerFactory::create("WatershedSegmenter");
+    return logger;
+}
+
+/**
+ * @brief ITK progress observer for callback integration
+ */
+class ProgressObserver : public itk::Command {
+public:
+    using Self = ProgressObserver;
+    using Superclass = itk::Command;
+    using Pointer = itk::SmartPointer<Self>;
+
+    itkNewMacro(Self);
+
+    void setCallback(WatershedSegmenter::ProgressCallback callback) {
+        callback_ = std::move(callback);
+    }
+
+    void Execute(itk::Object* caller, const itk::EventObject& event) override {
+        Execute(static_cast<const itk::Object*>(caller), event);
+    }
+
+    void Execute(const itk::Object* caller, const itk::EventObject& event) override {
+        if (!callback_) return;
+
+        if (itk::ProgressEvent().CheckEvent(&event)) {
+            const auto* process = dynamic_cast<const itk::ProcessObject*>(caller);
+            if (process) {
+                callback_(process->GetProgress());
+            }
+        }
+    }
+
+private:
+    WatershedSegmenter::ProgressCallback callback_;
+};
+
+}  // anonymous namespace
+
+std::expected<WatershedResult, SegmentationError>
+WatershedSegmenter::segment(
+    ImageType::Pointer input,
+    const WatershedParameters& params
+) const {
+    getLogger()->info("Watershed segmentation: level={:.3f}, threshold={:.3f}, sigma={:.2f}",
+                      params.level, params.threshold, params.gradientSigma);
+
+    if (!input) {
+        getLogger()->error("Input image is null");
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Input image is null"
+        });
+    }
+
+    if (!params.isValid()) {
+        getLogger()->error("Invalid parameters");
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidParameters,
+            "Invalid watershed parameters"
+        });
+    }
+
+    try {
+        // Compute gradient magnitude
+        auto gradient = computeGradientMagnitude(input, params.gradientSigma);
+
+        // Apply watershed transform
+        auto labelMap = applyWatershed(gradient, params.level, params.threshold);
+
+        // Remove small regions if requested
+        if (params.mergeSmallRegions && params.minimumRegionSize > 0) {
+            labelMap = removeSmallRegions(labelMap, params.minimumRegionSize);
+        }
+
+        // Compute region statistics
+        auto regions = computeRegionStatistics(labelMap);
+
+        WatershedResult result;
+        result.labelMap = labelMap;
+        result.regionCount = regions.size();
+        result.regions = std::move(regions);
+
+        getLogger()->info("Watershed complete: {} regions found", result.regionCount);
+        return result;
+    }
+    catch (const itk::ExceptionObject& e) {
+        getLogger()->error("ITK exception: {}", e.GetDescription());
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::ProcessingFailed,
+            std::string("ITK exception: ") + e.GetDescription()
+        });
+    }
+    catch (const std::exception& e) {
+        getLogger()->error("Standard exception: {}", e.what());
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InternalError,
+            std::string("Standard exception: ") + e.what()
+        });
+    }
+}
+
+std::expected<WatershedResult, SegmentationError>
+WatershedSegmenter::segmentWithMarkers(
+    ImageType::Pointer input,
+    LabelMapType::Pointer markers,
+    const WatershedParameters& params
+) const {
+    getLogger()->info("Marker-based watershed segmentation: sigma={:.2f}",
+                      params.gradientSigma);
+
+    if (!input) {
+        getLogger()->error("Input image is null");
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Input image is null"
+        });
+    }
+
+    if (!markers) {
+        getLogger()->error("Marker image is null");
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Marker image is null"
+        });
+    }
+
+    // Verify dimensions match
+    auto inputSize = input->GetLargestPossibleRegion().GetSize();
+    auto markerSize = markers->GetLargestPossibleRegion().GetSize();
+    if (inputSize != markerSize) {
+        getLogger()->error("Input and marker dimensions do not match");
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Input and marker image dimensions must match"
+        });
+    }
+
+    if (!params.isValid()) {
+        getLogger()->error("Invalid parameters");
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidParameters,
+            "Invalid watershed parameters"
+        });
+    }
+
+    try {
+        // Compute gradient magnitude
+        auto gradient = computeGradientMagnitude(input, params.gradientSigma);
+
+        // Apply marker-based watershed
+        auto labelMap = applyMarkerWatershed(gradient, markers);
+
+        // Remove small regions if requested
+        if (params.mergeSmallRegions && params.minimumRegionSize > 0) {
+            labelMap = removeSmallRegions(labelMap, params.minimumRegionSize);
+        }
+
+        // Compute region statistics
+        auto regions = computeRegionStatistics(labelMap);
+
+        WatershedResult result;
+        result.labelMap = labelMap;
+        result.regionCount = regions.size();
+        result.regions = std::move(regions);
+
+        getLogger()->info("Marker watershed complete: {} regions found", result.regionCount);
+        return result;
+    }
+    catch (const itk::ExceptionObject& e) {
+        getLogger()->error("ITK exception: {}", e.GetDescription());
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::ProcessingFailed,
+            std::string("ITK exception: ") + e.GetDescription()
+        });
+    }
+    catch (const std::exception& e) {
+        getLogger()->error("Standard exception: {}", e.what());
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InternalError,
+            std::string("Standard exception: ") + e.what()
+        });
+    }
+}
+
+std::expected<WatershedSegmenter::BinaryMaskType::Pointer, SegmentationError>
+WatershedSegmenter::extractRegion(
+    LabelMapType::Pointer labelMap,
+    unsigned long regionLabel
+) const {
+    if (!labelMap) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Label map is null"
+        });
+    }
+
+    try {
+        using ThresholdFilterType = itk::BinaryThresholdImageFilter<LabelMapType, BinaryMaskType>;
+        auto filter = ThresholdFilterType::New();
+
+        filter->SetInput(labelMap);
+        filter->SetLowerThreshold(regionLabel);
+        filter->SetUpperThreshold(regionLabel);
+        filter->SetInsideValue(1);
+        filter->SetOutsideValue(0);
+
+        filter->Update();
+
+        return filter->GetOutput();
+    }
+    catch (const itk::ExceptionObject& e) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::ProcessingFailed,
+            std::string("ITK exception: ") + e.GetDescription()
+        });
+    }
+}
+
+void WatershedSegmenter::setProgressCallback(ProgressCallback callback) {
+    progressCallback_ = std::move(callback);
+}
+
+WatershedSegmenter::FloatImageType::Pointer
+WatershedSegmenter::computeGradientMagnitude(
+    ImageType::Pointer input,
+    double sigma
+) const {
+    // Cast to float for gradient computation
+    using CastFilterType = itk::CastImageFilter<ImageType, FloatImageType>;
+    auto castFilter = CastFilterType::New();
+    castFilter->SetInput(input);
+
+    // Apply gradient magnitude filter with Gaussian smoothing
+    using GradientFilterType = itk::GradientMagnitudeRecursiveGaussianImageFilter<
+        FloatImageType, FloatImageType>;
+    auto gradientFilter = GradientFilterType::New();
+
+    gradientFilter->SetInput(castFilter->GetOutput());
+    gradientFilter->SetSigma(sigma);
+
+    if (progressCallback_) {
+        auto observer = ProgressObserver::New();
+        observer->setCallback([this](double progress) {
+            progressCallback_(progress * 0.3);  // Gradient is ~30% of total work
+        });
+        gradientFilter->AddObserver(itk::ProgressEvent(), observer);
+    }
+
+    gradientFilter->Update();
+
+    return gradientFilter->GetOutput();
+}
+
+WatershedSegmenter::LabelMapType::Pointer
+WatershedSegmenter::applyWatershed(
+    FloatImageType::Pointer gradient,
+    double level,
+    double threshold
+) const {
+    using WatershedFilterType = itk::WatershedImageFilter<FloatImageType>;
+    auto watershedFilter = WatershedFilterType::New();
+
+    watershedFilter->SetInput(gradient);
+    watershedFilter->SetLevel(level);
+    watershedFilter->SetThreshold(threshold);
+
+    if (progressCallback_) {
+        auto observer = ProgressObserver::New();
+        observer->setCallback([this](double progress) {
+            progressCallback_(0.3 + progress * 0.6);  // Watershed is ~60% of work
+        });
+        watershedFilter->AddObserver(itk::ProgressEvent(), observer);
+    }
+
+    watershedFilter->Update();
+
+    return watershedFilter->GetOutput();
+}
+
+WatershedSegmenter::LabelMapType::Pointer
+WatershedSegmenter::applyMarkerWatershed(
+    FloatImageType::Pointer gradient,
+    LabelMapType::Pointer markers
+) const {
+    using MorphoWatershedFilterType = itk::MorphologicalWatershedFromMarkersImageFilter<
+        FloatImageType, LabelMapType>;
+    auto watershedFilter = MorphoWatershedFilterType::New();
+
+    watershedFilter->SetInput(gradient);
+    watershedFilter->SetMarkerImage(markers);
+    watershedFilter->SetMarkWatershedLine(false);
+
+    if (progressCallback_) {
+        auto observer = ProgressObserver::New();
+        observer->setCallback([this](double progress) {
+            progressCallback_(0.3 + progress * 0.6);
+        });
+        watershedFilter->AddObserver(itk::ProgressEvent(), observer);
+    }
+
+    watershedFilter->Update();
+
+    return watershedFilter->GetOutput();
+}
+
+WatershedSegmenter::LabelMapType::Pointer
+WatershedSegmenter::removeSmallRegions(
+    LabelMapType::Pointer labelMap,
+    int minimumSize
+) const {
+    using RelabelFilterType = itk::RelabelComponentImageFilter<LabelMapType, LabelMapType>;
+    auto relabelFilter = RelabelFilterType::New();
+
+    relabelFilter->SetInput(labelMap);
+    relabelFilter->SetMinimumObjectSize(static_cast<unsigned long>(minimumSize));
+
+    if (progressCallback_) {
+        auto observer = ProgressObserver::New();
+        observer->setCallback([this](double progress) {
+            progressCallback_(0.9 + progress * 0.1);  // Relabel is ~10% of work
+        });
+        relabelFilter->AddObserver(itk::ProgressEvent(), observer);
+    }
+
+    relabelFilter->Update();
+
+    return relabelFilter->GetOutput();
+}
+
+std::vector<RegionInfo>
+WatershedSegmenter::computeRegionStatistics(
+    LabelMapType::Pointer labelMap
+) const {
+    std::unordered_map<unsigned long, RegionInfo> regionMap;
+
+    auto region = labelMap->GetLargestPossibleRegion();
+    itk::ImageRegionConstIterator<LabelMapType> it(labelMap, region);
+
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        unsigned long label = it.Get();
+        if (label == 0) continue;  // Skip background
+
+        auto& info = regionMap[label];
+        info.label = label;
+        info.voxelCount++;
+
+        auto idx = it.GetIndex();
+        info.centroid[0] += static_cast<double>(idx[0]);
+        info.centroid[1] += static_cast<double>(idx[1]);
+        info.centroid[2] += static_cast<double>(idx[2]);
+    }
+
+    // Finalize centroids
+    std::vector<RegionInfo> regions;
+    regions.reserve(regionMap.size());
+
+    for (auto& [label, info] : regionMap) {
+        if (info.voxelCount > 0) {
+            info.centroid[0] /= static_cast<double>(info.voxelCount);
+            info.centroid[1] /= static_cast<double>(info.voxelCount);
+            info.centroid[2] /= static_cast<double>(info.voxelCount);
+        }
+        regions.push_back(info);
+    }
+
+    // Sort by label
+    std::sort(regions.begin(), regions.end(),
+              [](const RegionInfo& a, const RegionInfo& b) {
+                  return a.label < b.label;
+              });
+
+    return regions;
+}
+
+}  // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -673,3 +673,20 @@ target_include_directories(slice_interpolator_test PRIVATE
 )
 
 gtest_discover_tests(slice_interpolator_test DISCOVERY_TIMEOUT 120)
+
+# Unit tests for Watershed Segmenter
+add_executable(watershed_segmenter_test
+    unit/watershed_segmenter_test.cpp
+)
+
+target_link_libraries(watershed_segmenter_test PRIVATE
+    segmentation_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(watershed_segmenter_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(watershed_segmenter_test DISCOVERY_TIMEOUT 120)

--- a/tests/unit/watershed_segmenter_test.cpp
+++ b/tests/unit/watershed_segmenter_test.cpp
@@ -1,0 +1,508 @@
+#include <gtest/gtest.h>
+
+#include "services/segmentation/watershed_segmenter.hpp"
+#include "services/segmentation/threshold_segmenter.hpp"
+
+#include <itkImageRegionIterator.h>
+
+using namespace dicom_viewer::services;
+
+class WatershedSegmenterTest : public ::testing::Test {
+protected:
+    using ImageType = WatershedSegmenter::ImageType;
+    using LabelMapType = WatershedSegmenter::LabelMapType;
+    using BinaryMaskType = WatershedSegmenter::BinaryMaskType;
+
+    void SetUp() override {
+        segmenter_ = std::make_unique<WatershedSegmenter>();
+    }
+
+    /**
+     * @brief Create a test image with two distinct intensity regions
+     *
+     * Creates a 20x20x10 image where:
+     * - Left half (x < 10): low intensity values (100)
+     * - Right half (x >= 10): high intensity values (200)
+     * This creates a clear boundary for watershed segmentation.
+     */
+    ImageType::Pointer createTwoRegionImage() {
+        auto image = ImageType::New();
+
+        ImageType::SizeType size;
+        size[0] = 20;
+        size[1] = 20;
+        size[2] = 10;
+
+        ImageType::IndexType start;
+        start.Fill(0);
+
+        ImageType::RegionType region;
+        region.SetSize(size);
+        region.SetIndex(start);
+
+        image->SetRegions(region);
+        image->Allocate();
+
+        itk::ImageRegionIterator<ImageType> it(image, region);
+        for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+            auto idx = it.GetIndex();
+            if (idx[0] < 10) {
+                it.Set(100);  // Low intensity region
+            } else {
+                it.Set(200);  // High intensity region
+            }
+        }
+
+        return image;
+    }
+
+    /**
+     * @brief Create a test image with gradient from left to right
+     *
+     * Creates a 20x20x10 image where pixel values vary from 0 to 255
+     * based on x coordinate.
+     */
+    ImageType::Pointer createGradientImage() {
+        auto image = ImageType::New();
+
+        ImageType::SizeType size;
+        size[0] = 20;
+        size[1] = 20;
+        size[2] = 10;
+
+        ImageType::IndexType start;
+        start.Fill(0);
+
+        ImageType::RegionType region;
+        region.SetSize(size);
+        region.SetIndex(start);
+
+        image->SetRegions(region);
+        image->Allocate();
+
+        itk::ImageRegionIterator<ImageType> it(image, region);
+        for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+            auto idx = it.GetIndex();
+            // Gradient from 0 to 255 based on x coordinate
+            it.Set(static_cast<short>(idx[0] * 255 / 19));
+        }
+
+        return image;
+    }
+
+    /**
+     * @brief Create marker image for marker-based watershed
+     *
+     * Creates markers for two regions at opposite corners.
+     */
+    LabelMapType::Pointer createMarkerImage() {
+        auto markers = LabelMapType::New();
+
+        LabelMapType::SizeType size;
+        size[0] = 20;
+        size[1] = 20;
+        size[2] = 10;
+
+        LabelMapType::IndexType start;
+        start.Fill(0);
+
+        LabelMapType::RegionType region;
+        region.SetSize(size);
+        region.SetIndex(start);
+
+        markers->SetRegions(region);
+        markers->Allocate();
+        markers->FillBuffer(0);
+
+        // Create two marker regions
+        LabelMapType::IndexType idx1 = {{2, 2, 5}};
+        LabelMapType::IndexType idx2 = {{17, 17, 5}};
+
+        // Small marker regions (3x3x3)
+        for (int dx = -1; dx <= 1; ++dx) {
+            for (int dy = -1; dy <= 1; ++dy) {
+                for (int dz = -1; dz <= 1; ++dz) {
+                    LabelMapType::IndexType p1 = {{idx1[0] + dx, idx1[1] + dy, idx1[2] + dz}};
+                    LabelMapType::IndexType p2 = {{idx2[0] + dx, idx2[1] + dy, idx2[2] + dz}};
+
+                    if (region.IsInside(p1)) {
+                        markers->SetPixel(p1, 1);
+                    }
+                    if (region.IsInside(p2)) {
+                        markers->SetPixel(p2, 2);
+                    }
+                }
+            }
+        }
+
+        return markers;
+    }
+
+    /**
+     * @brief Count unique labels in label map (excluding background 0)
+     */
+    size_t countUniqueLabels(LabelMapType::Pointer labelMap) {
+        std::set<unsigned long> labels;
+        itk::ImageRegionConstIterator<LabelMapType> it(
+            labelMap, labelMap->GetLargestPossibleRegion()
+        );
+        for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+            if (it.Get() != 0) {
+                labels.insert(it.Get());
+            }
+        }
+        return labels.size();
+    }
+
+    /**
+     * @brief Count non-zero pixels in binary mask
+     */
+    int countNonZeroPixels(BinaryMaskType::Pointer mask) {
+        int count = 0;
+        itk::ImageRegionConstIterator<BinaryMaskType> it(
+            mask, mask->GetLargestPossibleRegion()
+        );
+        for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+            if (it.Get() != 0) {
+                ++count;
+            }
+        }
+        return count;
+    }
+
+    std::unique_ptr<WatershedSegmenter> segmenter_;
+};
+
+// Basic functionality tests
+TEST_F(WatershedSegmenterTest, SegmentReturnsValidResult) {
+    auto image = createTwoRegionImage();
+
+    WatershedParameters params;
+    params.level = 0.1;
+    params.threshold = 0.01;
+    params.gradientSigma = 1.0;
+
+    auto result = segmenter_->segment(image, params);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NE(result->labelMap, nullptr);
+    EXPECT_GT(result->regionCount, 0u);
+}
+
+TEST_F(WatershedSegmenterTest, SegmentHandlesNullInput) {
+    WatershedParameters params;
+    params.level = 0.1;
+
+    auto result = segmenter_->segment(nullptr, params);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+TEST_F(WatershedSegmenterTest, SegmentRejectsInvalidParameters) {
+    auto image = createTwoRegionImage();
+
+    // Level out of range
+    WatershedParameters invalidParams;
+    invalidParams.level = 1.5;  // Invalid: should be 0-1
+
+    auto result = segmenter_->segment(image, invalidParams);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidParameters);
+}
+
+TEST_F(WatershedSegmenterTest, SegmentProducesMultipleRegions) {
+    auto image = createTwoRegionImage();
+
+    WatershedParameters params;
+    params.level = 0.5;  // Higher level = fewer regions
+    params.threshold = 0.001;
+    params.gradientSigma = 0.5;
+
+    auto result = segmenter_->segment(image, params);
+
+    ASSERT_TRUE(result.has_value());
+    // Should produce at least 1 region (watershed always produces some regions)
+    EXPECT_GE(result->regionCount, 1u);
+    EXPECT_EQ(result->regions.size(), result->regionCount);
+}
+
+TEST_F(WatershedSegmenterTest, SegmentWithHighLevelProducesFewerRegions) {
+    auto image = createGradientImage();
+
+    WatershedParameters lowLevelParams;
+    lowLevelParams.level = 0.01;
+    lowLevelParams.threshold = 0.001;
+
+    WatershedParameters highLevelParams;
+    highLevelParams.level = 0.5;
+    highLevelParams.threshold = 0.001;
+
+    auto lowLevelResult = segmenter_->segment(image, lowLevelParams);
+    auto highLevelResult = segmenter_->segment(image, highLevelParams);
+
+    ASSERT_TRUE(lowLevelResult.has_value());
+    ASSERT_TRUE(highLevelResult.has_value());
+
+    // Higher level should produce fewer or equal regions
+    EXPECT_LE(highLevelResult->regionCount, lowLevelResult->regionCount);
+}
+
+// Marker-based watershed tests
+TEST_F(WatershedSegmenterTest, MarkerWatershedReturnsValidResult) {
+    auto image = createTwoRegionImage();
+    auto markers = createMarkerImage();
+
+    WatershedParameters params;
+    params.gradientSigma = 1.0;
+
+    auto result = segmenter_->segmentWithMarkers(image, markers, params);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NE(result->labelMap, nullptr);
+    EXPECT_GE(result->regionCount, 1u);
+}
+
+TEST_F(WatershedSegmenterTest, MarkerWatershedHandlesNullInput) {
+    auto markers = createMarkerImage();
+    WatershedParameters params;
+
+    auto result = segmenter_->segmentWithMarkers(nullptr, markers, params);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+TEST_F(WatershedSegmenterTest, MarkerWatershedHandlesNullMarkers) {
+    auto image = createTwoRegionImage();
+    WatershedParameters params;
+
+    auto result = segmenter_->segmentWithMarkers(image, nullptr, params);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+TEST_F(WatershedSegmenterTest, MarkerWatershedRejectsDimensionMismatch) {
+    auto image = createTwoRegionImage();
+
+    // Create markers with different size
+    auto wrongMarkers = LabelMapType::New();
+    LabelMapType::SizeType size;
+    size[0] = 10;  // Different from image (20)
+    size[1] = 10;
+    size[2] = 5;
+
+    LabelMapType::IndexType start;
+    start.Fill(0);
+
+    LabelMapType::RegionType region;
+    region.SetSize(size);
+    region.SetIndex(start);
+
+    wrongMarkers->SetRegions(region);
+    wrongMarkers->Allocate();
+    wrongMarkers->FillBuffer(0);
+
+    WatershedParameters params;
+
+    auto result = segmenter_->segmentWithMarkers(image, wrongMarkers, params);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+// Region extraction tests
+TEST_F(WatershedSegmenterTest, ExtractRegionReturnsValidMask) {
+    auto image = createTwoRegionImage();
+
+    WatershedParameters params;
+    params.level = 0.1;
+
+    auto segResult = segmenter_->segment(image, params);
+    ASSERT_TRUE(segResult.has_value());
+    ASSERT_GT(segResult->regions.size(), 0u);
+
+    // Extract the first region
+    unsigned long firstLabel = segResult->regions[0].label;
+    auto extractResult = segmenter_->extractRegion(segResult->labelMap, firstLabel);
+
+    ASSERT_TRUE(extractResult.has_value());
+    EXPECT_NE(extractResult.value(), nullptr);
+
+    // Should have some non-zero pixels
+    int nonZeroCount = countNonZeroPixels(extractResult.value());
+    EXPECT_GT(nonZeroCount, 0);
+}
+
+TEST_F(WatershedSegmenterTest, ExtractRegionHandlesNullInput) {
+    auto result = segmenter_->extractRegion(nullptr, 1);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+TEST_F(WatershedSegmenterTest, ExtractRegionHandlesNonexistentLabel) {
+    auto image = createTwoRegionImage();
+
+    WatershedParameters params;
+    params.level = 0.1;
+
+    auto segResult = segmenter_->segment(image, params);
+    ASSERT_TRUE(segResult.has_value());
+
+    // Extract with a label that doesn't exist
+    auto extractResult = segmenter_->extractRegion(segResult->labelMap, 999999);
+
+    // Should succeed but return empty mask
+    ASSERT_TRUE(extractResult.has_value());
+    int nonZeroCount = countNonZeroPixels(extractResult.value());
+    EXPECT_EQ(nonZeroCount, 0);
+}
+
+// Region statistics tests
+TEST_F(WatershedSegmenterTest, RegionInfoContainsValidData) {
+    auto image = createTwoRegionImage();
+
+    WatershedParameters params;
+    params.level = 0.1;
+
+    auto result = segmenter_->segment(image, params);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_GT(result->regions.size(), 0u);
+
+    for (const auto& region : result->regions) {
+        EXPECT_GT(region.label, 0u);
+        EXPECT_GT(region.voxelCount, 0u);
+
+        // Centroids should be within image bounds
+        EXPECT_GE(region.centroid[0], 0.0);
+        EXPECT_LT(region.centroid[0], 20.0);
+        EXPECT_GE(region.centroid[1], 0.0);
+        EXPECT_LT(region.centroid[1], 20.0);
+        EXPECT_GE(region.centroid[2], 0.0);
+        EXPECT_LT(region.centroid[2], 10.0);
+    }
+}
+
+// Small region removal tests
+TEST_F(WatershedSegmenterTest, SmallRegionsAreRemoved) {
+    auto image = createGradientImage();
+
+    // First run without small region removal
+    WatershedParameters paramsNoRemoval;
+    paramsNoRemoval.level = 0.01;
+    paramsNoRemoval.mergeSmallRegions = false;
+
+    auto resultNoRemoval = segmenter_->segment(image, paramsNoRemoval);
+    ASSERT_TRUE(resultNoRemoval.has_value());
+
+    // Then run with small region removal (high minimum size)
+    WatershedParameters paramsWithRemoval;
+    paramsWithRemoval.level = 0.01;
+    paramsWithRemoval.mergeSmallRegions = true;
+    paramsWithRemoval.minimumRegionSize = 500;  // High threshold
+
+    auto resultWithRemoval = segmenter_->segment(image, paramsWithRemoval);
+    ASSERT_TRUE(resultWithRemoval.has_value());
+
+    // Should have fewer or equal regions after removal
+    EXPECT_LE(resultWithRemoval->regionCount, resultNoRemoval->regionCount);
+}
+
+// Parameter validation tests
+TEST_F(WatershedSegmenterTest, ParametersValidationWorks) {
+    WatershedParameters valid;
+    valid.level = 0.5;
+    valid.threshold = 0.01;
+    valid.gradientSigma = 1.0;
+    EXPECT_TRUE(valid.isValid());
+
+    WatershedParameters boundaryLow;
+    boundaryLow.level = 0.0;  // Boundary value
+    boundaryLow.threshold = 0.0;
+    boundaryLow.gradientSigma = 0.1;
+    EXPECT_TRUE(boundaryLow.isValid());
+
+    WatershedParameters boundaryHigh;
+    boundaryHigh.level = 1.0;  // Boundary value
+    boundaryHigh.threshold = 1.0;
+    boundaryHigh.gradientSigma = 10.0;
+    EXPECT_TRUE(boundaryHigh.isValid());
+
+    WatershedParameters invalidLevel;
+    invalidLevel.level = -0.1;  // Invalid
+    EXPECT_FALSE(invalidLevel.isValid());
+
+    WatershedParameters invalidLevelHigh;
+    invalidLevelHigh.level = 1.1;  // Invalid
+    EXPECT_FALSE(invalidLevelHigh.isValid());
+
+    WatershedParameters invalidSigma;
+    invalidSigma.level = 0.1;
+    invalidSigma.gradientSigma = 0.0;  // Invalid
+    EXPECT_FALSE(invalidSigma.isValid());
+
+    WatershedParameters invalidSigmaNegative;
+    invalidSigmaNegative.level = 0.1;
+    invalidSigmaNegative.gradientSigma = -1.0;  // Invalid
+    EXPECT_FALSE(invalidSigmaNegative.isValid());
+}
+
+// Progress callback tests
+TEST_F(WatershedSegmenterTest, ProgressCallbackIsCalled) {
+    auto image = createTwoRegionImage();
+
+    bool callbackCalled = false;
+    segmenter_->setProgressCallback([&callbackCalled](double /*progress*/) {
+        callbackCalled = true;
+    });
+
+    WatershedParameters params;
+    params.level = 0.1;
+
+    auto result = segmenter_->segment(image, params);
+
+    ASSERT_TRUE(result.has_value());
+    // Progress callback may or may not be called depending on filter implementation
+    // This test ensures no crash occurs
+}
+
+// Large volume test (performance check)
+TEST_F(WatershedSegmenterTest, HandlesLargerVolume) {
+    // Create a larger test image (50x50x20)
+    auto image = ImageType::New();
+
+    ImageType::SizeType size;
+    size[0] = 50;
+    size[1] = 50;
+    size[2] = 20;
+
+    ImageType::IndexType start;
+    start.Fill(0);
+
+    ImageType::RegionType region;
+    region.SetSize(size);
+    region.SetIndex(start);
+
+    image->SetRegions(region);
+    image->Allocate();
+
+    // Fill with checkerboard pattern
+    itk::ImageRegionIterator<ImageType> it(image, region);
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        auto idx = it.GetIndex();
+        bool checker = ((idx[0] / 10) + (idx[1] / 10) + (idx[2] / 5)) % 2 == 0;
+        it.Set(checker ? 100 : 200);
+    }
+
+    WatershedParameters params;
+    params.level = 0.5;
+    params.gradientSigma = 2.0;
+
+    auto result = segmenter_->segment(image, params);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_GE(result->regionCount, 1u);
+}


### PR DESCRIPTION
## Summary
- Implement `WatershedSegmenter` class for image partitioning using ITK Watershed filters
- Add automatic and marker-based watershed segmentation modes
- Include region statistics computation and small region removal
- Provide comprehensive unit test coverage (17 test cases)

## Technical Details
- Uses ITK's `WatershedImageFilter` for automatic segmentation
- Uses `MorphologicalWatershedFromMarkersImageFilter` for marker-based approach
- Implements `RelabelComponentImageFilter` for small region removal
- Level parameter (0-1) controls segmentation granularity
- Full support for 3D medical imaging data (CT/MRI)

## Test Plan
- [x] Build passes (`cmake --build build/`)
- [x] All 17 unit tests pass (`ctest -R WatershedSegmenter`)
- [x] Tests cover: null input, invalid parameters, region extraction, marker-based mode
- [x] Performance test with 50x50x20 volume

## Files Changed
- `include/services/segmentation/watershed_segmenter.hpp` - Header with public API
- `src/services/segmentation/watershed_segmenter.cpp` - Implementation
- `tests/unit/watershed_segmenter_test.cpp` - Unit tests
- `CMakeLists.txt` - Added ITKWatersheds and ITKConnectedComponents modules
- `tests/CMakeLists.txt` - Added test target

Closes #78