### PR TITLE
refactor(pacs): migrate DicomEchoSCU from DCMTK to pacs_system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,24 @@ if(USE_PACS_SYSTEM)
         set(PACS_SYSTEM_BUILD_DIR "${PACS_SYSTEM_ROOT}/build" CACHE PATH "Path to pacs_system build directory")
     endif()
 
+    # common_system is a dependency of pacs_system
+    if(NOT COMMON_SYSTEM_ROOT)
+        set(COMMON_SYSTEM_ROOT "${CMAKE_SOURCE_DIR}/../common_system" CACHE PATH "Path to common_system source")
+    endif()
+    if(EXISTS "${COMMON_SYSTEM_ROOT}/include")
+        set(COMMON_SYSTEM_INCLUDE_DIR "${COMMON_SYSTEM_ROOT}/include")
+        message(STATUS "Found common_system at: ${COMMON_SYSTEM_ROOT}")
+    endif()
+
+    # thread_system is a dependency of pacs_system
+    if(NOT THREAD_SYSTEM_ROOT)
+        set(THREAD_SYSTEM_ROOT "${CMAKE_SOURCE_DIR}/../thread_system" CACHE PATH "Path to thread_system source")
+    endif()
+    if(EXISTS "${THREAD_SYSTEM_ROOT}/include")
+        set(THREAD_SYSTEM_INCLUDE_DIR "${THREAD_SYSTEM_ROOT}/include")
+        message(STATUS "Found thread_system at: ${THREAD_SYSTEM_ROOT}")
+    endif()
+
     if(EXISTS "${PACS_SYSTEM_ROOT}" AND EXISTS "${PACS_SYSTEM_BUILD_DIR}/lib")
         message(STATUS "Found pacs_system at: ${PACS_SYSTEM_ROOT}")
         message(STATUS "pacs_system build directory: ${PACS_SYSTEM_BUILD_DIR}")
@@ -185,30 +203,39 @@ if(USE_PACS_SYSTEM)
             message(STATUS "  - pacs_network: ${PACS_NETWORK_LIB}")
             message(STATUS "  - pacs_services: ${PACS_SERVICES_LIB}")
 
+            # Build include directories list for pacs_system
+            set(PACS_INCLUDE_DIRS "${PACS_SYSTEM_INCLUDE_DIR}")
+            if(COMMON_SYSTEM_INCLUDE_DIR)
+                list(APPEND PACS_INCLUDE_DIRS "${COMMON_SYSTEM_INCLUDE_DIR}")
+            endif()
+            if(THREAD_SYSTEM_INCLUDE_DIR)
+                list(APPEND PACS_INCLUDE_DIRS "${THREAD_SYSTEM_INCLUDE_DIR}")
+            endif()
+
             # Create imported target for pacs_system
             add_library(pacs::core STATIC IMPORTED)
             set_target_properties(pacs::core PROPERTIES
                 IMPORTED_LOCATION "${PACS_CORE_LIB}"
-                INTERFACE_INCLUDE_DIRECTORIES "${PACS_SYSTEM_INCLUDE_DIR}"
+                INTERFACE_INCLUDE_DIRECTORIES "${PACS_INCLUDE_DIRS}"
             )
 
             add_library(pacs::network STATIC IMPORTED)
             set_target_properties(pacs::network PROPERTIES
                 IMPORTED_LOCATION "${PACS_NETWORK_LIB}"
-                INTERFACE_INCLUDE_DIRECTORIES "${PACS_SYSTEM_INCLUDE_DIR}"
+                INTERFACE_INCLUDE_DIRECTORIES "${PACS_INCLUDE_DIRS}"
             )
 
             add_library(pacs::services STATIC IMPORTED)
             set_target_properties(pacs::services PROPERTIES
                 IMPORTED_LOCATION "${PACS_SERVICES_LIB}"
-                INTERFACE_INCLUDE_DIRECTORIES "${PACS_SYSTEM_INCLUDE_DIR}"
+                INTERFACE_INCLUDE_DIRECTORIES "${PACS_INCLUDE_DIRS}"
             )
 
             if(PACS_ENCODING_LIB)
                 add_library(pacs::encoding STATIC IMPORTED)
                 set_target_properties(pacs::encoding PROPERTIES
                     IMPORTED_LOCATION "${PACS_ENCODING_LIB}"
-                    INTERFACE_INCLUDE_DIRECTORIES "${PACS_SYSTEM_INCLUDE_DIR}"
+                    INTERFACE_INCLUDE_DIRECTORIES "${PACS_INCLUDE_DIRS}"
                 )
             endif()
 
