### PR TITLE
docs: bump PRD/SRS/SDS version to v0.3.0

### DIFF
--- a/docs/PRD.kr.md
+++ b/docs/PRD.kr.md
@@ -1,8 +1,8 @@
 # DICOM Viewer - Product Requirements Document (PRD)
 
-> **Version**: 0.2.0
+> **Version**: 0.3.0
 > **Created**: 2025-12-31
-> **Last Updated**: 2025-12-31
+> **Last Updated**: 2026-02-11
 > **Status**: Draft (Pre-release)
 > **Author**: Development Team
 
@@ -909,6 +909,7 @@
 |---------|------|--------|---------|
 | 0.1.0 | 2025-12-31 | Development Team | Initial PRD |
 | 0.2.0 | 2025-12-31 | Development Team | 세그먼테이션 및 영역 측정 기능 상세화 (FR-006, FR-007 확장, FR-012, FR-013 추가) |
+| 0.3.0 | 2026-02-11 | Development Team | DCMTK를 pacs_system으로 교체하여 DICOM 네트워크 운영 변경; 빌드 시스템과 버전 동기화 |
 
 > **Note**: v0.x.x는 Pre-release 버전입니다. 정식 릴리스는 v1.0.0부터 시작됩니다.
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,8 +1,8 @@
 # DICOM Viewer - Product Requirements Document (PRD)
 
-> **Version**: 0.2.0
+> **Version**: 0.3.0
 > **Created**: 2025-12-31
-> **Last Updated**: 2025-12-31
+> **Last Updated**: 2026-02-11
 > **Status**: Draft (Pre-release)
 > **Author**: Development Team
 
