### PR TITLE
refactor(pacs): migrate DicomStoreSCP from DCMTK to pacs_system

### DIFF
--- a/src/services/pacs/dicom_store_scp.cpp
+++ b/src/services/pacs/dicom_store_scp.cpp
@@ -5,7 +5,22 @@
 #include <mutex>
 #include <thread>
 
-// DCMTK headers
+#include <spdlog/spdlog.h>
+
+#ifdef DICOM_VIEWER_USE_PACS_SYSTEM
+// pacs_system headers for new implementation
+#include <pacs/core/dicom_dataset.hpp>
+#include <pacs/core/dicom_file.hpp>
+#include <pacs/core/dicom_tag_constants.hpp>
+#include <pacs/core/result.hpp>
+#include <pacs/network/dicom_server.hpp>
+#include <pacs/network/server_config.hpp>
+#include <pacs/services/storage_scp.hpp>
+#include <pacs/services/verification_scp.hpp>
+#include <pacs/encoding/vr_type.hpp>
+#include <pacs/encoding/transfer_syntax.hpp>
+#else
+// DCMTK headers for legacy implementation
 #include <dcmtk/config/osconfig.h>
 #include <dcmtk/dcmdata/dcfilefo.h>
 #include <dcmtk/dcmdata/dcmetinf.h>
@@ -13,10 +28,299 @@
 #include <dcmtk/dcmnet/assoc.h>
 #include <dcmtk/dcmnet/dimse.h>
 #include <dcmtk/dcmnet/diutil.h>