@@ -216,7 +243,7 @@ if(USE_PACS_SYSTEM)
                 add_library(pacs::integration STATIC IMPORTED)
                 set_target_properties(pacs::integration PROPERTIES
                     IMPORTED_LOCATION "${PACS_INTEGRATION_LIB}"
-                    INTERFACE_INCLUDE_DIRECTORIES "${PACS_SYSTEM_INCLUDE_DIR}"
+                    INTERFACE_INCLUDE_DIRECTORIES "${PACS_INCLUDE_DIRS}"
                 )
             endif()
 

--- a/src/services/pacs/dicom_echo_scu.cpp
+++ b/src/services/pacs/dicom_echo_scu.cpp
@@ -4,15 +4,256 @@
 #include <chrono>
 #include <mutex>
 
-// DCMTK headers
+#include <spdlog/spdlog.h>
+
+#ifdef DICOM_VIEWER_USE_PACS_SYSTEM
+// pacs_system headers for new implementation
+#include <pacs/core/result.hpp>
+#include <pacs/network/association.hpp>
+#include <pacs/network/dimse/dimse_message.hpp>
+#include <pacs/network/dimse/status_codes.hpp>
+#else
+// DCMTK headers for legacy implementation
 #include <dcmtk/config/osconfig.h>
 #include <dcmtk/dcmnet/assoc.h>
 #include <dcmtk/dcmnet/dimse.h>
 #include <dcmtk/dcmnet/diutil.h>
