### PR TITLE
refactor(build): integrate pacs_system library into CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,8 +137,121 @@ find_package(ITK REQUIRED COMPONENTS
     ITKConnectedComponents
 )
 
-# DCMTK for DICOM network operations
+# DCMTK for DICOM network operations (legacy, being migrated to pacs_system)
 find_package(DCMTK REQUIRED)
+
+# pacs_system for DICOM network operations (migration in progress)
+# Option to enable pacs_system integration
+option(USE_PACS_SYSTEM "Use pacs_system library for DICOM network operations" OFF)
+
+if(USE_PACS_SYSTEM)
+    # pacs_system local path configuration
+    # Set PACS_SYSTEM_ROOT to the pacs_system source directory
+    if(NOT PACS_SYSTEM_ROOT)
+        # Default to sibling directory
+        set(PACS_SYSTEM_ROOT "${CMAKE_SOURCE_DIR}/../pacs_system" CACHE PATH "Path to pacs_system source")
+    endif()
+
+    if(NOT PACS_SYSTEM_BUILD_DIR)
+        set(PACS_SYSTEM_BUILD_DIR "${PACS_SYSTEM_ROOT}/build" CACHE PATH "Path to pacs_system build directory")
+    endif()
+
+    if(EXISTS "${PACS_SYSTEM_ROOT}" AND EXISTS "${PACS_SYSTEM_BUILD_DIR}/lib")
+        message(STATUS "Found pacs_system at: ${PACS_SYSTEM_ROOT}")
+        message(STATUS "pacs_system build directory: ${PACS_SYSTEM_BUILD_DIR}")
+
+        # pacs_system include directory
+        set(PACS_SYSTEM_INCLUDE_DIR "${PACS_SYSTEM_ROOT}/include")
+
+        # pacs_system library directory
+        set(PACS_SYSTEM_LIB_DIR "${PACS_SYSTEM_BUILD_DIR}/lib")
+
+        # Find required pacs_system libraries
+        find_library(PACS_CORE_LIB pacs_core HINTS ${PACS_SYSTEM_LIB_DIR})
+        find_library(PACS_NETWORK_LIB pacs_network HINTS ${PACS_SYSTEM_LIB_DIR})
+        find_library(PACS_SERVICES_LIB pacs_services HINTS ${PACS_SYSTEM_LIB_DIR})
+        find_library(PACS_ENCODING_LIB pacs_encoding HINTS ${PACS_SYSTEM_LIB_DIR})
+        find_library(PACS_INTEGRATION_LIB pacs_integration HINTS ${PACS_SYSTEM_LIB_DIR})
+
+        # Find dependency libraries from pacs_system
+        find_library(CONTAINER_SYSTEM_LIB container_system HINTS ${PACS_SYSTEM_LIB_DIR})
+        find_library(NETWORK_SYSTEM_LIB NetworkSystem HINTS ${PACS_SYSTEM_LIB_DIR})
+        find_library(LOGGER_SYSTEM_LIB LoggerSystem HINTS ${PACS_SYSTEM_LIB_DIR})
+
+        if(PACS_CORE_LIB AND PACS_NETWORK_LIB AND PACS_SERVICES_LIB)
+            set(PACS_SYSTEM_FOUND TRUE)
+            message(STATUS "pacs_system libraries found:")
+            message(STATUS "  - pacs_core: ${PACS_CORE_LIB}")
+            message(STATUS "  - pacs_network: ${PACS_NETWORK_LIB}")
+            message(STATUS "  - pacs_services: ${PACS_SERVICES_LIB}")
+
+            # Create imported target for pacs_system
+            add_library(pacs::core STATIC IMPORTED)
+            set_target_properties(pacs::core PROPERTIES
+                IMPORTED_LOCATION "${PACS_CORE_LIB}"
+                INTERFACE_INCLUDE_DIRECTORIES "${PACS_SYSTEM_INCLUDE_DIR}"
+            )
+
+            add_library(pacs::network STATIC IMPORTED)
+            set_target_properties(pacs::network PROPERTIES
+                IMPORTED_LOCATION "${PACS_NETWORK_LIB}"
+                INTERFACE_INCLUDE_DIRECTORIES "${PACS_SYSTEM_INCLUDE_DIR}"
+            )
+
+            add_library(pacs::services STATIC IMPORTED)
+            set_target_properties(pacs::services PROPERTIES
+                IMPORTED_LOCATION "${PACS_SERVICES_LIB}"
+                INTERFACE_INCLUDE_DIRECTORIES "${PACS_SYSTEM_INCLUDE_DIR}"
+            )
+
+            if(PACS_ENCODING_LIB)
+                add_library(pacs::encoding STATIC IMPORTED)
+                set_target_properties(pacs::encoding PROPERTIES
+                    IMPORTED_LOCATION "${PACS_ENCODING_LIB}"
+                    INTERFACE_INCLUDE_DIRECTORIES "${PACS_SYSTEM_INCLUDE_DIR}"
+                )
+            endif()
+
+            if(PACS_INTEGRATION_LIB)
+                add_library(pacs::integration STATIC IMPORTED)
+                set_target_properties(pacs::integration PROPERTIES
+                    IMPORTED_LOCATION "${PACS_INTEGRATION_LIB}"
+                    INTERFACE_INCLUDE_DIRECTORIES "${PACS_SYSTEM_INCLUDE_DIR}"
+                )
+            endif()
+
+            # Create wrapper targets for dependencies
+            if(CONTAINER_SYSTEM_LIB)
+                add_library(pacs::container_system STATIC IMPORTED)
+                set_target_properties(pacs::container_system PROPERTIES
+                    IMPORTED_LOCATION "${CONTAINER_SYSTEM_LIB}"
+                )
+            endif()
+
+            if(NETWORK_SYSTEM_LIB)
+                add_library(pacs::network_system STATIC IMPORTED)
+                set_target_properties(pacs::network_system PROPERTIES
+                    IMPORTED_LOCATION "${NETWORK_SYSTEM_LIB}"
+                )
+            endif()
+
+            if(LOGGER_SYSTEM_LIB)
+                add_library(pacs::logger_system STATIC IMPORTED)
+                set_target_properties(pacs::logger_system PROPERTIES
+                    IMPORTED_LOCATION "${LOGGER_SYSTEM_LIB}"
+                )
+            endif()
+
+            add_compile_definitions(DICOM_VIEWER_USE_PACS_SYSTEM)
+        else()
+            set(PACS_SYSTEM_FOUND FALSE)
+            message(WARNING "pacs_system libraries not found. Falling back to DCMTK only.")
+        endif()
+    else()
+        set(PACS_SYSTEM_FOUND FALSE)
+        message(WARNING "pacs_system not found at ${PACS_SYSTEM_ROOT}. Falling back to DCMTK only.")
+    endif()
+endif()
 
 find_package(spdlog REQUIRED)
 find_package(fmt REQUIRED)