-
-#include <spdlog/spdlog.h>
+#endif
 
 namespace dicom_viewer::services {
+
+#ifdef DICOM_VIEWER_USE_PACS_SYSTEM
+
+// pacs_system-based implementation
+class DicomStoreSCP::Impl {
+public:
+    Impl() = default;
+    ~Impl() {
+        stop();
+    }
+
+    std::expected<void, PacsErrorInfo> start(const StorageScpConfig& config) {
+        if (!config.isValid()) {
+            return std::unexpected(PacsErrorInfo{
+                PacsError::ConfigurationInvalid,
+                "Invalid Storage SCP configuration"
+            });
+        }
+
+        if (isRunning_.load()) {
+            return std::unexpected(PacsErrorInfo{
+                PacsError::InternalError,
+                "Storage SCP is already running"
+            });
+        }
+
+        // Store configuration
+        config_ = config;
+
+        // Create storage directory if it doesn't exist
+        std::error_code ec;
+        if (!std::filesystem::exists(config_.storageDirectory)) {
+            if (!std::filesystem::create_directories(config_.storageDirectory, ec)) {
+                return std::unexpected(PacsErrorInfo{
+                    PacsError::InternalError,
+                    "Failed to create storage directory: " + ec.message()
+                });
+            }
+        }
+
+        // Configure server
+        pacs::network::server_config serverConfig;
+        serverConfig.ae_title = config_.aeTitle;
+        serverConfig.port = config_.port;
+        serverConfig.max_pdu_size = config_.maxPduSize;
+        serverConfig.idle_timeout = config_.connectionTimeout;
+        serverConfig.max_associations = config_.maxAssociations;
+
+        // Create server
+        server_ = std::make_unique<pacs::network::dicom_server>(serverConfig);
+
+        // Create and configure storage SCP service
+        pacs::services::storage_scp_config scpConfig;
+        scpConfig.accepted_sop_classes = DicomStoreSCP::getSupportedSopClasses();
+        scpConfig.dup_policy = pacs::services::duplicate_policy::replace;
+
+        storageScp_ = std::make_unique<pacs::services::storage_scp>(scpConfig);
+
+        // Set storage handler
+        storageScp_->set_handler(
+            [this](const pacs::core::dicom_dataset& dataset,
+                   const std::string& callingAe,
+                   const std::string& sopClassUid,
+                   const std::string& sopInstanceUid) {
+                return handleStoreRequest(dataset, callingAe, sopClassUid, sopInstanceUid);
+            }
+        );
+
+        // Set post-store handler for callbacks
+        storageScp_->set_post_store_handler(
+            [this](const pacs::core::dicom_dataset& dataset,
+                   const std::string& patientId,
+                   const std::string& studyUid,
+                   const std::string& seriesUid,
+                   const std::string& sopInstanceUid) {
+                handlePostStore(dataset, patientId, studyUid, seriesUid, sopInstanceUid);
+            }
+        );
+
+        // Create verification SCP for C-ECHO support
+        verificationScp_ = std::make_unique<pacs::services::verification_scp>();
+
+        // Register services with server
+        server_->register_service(std::move(storageScp_));
+        server_->register_service(std::move(verificationScp_));
+
+        // Set connection callbacks
+        server_->on_association_established([this](const pacs::network::association& assoc) {
+            std::string callingAe = assoc.calling_ae();
+            spdlog::info("Association request from: {}", callingAe);
+
+            {
+                std::lock_guard lock(callbackMutex_);
+                if (connectionCallback_) {
+                    connectionCallback_(callingAe, true);
+                }
+            }
+
+            {
+                std::lock_guard lock(statusMutex_);
+                status_.activeConnections++;
+            }
+        });
+
+        server_->on_association_released([this](const pacs::network::association& assoc) {
+            std::string callingAe = assoc.calling_ae();
+
+            {
+                std::lock_guard lock(statusMutex_);
+                if (status_.activeConnections > 0) {
+                    status_.activeConnections--;
+                }
+            }
+
+            {
+                std::lock_guard lock(callbackMutex_);
+                if (connectionCallback_) {
+                    connectionCallback_(callingAe, false);
+                }
+            }
+        });
+
+        server_->on_error([](const std::string& error) {
+            spdlog::error("Storage SCP error: {}", error);
+        });
+
+        // Start server
+        auto result = server_->start();
+        if (!result.is_ok()) {
+            spdlog::error("Failed to start server: {}", result.error().message);
+            server_.reset();
+            return std::unexpected(PacsErrorInfo{
+                PacsError::NetworkError,
+                "Failed to start server: " + result.error().message
+            });
+        }
+
+        // Update status
+        {
+            std::lock_guard lock(statusMutex_);
+            status_.isRunning = true;
+            status_.port = config_.port;
+            status_.startTime = std::chrono::system_clock::now();
+            status_.totalImagesReceived = 0;
+            status_.activeConnections = 0;
+        }
+
+        spdlog::info("Storage SCP started on port {} (AE: {})",
+                     config_.port, config_.aeTitle);
+
+        isRunning_.store(true);
+        return {};
+    }
+
+    void stop() {
+        if (!isRunning_.exchange(false)) {
+            return;
+        }
+
+        if (server_) {
+            server_->stop();
+            server_.reset();
+        }
+
+        {
+            std::lock_guard lock(statusMutex_);
+            status_.isRunning = false;
+        }
+
+        spdlog::info("Storage SCP stopped");
+    }
+
+    bool isRunning() const {
+        return isRunning_.load();
+    }
+
+    StorageScpStatus getStatus() const {
+        std::lock_guard lock(statusMutex_);
+        return status_;
+    }
+
+    void setImageReceivedCallback(ImageReceivedCallback callback) {
+        std::lock_guard lock(callbackMutex_);
+        imageReceivedCallback_ = std::move(callback);
+    }
+
+    void setConnectionCallback(ConnectionCallback callback) {
+        std::lock_guard lock(callbackMutex_);
+        connectionCallback_ = std::move(callback);
+    }
+
+private:
+    StorageScpConfig config_;
+    std::unique_ptr<pacs::network::dicom_server> server_;
+    std::unique_ptr<pacs::services::storage_scp> storageScp_;
+    std::unique_ptr<pacs::services::verification_scp> verificationScp_;
+    std::atomic<bool> isRunning_{false};
+
+    mutable std::mutex statusMutex_;
+    StorageScpStatus status_;
+
+    mutable std::mutex callbackMutex_;
+    ImageReceivedCallback imageReceivedCallback_;
+    ConnectionCallback connectionCallback_;
+
+    // Last received image info for post-store handler
+    mutable std::mutex lastImageMutex_;
+    std::string lastCallingAe_;
+    std::filesystem::path lastFilePath_;
+
+    pacs::services::storage_status handleStoreRequest(
+        const pacs::core::dicom_dataset& dataset,
+        const std::string& callingAe,
+        const std::string& sopClassUid,
+        const std::string& sopInstanceUid
+    ) {
+        // Prepare file path
+        std::filesystem::path filePath = config_.storageDirectory /
+            (sopInstanceUid + ".dcm");
+
+        // Create DICOM file from dataset using default transfer syntax
+        auto file = pacs::core::dicom_file::create(
+            pacs::core::dicom_dataset{dataset},
+            pacs::encoding::transfer_syntax::explicit_vr_little_endian
+        );
+
+        auto saveResult = file.save(filePath);
+        if (!saveResult.is_ok()) {
+            spdlog::error("Failed to save file: {}", saveResult.error().message);
+            return pacs::services::storage_status::out_of_resources_unable_to_store;
+        }
+
+        spdlog::info("Stored image: {}", filePath.string());
+
+        // Store info for post-store handler
+        {
+            std::lock_guard lock(lastImageMutex_);
+            lastCallingAe_ = callingAe;
+            lastFilePath_ = filePath;
+        }
+
+        return pacs::services::storage_status::success;
+    }
+
+    void handlePostStore(
+        const pacs::core::dicom_dataset& dataset,
+        const std::string& patientId,
+        const std::string& studyUid,
+        const std::string& seriesUid,
+        const std::string& sopInstanceUid
+    ) {
+        using namespace pacs::core;
+
+        // Get stored info
+        std::string callingAe;
+        std::filesystem::path filePath;
+        {
+            std::lock_guard lock(lastImageMutex_);
+            callingAe = lastCallingAe_;
+            filePath = lastFilePath_;
+        }
+
+        // Build received image info
+        ReceivedImageInfo info;
+        info.filePath = filePath;
+        info.sopClassUid = dataset.get_string(tags::sop_class_uid, "");
+        info.sopInstanceUid = sopInstanceUid;
+        info.patientId = patientId;
+        info.studyInstanceUid = studyUid;
+        info.seriesInstanceUid = seriesUid;
+        info.callingAeTitle = callingAe;
+        info.receivedTime = std::chrono::system_clock::now();
+
+        // Update status
+        {
+            std::lock_guard lock(statusMutex_);
+            status_.totalImagesReceived++;
+        }
+
+        // Notify callback
+        {
+            std::lock_guard lock(callbackMutex_);
+            if (imageReceivedCallback_) {
+                imageReceivedCallback_(info);
+            }
+        }
+    }
+};
+
+#else  // DCMTK-based legacy implementation
 
 class DicomStoreSCP::Impl {
 public:
@@ -419,6 +723,8 @@ private:
         }
     }
 };