-
-#include <spdlog/spdlog.h>
+#endif
 
 namespace dicom_viewer::services {
+
+#ifdef DICOM_VIEWER_USE_PACS_SYSTEM
+
+// pacs_system-based implementation
+class DicomEchoSCU::Impl {
+public:
+    Impl() = default;
+    ~Impl() = default;
+
+    std::expected<EchoResult, PacsErrorInfo> verify(const PacsServerConfig& config) {
+        if (!config.isValid()) {
+            return std::unexpected(PacsErrorInfo{
+                PacsError::ConfigurationInvalid,
+                "Invalid PACS server configuration"
+            });
+        }
+
+        if (isVerifying_.exchange(true)) {
+            return std::unexpected(PacsErrorInfo{
+                PacsError::InternalError,
+                "A verification is already in progress"
+            });
+        }
+
+        cancelled_.store(false);
+        auto result = performEcho(config);
+        isVerifying_.store(false);
+
+        return result;
+    }
+
+    void cancel() {
+        cancelled_.store(true);
+    }
+
+    bool isVerifying() const {
+        return isVerifying_.load();
+    }
+
+private:
+    std::atomic<bool> isVerifying_{false};
+    std::atomic<bool> cancelled_{false};
+    uint16_t nextMessageId_{1};
+
+    std::expected<EchoResult, PacsErrorInfo> performEcho(const PacsServerConfig& config) {
+        auto startTime = std::chrono::steady_clock::now();
+
+        // Build association configuration
+        pacs::network::association_config assocConfig;
+        assocConfig.calling_ae_title = config.callingAeTitle;
+        assocConfig.called_ae_title = config.calledAeTitle;
+        assocConfig.max_pdu_length = config.maxPduSize;
+
+        // Add Verification SOP Class presentation context
+        pacs::network::proposed_presentation_context verificationCtx;
+        verificationCtx.id = 1;
+        verificationCtx.abstract_syntax = VERIFICATION_SOP_CLASS_UID;
+        verificationCtx.transfer_syntaxes = {
+            "1.2.840.10008.1.2.1",  // Explicit VR Little Endian
+            "1.2.840.10008.1.2.2",  // Explicit VR Big Endian
+            "1.2.840.10008.1.2"     // Implicit VR Little Endian
+        };
+        assocConfig.proposed_contexts.push_back(verificationCtx);
+
+        // Check for cancellation before connection
+        if (cancelled_.load()) {
+            return std::unexpected(PacsErrorInfo{
+                PacsError::NetworkError,
+                "Operation cancelled"
+            });
+        }
+
+        spdlog::info("Requesting association with {}:{} (AE: {})",
+                     config.hostname, config.port, config.calledAeTitle);
+
+        // Connect to remote SCP
+        auto timeout = std::chrono::duration_cast<pacs::network::association::duration>(
+            config.connectionTimeout
+        );
+        auto connectResult = pacs::network::association::connect(
+            config.hostname,
+            config.port,
+            assocConfig,
+            timeout
+        );
+
+        if (!connectResult.is_ok()) {
+            const auto& err = connectResult.error();
+            return mapAssociationError(err);
+        }
+
+        auto assoc = std::move(connectResult.value());
+
+        // Check if Verification SOP Class was accepted
+        if (!assoc.has_accepted_context(VERIFICATION_SOP_CLASS_UID)) {
+            spdlog::error("Verification SOP Class was not accepted by the server");
+            assoc.abort();
+            return std::unexpected(PacsErrorInfo{
+                PacsError::AssociationRejected,
+                "Verification SOP Class was not accepted by the server"
+            });
+        }
+
+        auto contextId = assoc.accepted_context_id(VERIFICATION_SOP_CLASS_UID);
+        if (!contextId) {
+            assoc.abort();
+            return std::unexpected(PacsErrorInfo{
+                PacsError::InternalError,
+                "Failed to get accepted context ID"
+            });
+        }
+
+        // Check for cancellation before sending echo
+        if (cancelled_.load()) {
+            assoc.abort();
+            return std::unexpected(PacsErrorInfo{
+                PacsError::NetworkError,
+                "Operation cancelled"
+            });
+        }
+
+        // Create and send C-ECHO request
+        uint16_t messageId = nextMessageId_++;
+        auto echoRq = pacs::network::dimse::make_c_echo_rq(messageId, VERIFICATION_SOP_CLASS_UID);
+
+        spdlog::debug("Sending C-ECHO request (Message ID: {})", messageId);
+
+        auto sendResult = assoc.send_dimse(*contextId, echoRq);
+        if (!sendResult.is_ok()) {
+            spdlog::error("Failed to send C-ECHO request: {}", sendResult.error().message);
+            assoc.abort();
+            return std::unexpected(PacsErrorInfo{
+                PacsError::NetworkError,
+                "Failed to send C-ECHO request: " + sendResult.error().message
+            });
+        }
+
+        // Receive C-ECHO response
+        auto dimseTimeout = std::chrono::duration_cast<pacs::network::association::duration>(
+            config.dimseTimeout
+        );
+        auto receiveResult = assoc.receive_dimse(dimseTimeout);
+        if (!receiveResult.is_ok()) {
+            const auto& err = receiveResult.error();
+            spdlog::error("Failed to receive C-ECHO response: {}", err.message);
+            assoc.abort();
+
+            if (err.code == pacs::error_codes::receive_timeout) {
+                return std::unexpected(PacsErrorInfo{
+                    PacsError::Timeout,
+                    "C-ECHO timeout: " + err.message
+                });
+            }
+            return std::unexpected(PacsErrorInfo{
+                PacsError::NetworkError,
+                "C-ECHO failed: " + err.message
+            });
+        }
+
+        auto [respContextId, respMsg] = std::move(receiveResult).value();
+
+        // Check response status
+        auto status = respMsg.status();
+        if (status != pacs::network::dimse::status_success) {
+            spdlog::error("C-ECHO returned non-success status: {}", static_cast<uint16_t>(status));
+            (void)assoc.release();
+            return std::unexpected(PacsErrorInfo{
+                PacsError::NetworkError,
+                "C-ECHO returned non-success status: " + std::to_string(static_cast<uint16_t>(status))
+            });
+        }
+
+        // Calculate latency
+        auto endTime = std::chrono::steady_clock::now();
+        auto latency = std::chrono::duration_cast<std::chrono::milliseconds>(
+            endTime - startTime
+        );
+
+        // Release association gracefully
+        auto releaseResult = assoc.release(dimseTimeout);
+        if (!releaseResult.is_ok()) {
+            spdlog::warn("Failed to release association gracefully: {}",
+                         releaseResult.error().message);
+        }
+
+        spdlog::info("C-ECHO successful to {} (latency: {}ms)",
+                     config.calledAeTitle, latency.count());
+
+        return EchoResult{
+            .success = true,
+            .latency = latency,
+            .message = "Echo successful"
+        };
+    }
+
+    std::unexpected<PacsErrorInfo> mapAssociationError(const pacs::error_info& err) {
+        int code = err.code;
+
+        if (code == pacs::error_codes::connection_failed ||
+            code == pacs::error_codes::connection_timeout) {
+            spdlog::error("Connection failed: {}", err.message);
+            return std::unexpected(PacsErrorInfo{
+                PacsError::ConnectionFailed,
+                "Failed to connect: " + err.message
+            });
+        }
+
+        if (code == pacs::error_codes::association_rejected) {
+            spdlog::error("Association rejected: {}", err.message);
+            return std::unexpected(PacsErrorInfo{
+                PacsError::AssociationRejected,
+                "Association rejected: " + err.message
+            });
+        }
+
+        if (code == pacs::error_codes::receive_timeout ||
+            code == pacs::error_codes::connection_timeout) {
+            spdlog::error("Connection timeout: {}", err.message);
+            return std::unexpected(PacsErrorInfo{
+                PacsError::Timeout,
+                "Connection timeout: " + err.message
+            });
+        }
+
+        spdlog::error("Network error: {}", err.message);
+        return std::unexpected(PacsErrorInfo{
+            PacsError::NetworkError,
+            "Network error: " + err.message
+        });
+    }
+};
+
+#else  // DCMTK-based legacy implementation
 
 class DicomEchoSCU::Impl {
 public:
@@ -228,6 +469,8 @@ private:
         };
     }
 };
