### PR TITLE
docs: remove non-existent NetworkController from specifications

### DIFF
--- a/docs/PRD.kr.md
+++ b/docs/PRD.kr.md
@@ -695,8 +695,7 @@
 │   │                                                                   │  │
 │   │  ViewerController ─┬─ LoadingController (로딩 제어)              │  │
 │   │                    ├─ RenderingController (렌더링 제어)          │  │
-│   │                    ├─ ToolController (도구 제어)                 │  │
-│   │                    └─ NetworkController (PACS 제어)              │  │
+│   │                    └─ ToolController (도구 제어)                 │  │
 │   │                                                                   │  │
 │   └─────────────────────────────────────────────────────────────────┘  │
 │                              │                                          │

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -702,8 +702,7 @@
 │   │                                                                   │  │
 │   │  ViewerController ─┬─ LoadingController (Loading control)        │  │
 │   │                    ├─ RenderingController (Rendering control)    │  │
-│   │                    ├─ ToolController (Tool control)              │  │
-│   │                    └─ NetworkController (PACS control)           │  │
+│   │                    └─ ToolController (Tool control)              │  │
 │   │                                                                   │  │
 │   └─────────────────────────────────────────────────────────────────┘  │
 │                              │                                          │

--- a/docs/SRS.kr.md
+++ b/docs/SRS.kr.md
@@ -90,7 +90,7 @@ DICOM Viewer는 의료 영상(CT, MRI, DR/CR) 뷰어로서:
 │   │                     Controller Layer                             │  │
 │   │                                                                   │  │
 │   │    ViewerController → LoadingController, RenderingController,    │  │
-│   │                       ToolController, NetworkController          │  │
+│   │                       ToolController                             │  │
 │   │                                                                   │  │
 │   └─────────────────────────────────────────────────────────────────┘  │
 │                              │                                          │

--- a/docs/SRS.md
+++ b/docs/SRS.md
@@ -90,7 +90,7 @@ DICOM Viewer is a desktop application for medical imaging (CT, MRI, DR/CR) that 
 │   │                     Controller Layer                             │  │
 │   │                                                                   │  │
 │   │    ViewerController → LoadingController, RenderingController,    │  │
-│   │                       ToolController, NetworkController          │  │
+│   │                       ToolController                             │  │
 │   │                                                                   │  │
 │   └─────────────────────────────────────────────────────────────────┘  │
 │                              │                                          │


### PR DESCRIPTION
Closes #128

## Summary
- Remove all references to NetworkController from PRD and SRS documents (English and Korean)
- NetworkController was documented as a controller-layer component for PACS communication but was never implemented (not even a stub file)
- PACS functionality operates correctly through direct service components (DicomFindSCU, DicomMoveSCU, DicomStoreSCP, DicomEchoSCU)
- SDS references were already removed in PR #133

## Files Modified
- `docs/PRD.md` — Removed NetworkController from controller layer diagram
- `docs/PRD.kr.md` — Same change in Korean version
- `docs/SRS.md` — Removed NetworkController from controller relationships
- `docs/SRS.kr.md` — Same change in Korean version

## Test Plan
- [x] Grep confirms zero remaining references to NetworkController/NetworkCtrl/network_controller across all docs
- [x] Controller layer now correctly lists 3 controllers: LoadingController, RenderingController, ToolController