+
+#endif  // DICOM_VIEWER_USE_PACS_SYSTEM
 
 // Public interface implementation
 


### PR DESCRIPTION
## Summary
- Migrate DicomStoreSCP implementation from DCMTK to pacs_system library
- Add conditional compilation to support both DCMTK and pacs_system backends
- Implement using dicom_server for connection management and storage_scp for C-STORE handling
- Add verification_scp for C-ECHO support

## What
This PR migrates the Storage SCP (Service Class Provider) from DCMTK to pacs_system library as part of the ongoing DCMTK replacement effort (#110).

### Technical Approach
1. Use `dicom_server` for network server lifecycle and association management
2. Register `storage_scp` service for handling C-STORE requests
3. Register `verification_scp` service for C-ECHO support
4. Use `dicom_file::create` for saving received DICOM files
5. Maintain callback-based notification for image received and connection events

### Changes Made
- Add pacs_system headers for new implementation
- Implement new `Impl` class using pacs_system components
- Keep DCMTK implementation behind `#ifdef DICOM_VIEWER_USE_PACS_SYSTEM`
- Maintain identical public API

## Why
- Part of Epic #110: Replace DCMTK with pacs_system for DICOM network services
- pacs_system provides modern C++ API with better error handling
- Enables gradual migration without breaking existing functionality

## Related Issues
Closes #115

## Test Plan
- [x] All existing DicomStoreSCP unit tests pass (20/20)
- [x] Build succeeds with pacs_system enabled
- [x] Build succeeds with DCMTK fallback

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass
- [x] No DCMTK headers in new implementation
- [x] Backward compatibility maintained