### PR TITLE
docs: remove phantom Controller Layer from README architecture

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -94,22 +94,26 @@
 
 ## 아키텍처
 
-DICOM Viewer는 **4-Layer 아키텍처**를 채택하여 관심사 분리와 유지보수성을 극대화합니다.
+DICOM Viewer는 **3-Layer 아키텍처**를 채택하여 관심사 분리와 유지보수성을 극대화합니다. UI 컴포넌트가 서비스 클래스를 직접 사용하는 구조입니다.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
 │  Presentation Layer (Qt6)                                               │
-│  • MainWindow, ViewportWidget, ToolsPanel, PatientBrowser               │
-├─────────────────────────────────────────────────────────────────────────┤
-│  Controller Layer                                                       │
-│  • ViewerController → Loading, Rendering, Tool, Network Controllers     │
+│  • MainWindow, ViewportWidget, PatientBrowser, ToolsPanel               │
+│  • SegmentationPanel, StatisticsPanel, PacsConfigDialog                 │
 ├─────────────────────────────────────────────────────────────────────────┤
 │  Service Layer                                                          │
-│  • ImageService (ITK) • RenderService (VTK) • NetworkService (pacs)     │
-│  • MeasurementService • SegmentationService                             │
+│  • Render: VolumeRenderer, SurfaceRenderer, MPRRenderer (VTK)           │
+│  • Segmentation: Threshold, RegionGrowing, LevelSet, Watershed (ITK)    │
+│  • Measurement: Linear, Area, Volume, ROI Statistics, ShapeAnalyzer     │
+│  • Preprocessing: Gaussian, AnisotropicDiffusion, N4Bias, Resampler     │
+│  • PACS: DicomFind/Move/Store/Echo (pacs_system)                        │
+│  • Export: Report, MeshExporter, DicomSR, DataExporter                  │
 ├─────────────────────────────────────────────────────────────────────────┤
-│  Data Layer                                                             │
-│  • ImageData (ITK/VTK) • DicomData (pacs_system) • SegmentData          │
+│  Core / Data Layer                                                      │
+│  • DicomLoader, SeriesBuilder, TransferSyntaxDecoder                    │
+│  • HounsfieldConverter, ImageConverter (ITK↔VTK)                        │
+│  • ImageData (ITK/VTK), DicomData (pacs_system), SegmentData            │
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,23 +94,26 @@
 
 ## Architecture
 
-DICOM Viewer adopts a **4-Layer Architecture** to maximize separation of concerns and maintainability.
+DICOM Viewer adopts a **3-Layer Architecture** to maximize separation of concerns and maintainability. UI components access service classes directly without an intermediary controller layer.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
 │  Presentation Layer (Qt6)                                               │
-│  • MainWindow, ViewportWidget, ToolsPanel, PatientBrowser               │
-│  • SegmentationPanel, StatisticsPanel                                   │
-├─────────────────────────────────────────────────────────────────────────┤
-│  Controller Layer                                                       │
-│  • ViewerController → Loading, Rendering, Tool, Network Controllers     │
+│  • MainWindow, ViewportWidget, PatientBrowser, ToolsPanel               │
+│  • SegmentationPanel, StatisticsPanel, PacsConfigDialog                 │
 ├─────────────────────────────────────────────────────────────────────────┤
 │  Service Layer                                                          │
-│  • ImageService (ITK) • RenderService (VTK) • NetworkService (pacs)     │
-│  • MeasurementService • SegmentationService                             │
+│  • Render: VolumeRenderer, SurfaceRenderer, MPRRenderer (VTK)           │
+│  • Segmentation: Threshold, RegionGrowing, LevelSet, Watershed (ITK)    │
+│  • Measurement: Linear, Area, Volume, ROI Statistics, ShapeAnalyzer     │
+│  • Preprocessing: Gaussian, AnisotropicDiffusion, N4Bias, Resampler     │
+│  • PACS: DicomFind/Move/Store/Echo (pacs_system)                        │
+│  • Export: Report, MeshExporter, DicomSR, DataExporter                  │
 ├─────────────────────────────────────────────────────────────────────────┤
-│  Data Layer                                                             │
-│  • ImageData (ITK/VTK) • DicomData (pacs_system) • SegmentData          │
+│  Core / Data Layer                                                      │
+│  • DicomLoader, SeriesBuilder, TransferSyntaxDecoder                    │
+│  • HounsfieldConverter, ImageConverter (ITK↔VTK)                        │
+│  • ImageData (ITK/VTK), DicomData (pacs_system), SegmentData            │
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 


### PR DESCRIPTION
Closes #138

## Summary
- Replace 4-layer architecture diagram with accurate 3-layer diagram in both README.md and README.kr.md
- Remove all references to ViewerController, LoadingController, RenderingController, ToolController, NetworkController
- Update service layer to show actual component class names (VolumeRenderer, ThresholdSegmenter, etc.) instead of facade names (ImageService, RenderService)
- Expand core/data layer listing with actual classes (DicomLoader, SeriesBuilder, etc.)

## Context
The Controller Layer stub files were removed in commit bd239bd (#129), and the SDS was updated in #127, but the README architecture diagrams were never updated. This PR completes the documentation alignment.

## Test Plan
- [x] Verify README.md architecture diagram matches actual codebase (no controller layer, 3-layer design)
- [x] Verify README.kr.md has identical structural changes
- [x] Verify no remaining references to Controller Layer in either README