+
+#endif  // DICOM_VIEWER_USE_PACS_SYSTEM
 
 // Public interface implementation
 


### PR DESCRIPTION
## What

### Summary
Implements pacs_system-based DicomEchoSCU while maintaining DCMTK backward compatibility through conditional compilation.

### Change Type
- [x] Refactor (code restructuring with no behavior change in default mode)
- [ ] Feature
- [ ] Bugfix

### Affected Components
- `src/services/pacs/dicom_echo_scu.cpp` - Dual implementation (pacs_system + DCMTK)
- `CMakeLists.txt` - common_system and thread_system include paths

## Why

### Related Issues
- Closes #112 (refactor(pacs): Migrate DicomEchoSCU from DCMTK to pacs_system)
- Part of #110 (Epic: DCMTK to pacs_system Migration)

### Motivation
This PR is the first step in migrating DICOM network services from DCMTK to pacs_system library. C-ECHO is the simplest DICOM service and serves as a template for future migrations (C-FIND, C-MOVE, C-STORE, Store SCP).

## Who

### Reviewers
- @kcenon - Code owner

## When

### Urgency
- [x] Normal - Follow standard review process
- [ ] High Priority
- [ ] Hotfix

## Where

### Files Changed Summary
| Directory | Files | Type of Change |
|-----------|-------|----------------|
| `src/services/pacs/` | 1 | Dual implementation |
| `CMakeLists.txt` | 1 | Build configuration |

### API Changes
None - Public API (EchoResult, PacsErrorInfo, DicomEchoSCU) is unchanged.

## How

### Implementation Highlights
1. **Conditional Compilation**: Uses `#ifdef DICOM_VIEWER_USE_PACS_SYSTEM` to switch implementations
2. **pacs_system Integration**: Maps DCMTK APIs to pacs_system equivalents:
   - `ASC_*` functions → `association::connect()`, `association::release()`
   - `DIMSE_echoUser()` → `make_c_echo_rq()`, `send_dimse()`, `receive_dimse()`
3. **Error Mapping**: Converts pacs::error_codes to existing PacsError enum
4. **CMake Updates**: Adds common_system and thread_system include paths for pacs_system dependencies

### Testing Done
- [x] Unit tests (21 tests pass with DCMTK mode)
- [x] pacs_service library compiles with both modes
- [ ] Integration test with Orthanc PACS (requires manual verification)

### Test Plan
1. Build with default settings: `cmake -DUSE_PACS_SYSTEM=OFF ..`
2. Run tests: `./bin/dicom_echo_scu_test`
3. All 21 tests should pass

### Breaking Changes
None - Default build uses DCMTK, maintaining backward compatibility.

### Known Limitations
- pacs_system mode requires thread_system library to be linked (full CMake integration pending #111)
- pacs_system implementation not yet tested against live PACS server

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass (DCMTK mode)
- [x] Related issue linked with closing keywords