### PR TITLE
chore: clean up orphaned stub files and update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,7 +312,6 @@ add_library(dicom_viewer_core STATIC
     src/core/dicom/transfer_syntax_decoder.cpp
     src/core/image/image_converter.cpp
     src/core/image/hounsfield_converter.cpp
-    src/core/data/patient_data.cpp
 )
 
 target_include_directories(dicom_viewer_core PUBLIC
@@ -330,17 +329,6 @@ target_link_libraries(dicom_viewer_core PUBLIC
     ${FFTW3_THREADS_LIBRARY}
     spdlog::spdlog
     fmt::fmt
-)
-
-# Service libraries
-add_library(image_service STATIC
-    src/services/image/image_service.cpp
-    src/services/image/preprocessing_service.cpp
-)
-
-target_link_libraries(image_service PUBLIC
-    dicom_viewer_core
-    ${ITK_LIBRARIES}
 )
 
 # Coordinate transformation service (unified MPR coordinate system)
@@ -370,9 +358,6 @@ target_link_libraries(render_service PUBLIC
 add_library(measurement_service STATIC
     src/services/measurement/linear_measurement_tool.cpp
     src/services/measurement/area_measurement_tool.cpp
-    src/services/measurement/distance_tool.cpp
-    src/services/measurement/area_tool.cpp
-    src/services/measurement/statistics.cpp
     src/services/measurement/roi_statistics.cpp
     src/services/measurement/volume_calculator.cpp
     src/services/measurement/shape_analyzer.cpp
@@ -501,23 +486,6 @@ target_link_libraries(export_service PUBLIC
     ${VTK_LIBRARIES}
 )
 
-# Controller library
-add_library(dicom_viewer_controller STATIC
-    src/controller/viewer_controller.cpp
-    src/controller/loading_controller.cpp
-    src/controller/rendering_controller.cpp
-    src/controller/tool_controller.cpp
-)
-
-target_link_libraries(dicom_viewer_controller PUBLIC
-    image_service
-    render_service
-    measurement_service
-    segmentation_service
-    pacs_service
-    export_service
-)
-
 # UI library
 add_library(dicom_viewer_ui STATIC
     src/ui/main_window.cpp
@@ -544,7 +512,11 @@ add_library(dicom_viewer_ui STATIC
 )
 
 target_link_libraries(dicom_viewer_ui PUBLIC
-    dicom_viewer_controller
+    render_service
+    measurement_service
+    segmentation_service
+    pacs_service
+    export_service
     Qt6::Core
     Qt6::Widgets
     Qt6::Gui

--- a/src/controller/loading_controller.cpp
+++ b/src/controller/loading_controller.cpp
@@ -1,4 +1,0 @@
-// Stub implementation - to be completed
-namespace dicom_viewer::controller {
-// LoadingController implementation will be added here
-} // namespace dicom_viewer::controller

--- a/src/controller/rendering_controller.cpp
+++ b/src/controller/rendering_controller.cpp
@@ -1,4 +1,0 @@
-// Stub implementation - to be completed
-namespace dicom_viewer::controller {
-// RenderingController implementation will be added here
-} // namespace dicom_viewer::controller

--- a/src/controller/tool_controller.cpp
+++ b/src/controller/tool_controller.cpp
@@ -1,4 +1,0 @@
-// Stub implementation - to be completed
-namespace dicom_viewer::controller {
-// ToolController implementation will be added here
-} // namespace dicom_viewer::controller

--- a/src/controller/viewer_controller.cpp
+++ b/src/controller/viewer_controller.cpp
@@ -1,4 +1,0 @@
-// Stub implementation - to be completed
-namespace dicom_viewer::controller {
-// ViewerController implementation will be added here
-} // namespace dicom_viewer::controller

--- a/src/core/data/patient_data.cpp
+++ b/src/core/data/patient_data.cpp
@@ -1,4 +1,0 @@
-// Stub implementation - to be completed
-namespace dicom_viewer::core {
-// Patient/Study/Series data management will be added here
-} // namespace dicom_viewer::core

--- a/src/services/image/image_service.cpp
+++ b/src/services/image/image_service.cpp
@@ -1,4 +1,0 @@
-// Stub implementation - to be completed
-namespace dicom_viewer::services {
-// ImageService implementation will be added here
-} // namespace dicom_viewer::services

--- a/src/services/image/preprocessing_service.cpp
+++ b/src/services/image/preprocessing_service.cpp
@@ -1,4 +1,0 @@
-// Stub implementation - to be completed
-namespace dicom_viewer::services {
-// PreprocessingService implementation will be added here
-} // namespace dicom_viewer::services

--- a/src/services/measurement/area_tool.cpp
+++ b/src/services/measurement/area_tool.cpp
@@ -1,4 +1,0 @@
-// Stub implementation - to be completed
-namespace dicom_viewer::services {
-// AreaTool implementation will be added here
-} // namespace dicom_viewer::services

--- a/src/services/measurement/distance_tool.cpp
+++ b/src/services/measurement/distance_tool.cpp
@@ -1,4 +1,0 @@
-// Stub implementation - to be completed
-namespace dicom_viewer::services {
-// DistanceTool implementation will be added here
-} // namespace dicom_viewer::services

--- a/src/services/measurement/statistics.cpp
+++ b/src/services/measurement/statistics.cpp
@@ -1,4 +1,0 @@
-// Stub implementation - to be completed
-namespace dicom_viewer::services {
-// Statistics implementation will be added here
-} // namespace dicom_viewer::services


### PR DESCRIPTION
Closes #129

## Summary
- Remove 10 stub files (4-line empty namespace placeholders) that provided zero functionality
- Remove `dicom_viewer_controller` CMake library target (all 4 source files were stubs)
- Remove `image_service` CMake library target (both source files were stubs)
- Remove 3 redundant measurement stubs from `measurement_service` library (`distance_tool.cpp`, `area_tool.cpp`, `statistics.cpp`)
- Remove `patient_data.cpp` stub from `dicom_viewer_core` library
- Update `dicom_viewer_ui` to link directly to service libraries instead of through the removed controller library

## Stub Files Removed

| Category | Files | Reason |
|----------|-------|--------|
| Controller (4) | viewer_controller, loading_controller, rendering_controller, tool_controller | No headers exist, empty namespace only |
| Service orchestrator (2) | image_service, preprocessing_service | Individual components work independently |
| Measurement (3) | distance_tool, area_tool, statistics | Superseded by linear_measurement_tool, area_measurement_tool, roi_statistics |
| Data (1) | patient_data | No corresponding header |

## CMakeLists.txt Changes
- Removed `dicom_viewer_controller` library definition and link target
- Removed `image_service` library definition and link target
- Cleaned `measurement_service` source list
- Cleaned `dicom_viewer_core` source list
- `dicom_viewer_ui` now links directly to: render_service, measurement_service, segmentation_service, pacs_service, export_service

## Test Plan
- [x] Main application (`dicom_viewer`) builds successfully
- [x] All non-PACS tests pass (993/996, 3 pre-existing failures unrelated to this change)
- [x] PACS test link failures are pre-existing (pacs_system thread_pool symbol issue)
- [x] No remaining stubs in scope (2 UI stubs exist but are out of scope for this issue)