@@ -289,6 +402,13 @@ target_include_directories(pacs_service PUBLIC
     ${DCMTK_INCLUDE_DIRS}
 )
 
+# Add pacs_system include directories if available
+if(USE_PACS_SYSTEM AND PACS_SYSTEM_FOUND)
+    target_include_directories(pacs_service PUBLIC
+        ${PACS_SYSTEM_INCLUDE_DIR}
+    )
+endif()
+
 target_link_directories(pacs_service PUBLIC
     ${DCMTK_LIBRARY_DIRS}
     /opt/homebrew/lib
@@ -300,6 +420,38 @@ target_link_libraries(pacs_service PUBLIC
     fmt::fmt
     Qt6::Core
 )
+
+# Link pacs_system libraries if available (for gradual migration)
+if(USE_PACS_SYSTEM AND PACS_SYSTEM_FOUND)
+    target_link_libraries(pacs_service PUBLIC
+        pacs::core
+        pacs::network
+        pacs::services
+    )
+
+    if(TARGET pacs::encoding)
+        target_link_libraries(pacs_service PUBLIC pacs::encoding)
+    endif()
+
+    if(TARGET pacs::integration)
+        target_link_libraries(pacs_service PUBLIC pacs::integration)
+    endif()
+
+    # Link pacs_system dependencies
+    if(TARGET pacs::container_system)
+        target_link_libraries(pacs_service PUBLIC pacs::container_system)
+    endif()
+
+    if(TARGET pacs::network_system)
+        target_link_libraries(pacs_service PUBLIC pacs::network_system)
+    endif()
+
+    if(TARGET pacs::logger_system)
+        target_link_libraries(pacs_service PUBLIC pacs::logger_system)
+    endif()
+
+    message(STATUS "pacs_service: pacs_system integration enabled")
+endif()
 
 add_library(export_service STATIC
     src/services/export/report_generator.cpp
@@ -313,6 +465,13 @@ target_include_directories(export_service PUBLIC
     ${CMAKE_SOURCE_DIR}/include
     ${DCMTK_INCLUDE_DIRS}
 )
+
+# Add pacs_system include directories if available
+if(USE_PACS_SYSTEM AND PACS_SYSTEM_FOUND)
+    target_include_directories(export_service PUBLIC
+        ${PACS_SYSTEM_INCLUDE_DIR}
+    )
+endif()
 
 target_link_directories(export_service PUBLIC
     ${DCMTK_LIBRARY_DIRS}
@@ -332,6 +491,8 @@ target_link_libraries(export_service PUBLIC
     ${VTK_LIBRARIES}
     ${DCMTK_LIBRARIES}
 )
+
+# Note: pacs_system libraries are linked through pacs_service dependency
 
 # Controller library
 add_library(dicom_viewer_controller STATIC
@@ -412,3 +573,25 @@ install(TARGETS dicom_viewer
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
 )
+
+# Build configuration summary
+message(STATUS "")
+message(STATUS "=== dicom_viewer Build Configuration ===")
+message(STATUS "Version: ${PROJECT_VERSION}")
+message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+message(STATUS "C++ Standard: ${CMAKE_CXX_STANDARD}")
+message(STATUS "")
+message(STATUS "DICOM Network Libraries:")
+message(STATUS "  DCMTK: Found (legacy)")
+if(USE_PACS_SYSTEM)
+    if(PACS_SYSTEM_FOUND)
+        message(STATUS "  pacs_system: Found and enabled")
+        message(STATUS "    Root: ${PACS_SYSTEM_ROOT}")
+        message(STATUS "    Build: ${PACS_SYSTEM_BUILD_DIR}")
+    else()
+        message(STATUS "  pacs_system: NOT FOUND (USE_PACS_SYSTEM=ON but library not available)")
+    endif()
+else()
+    message(STATUS "  pacs_system: Disabled (USE_PACS_SYSTEM=OFF)")
+endif()
+message(STATUS "")

--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@
 | **GUI** | Qt | 6.5+ |
 | **Image Processing** | ITK | 5.4+ |
 | **Visualization** | VTK | 9.3+ |
-| **DICOM Network** | DCMTK | 3.6.8+ |
+| **DICOM Network** | DCMTK / pacs_system | 3.6.8+ / Latest |
 | **DICOM I/O** | GDCM (via ITK) | Latest |
+
+> **Note**: DICOM network operations are being migrated from DCMTK to [pacs_system](https://github.com/kcenon/pacs_system). See [Build Options](#build-options) for configuration.
 
 ## Architecture
 
@@ -167,6 +169,44 @@ mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 cmake --build . --parallel
 ```
+
+### Build Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `BUILD_TESTS` | ON | Build unit tests |
+| `BUILD_DOCS` | OFF | Build documentation |
+| `USE_PACS_SYSTEM` | OFF | Enable pacs_system library integration (migration in progress) |
+
+### pacs_system Integration (Optional)
+
+The project supports optional integration with [pacs_system](https://github.com/kcenon/pacs_system) library for DICOM network operations. This is part of an ongoing migration from DCMTK.
+
+To enable pacs_system integration:
+
+```bash
+# Build pacs_system first (sibling directory)
+cd ../pacs_system
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+cmake --build . --parallel
+
+# Build dicom_viewer with pacs_system
+cd ../../dicom_viewer
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_PACS_SYSTEM=ON
+cmake --build . --parallel
+```
+
+Custom pacs_system location:
+
+```bash
+cmake .. -DUSE_PACS_SYSTEM=ON \
+  -DPACS_SYSTEM_ROOT=/path/to/pacs_system \
+  -DPACS_SYSTEM_BUILD_DIR=/path/to/pacs_system/build
+```
+
+> **Note**: When `USE_PACS_SYSTEM=ON`, both DCMTK and pacs_system are linked to allow gradual migration. The `DICOM_VIEWER_USE_PACS_SYSTEM` preprocessor macro is defined when pacs_system is enabled.
 
 ### Run
 


### PR DESCRIPTION
## Summary

Integrate pacs_system library into the CMake build system as the first step of the DCMTK migration. This establishes the foundation for gradually transitioning DICOM network operations from DCMTK to pacs_system.

- Add optional `USE_PACS_SYSTEM` CMake option with imported targets
- Configure dual library support for incremental migration
- Update build documentation with integration guide

Closes #111

## What Changed

### CMakeLists.txt
- Add `USE_PACS_SYSTEM` option (default: OFF)
- Add `PACS_SYSTEM_ROOT` and `PACS_SYSTEM_BUILD_DIR` cache variables
- Create imported targets: `pacs::core`, `pacs::network`, `pacs::services`, `pacs::encoding`, `pacs::integration`
- Link pacs_system libraries to `pacs_service` and `export_service` when enabled
- Define `DICOM_VIEWER_USE_PACS_SYSTEM` preprocessor macro
- Add build configuration summary section

### README.md
- Add Build Options table documenting CMake options
- Add pacs_system Integration section with configuration examples
- Update Technology Stack to reflect dual DCMTK/pacs_system support

## Test Plan

- [x] Build with `USE_PACS_SYSTEM=OFF` (DCMTK only) - SUCCESS
- [x] Build with `USE_PACS_SYSTEM=ON` (both libraries) - SUCCESS
- [x] CMake finds pacs_system libraries correctly
- [x] Build configuration summary displays correct status