@@ -918,6 +918,7 @@ For coordinate system information, see [03-itk-vtk-integration.md](reference/03-
 |---------|------|--------|---------|
 | 0.1.0 | 2025-12-31 | Development Team | Initial PRD |
 | 0.2.0 | 2025-12-31 | Development Team | Detailed segmentation and region measurement features (FR-006, FR-007 expansion, FR-012, FR-013 addition) |
+| 0.3.0 | 2026-02-11 | Development Team | Replaced DCMTK with pacs_system for DICOM network operations; version sync with build system |
 
 > **Note**: v0.x.x are Pre-release versions. Official releases start from v1.0.0.
 

--- a/docs/SDS.kr.md
+++ b/docs/SDS.kr.md
@@ -1,11 +1,11 @@
 # DICOM Viewer - Software Design Specification (SDS)
 
-> **Version**: 0.2.0
+> **Version**: 0.3.0
 > **Created**: 2025-12-31
-> **Last Updated**: 2025-12-31
+> **Last Updated**: 2026-02-11
 > **Status**: Draft (Pre-release)
 > **Author**: Development Team
-> **Based on**: [SRS v0.2.0](SRS.md), [PRD v0.2.0](PRD.md)
+> **Based on**: [SRS v0.3.0](SRS.md), [PRD v0.3.0](PRD.md)
 
 ---
 
@@ -17,6 +17,7 @@
 |---------|------|--------|-------------|
 | 0.1.0 | 2025-12-31 | Development Team | Initial SDS based on SRS 0.1.0 |
 | 0.2.0 | 2025-12-31 | Development Team | Added segmentation and measurement module design |
+| 0.3.0 | 2026-02-11 | Development Team | Replaced DCMTK with pacs_system for DICOM network operations; version sync with build system |
 
 ### Referenced Documents
 
@@ -2370,6 +2371,7 @@ dicom_viewer/
 |---------|------|--------|---------|
 | 0.1.0 | 2025-12-31 | Development Team | Initial SDS based on SRS 0.1.0 |
 | 0.2.0 | 2025-12-31 | Development Team | Added segmentation and measurement module design |
+| 0.3.0 | 2026-02-11 | Development Team | Replaced DCMTK with pacs_system for DICOM network operations; version sync with build system |
 
 > **Note**: v0.x.x는 Pre-release 버전입니다. 정식 릴리스는 v1.0.0부터 시작됩니다.
 

--- a/docs/SDS.md
+++ b/docs/SDS.md
@@ -1,11 +1,11 @@
 # DICOM Viewer - Software Design Specification (SDS)
 
-> **Version**: 0.2.0
+> **Version**: 0.3.0
 > **Created**: 2025-12-31
-> **Last Updated**: 2025-12-31
+> **Last Updated**: 2026-02-11
 > **Status**: Draft (Pre-release)
 > **Author**: Development Team
-> **Based on**: [SRS v0.2.0](SRS.md), [PRD v0.2.0](PRD.md)
+> **Based on**: [SRS v0.3.0](SRS.md), [PRD v0.3.0](PRD.md)
 
 ---
 
@@ -17,6 +17,7 @@
 |---------|------|--------|-------------|
 | 0.1.0 | 2025-12-31 | Development Team | Initial SDS based on SRS 0.1.0 |
 | 0.2.0 | 2025-12-31 | Development Team | Added segmentation and measurement module design |
+| 0.3.0 | 2026-02-11 | Development Team | Replaced DCMTK with pacs_system for DICOM network operations; version sync with build system |
 
 ### Referenced Documents
 
@@ -2396,6 +2397,7 @@ dicom_viewer/
 |---------|------|--------|---------|
 | 0.1.0 | 2025-12-31 | Development Team | Initial SDS based on SRS 0.1.0 |
 | 0.2.0 | 2025-12-31 | Development Team | Added segmentation and measurement module design |
+| 0.3.0 | 2026-02-11 | Development Team | Replaced DCMTK with pacs_system for DICOM network operations; version sync with build system |
 
 > **Note**: v0.x.x versions are pre-release. Official release starts from v1.0.0.
 

--- a/docs/SRS.kr.md
+++ b/docs/SRS.kr.md
@@ -1,11 +1,11 @@
 # DICOM Viewer - Software Requirements Specification (SRS)
 
-> **Version**: 0.2.0
+> **Version**: 0.3.0
 > **Created**: 2025-12-31
-> **Last Updated**: 2025-12-31
+> **Last Updated**: 2026-02-11
 > **Status**: Draft (Pre-release)
 > **Author**: Development Team
-> **Based on**: [PRD v0.2.0](PRD.md)
+> **Based on**: [PRD v0.3.0](PRD.md)
 
 ---
 
@@ -17,6 +17,7 @@
 |---------|------|--------|-------------|
 | 0.1.0 | 2025-12-31 | Development Team | Initial SRS based on PRD 0.1.0 |
 | 0.2.0 | 2025-12-31 | Development Team | Added segmentation and measurement requirements (FR-006, FR-007 expansion) |
+| 0.3.0 | 2026-02-11 | Development Team | Replaced DCMTK with pacs_system for DICOM network operations; version sync with build system |
 
 ### Referenced Documents
 
@@ -1681,6 +1682,7 @@ See SRS-FR-039 for detailed layout specification.
 |---------|------|--------|---------|
 | 0.1.0 | 2025-12-31 | Development Team | Initial SRS |
 | 0.2.0 | 2025-12-31 | Development Team | Added segmentation (SRS-FR-020~025), measurement (SRS-FR-026~030), ROI management (SRS-FR-031) |
+| 0.3.0 | 2026-02-11 | Development Team | Replaced DCMTK with pacs_system for DICOM network operations; version sync with build system |
 
 ---
 

--- a/docs/SRS.md
+++ b/docs/SRS.md
@@ -1,11 +1,11 @@
 # DICOM Viewer - Software Requirements Specification (SRS)
 
-> **Version**: 0.2.0
+> **Version**: 0.3.0
 > **Created**: 2025-12-31
-> **Last Updated**: 2025-12-31
+> **Last Updated**: 2026-02-11
 > **Status**: Draft (Pre-release)
 > **Author**: Development Team
-> **Based on**: [PRD v0.2.0](PRD.md)
+> **Based on**: [PRD v0.3.0](PRD.md)
 
 ---
 
@@ -17,6 +17,7 @@
 |---------|------|--------|-------------|
 | 0.1.0 | 2025-12-31 | Development Team | Initial SRS based on PRD 0.1.0 |
 | 0.2.0 | 2025-12-31 | Development Team | Added segmentation and measurement requirements (FR-006, FR-007 expansion) |
+| 0.3.0 | 2026-02-11 | Development Team | Replaced DCMTK with pacs_system for DICOM network operations; version sync with build system |
 
 ### Referenced Documents
 
@@ -1681,6 +1682,7 @@ See SRS-FR-039 for detailed layout specification.
 |---------|------|--------|---------|
 | 0.1.0 | 2025-12-31 | Development Team | Initial SRS |
 | 0.2.0 | 2025-12-31 | Development Team | Added segmentation (SRS-FR-020~025), measurement (SRS-FR-026~030), ROI management (SRS-FR-031) |
+| 0.3.0 | 2026-02-11 | Development Team | Replaced DCMTK with pacs_system for DICOM network operations; version sync with build system |
 
 ---
 


### PR DESCRIPTION
Closes #126

## Summary
- Bump version headers from 0.2.0 to 0.3.0 in all 6 specification documents (PRD, SRS, SDS — both EN and KR)
- Update `Last Updated` dates to 2026-02-11
- Update cross-references: SRS now references PRD v0.3.0, SDS references SRS v0.3.0 and PRD v0.3.0
- Add v0.3.0 revision history entry documenting DCMTK → pacs_system migration

## Context

The build system (CMakeLists.txt, vcpkg.json) was already at v0.3.0, but all specification documents remained at v0.2.0 since 2025-12-31. The v0.3.0 cycle included a major change — complete DCMTK → pacs_system migration (#110-#117) — that was not reflected in the specs.

## Changes per Document

| Document | Updates |
|----------|---------|
| `docs/PRD.md` | Version header + revision history + date |
| `docs/PRD.kr.md` | Version header + revision history + date |
| `docs/SRS.md` | Version header + cross-ref to PRD v0.3.0 + 2 revision history entries + date |
| `docs/SRS.kr.md` | Version header + cross-ref to PRD v0.3.0 + 2 revision history entries + date |
| `docs/SDS.md` | Version header + cross-ref to SRS/PRD v0.3.0 + 2 revision history entries + date |
| `docs/SDS.kr.md` | Version header + cross-ref to SRS/PRD v0.3.0 + 2 revision history entries + date |

## Verification

```bash
# All 6 docs now at v0.3.0
grep 'Version.*0.3.0' docs/PRD.md docs/PRD.kr.md docs/SRS.md docs/SRS.kr.md docs/SDS.md docs/SDS.kr.md
# 6 matches

# No stale v0.2.0 in headers
grep '^\*\*Version\*\*.*0.2.0' docs/*.md
# 0 matches (v0.2.0 only remains in revision history tables, which is correct)
```

## Test Plan
- [x] All 6 documents show version 0.3.0 in header
- [x] Cross-references between documents updated to v0.3.0
- [x] Revision history tables include v0.3.0 entry
- [x] English and Korean versions are synchronized
- [x] Existing v0.2.0 revision history entries preserved (not modified)