### PR TITLE
docs: fix stale DCMTK references in README.kr.md

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -87,8 +87,10 @@
 | **GUI** | Qt | 6.5+ |
 | **영상 처리** | ITK | 5.4+ |
 | **시각화** | VTK | 9.3+ |
-| **DICOM 네트워크** | DCMTK | 3.6.8+ |
+| **DICOM 네트워크** | pacs_system | Latest |
 | **DICOM I/O** | GDCM (via ITK) | Latest |
+
+> **참고**: DICOM 네트워크 작업은 kcenon 에코시스템의 순수 C++20 PACS 구현체인 [pacs_system](https://github.com/kcenon/pacs_system)을 사용합니다.
 
 ## 아키텍처
 
@@ -153,10 +155,10 @@ DICOM Viewer는 **4-Layer 아키텍처**를 채택하여 관심사 분리와 유
 
 ```bash
 # macOS (Homebrew)
-brew install itk vtk qt@6 fftw dcmtk spdlog fmt nlohmann-json
+brew install itk vtk qt@6 fftw spdlog fmt nlohmann-json
 
 # vcpkg 사용 시
-vcpkg install itk[vtk] vtk[qt] qt6 fftw3 dcmtk spdlog fmt nlohmann-json
+vcpkg install itk[vtk] vtk[qt] qt6 fftw3 spdlog fmt nlohmann-json
 ```
 
 ### 빌드


### PR DESCRIPTION
Closes #125

## Summary
- Replace `DCMTK | 3.6.8+` with `pacs_system | Latest` in Korean README technology stack table
- Remove `dcmtk` from Homebrew and vcpkg dependency installation commands
- Add pacs_system explanatory note to match English README (line 93)

## Context

After the DCMTK → pacs_system migration (#110-#117), the English README was updated but the Korean README was missed. This synchronizes both versions.

## Changes

| Location | Before | After |
|----------|--------|-------|
| Line 90 (tech stack) | `DCMTK \| 3.6.8+` | `pacs_system \| Latest` |
| Line 93 (new) | - | pacs_system explanatory note |
| Line 156 (brew) | `brew install ... dcmtk ...` | `brew install ... (no dcmtk)` |
| Line 159 (vcpkg) | `vcpkg install ... dcmtk ...` | `vcpkg install ... (no dcmtk)` |

## Verification

```bash
# Confirms zero DCMTK references remain
grep -c 'dcmtk\|DCMTK' README.kr.md
# Result: 0
```

## Test Plan
- [x] Verify no DCMTK references remain in README.kr.md
- [x] Verify technology stack matches README.md
- [x] Verify installation commands match README.md
- [x] Verify pacs_system note is present