### PR TITLE
docs(readme): update project structure to reflect actual directory layout

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -184,37 +184,53 @@ cmake --build . --parallel
 ```
 dicom_viewer/
 ├── docs/                           # 문서
-│   ├── PRD.md                      # 제품 요구사항 문서
-│   ├── SRS.md                      # 소프트웨어 요구사항 명세서
-│   ├── SDS.md                      # 소프트웨어 설계 명세서
-│   └── reference/                  # 기술 참조 문서
+│   ├── PRD.md / PRD.kr.md         # 제품 요구사항 문서
+│   ├── SRS.md / SRS.kr.md         # 소프트웨어 요구사항 명세서
+│   ├── SDS.md / SDS.kr.md         # 소프트웨어 설계 명세서
+│   └── reference/                  # 기술 참조 문서 (ITK, VTK, pacs_system)
 ├── include/                        # 헤더 파일
 │   ├── core/                       # 코어 모듈 헤더
 │   │   ├── dicom_loader.hpp        # DICOM 파일 로딩
 │   │   ├── series_builder.hpp      # 시리즈 조립 및 3D 볼륨
-│   │   ├── transfer_syntax_decoder.hpp  # 전송 구문 디코딩 지원
-│   │   ├── hounsfield_converter.hpp  # CT 픽셀 to HU 변환
-│   │   └── image_converter.hpp     # 이미지 포맷 변환
-│   └── services/                   # 서비스 레이어 헤더
-│       ├── volume_renderer.hpp     # GPU 볼륨 렌더링 (CPU 폴백 지원)
-│       ├── transfer_function_manager.hpp  # Transfer Function 프리셋 관리
-│       ├── mpr_renderer.hpp        # MPR (다중 평면 재구성) 뷰
-│       ├── pacs_config.hpp         # PACS 서버 설정
-│       └── dicom_echo_scu.hpp      # DICOM C-ECHO 연결 테스트
+│   │   ├── transfer_syntax_decoder.hpp  # 전송 구문 디코딩
+│   │   ├── hounsfield_converter.hpp  # CT 픽셀 → HU 변환
+│   │   └── image_converter.hpp     # ITK↔VTK 포맷 변환
+│   ├── services/                   # 서비스 레이어 헤더
+│   │   ├── render/                 # Oblique reslice 렌더러
+│   │   ├── measurement/            # 거리, 면적, 부피, ROI, 형상 분석
+│   │   ├── preprocessing/          # Gaussian, 이방성 확산, N4, 리샘플러
+│   │   ├── segmentation/           # 분할 알고리즘 및 라벨 관리
+│   │   ├── export/                 # 리포트, 메시, DICOM SR, 데이터 내보내기
+│   │   ├── coordinate/             # MPR 좌표 변환기
+│   │   ├── volume_renderer.hpp     # GPU 볼륨 렌더링 (CPU 폴백 지원)
+│   │   ├── surface_renderer.hpp    # 등위면 추출 및 렌더링
+│   │   ├── mpr_renderer.hpp        # MPR (다중 평면 재구성) 뷰
+│   │   └── dicom_*_scu.hpp        # PACS 서비스 (Echo, Find, Move, Store)
+│   └── ui/                         # UI 헤더
+│       ├── panels/                 # PatientBrowser, ToolsPanel 등
+│       └── dialogs/                # SettingsDialog, PacsConfigDialog
 ├── src/                            # 소스 코드
+│   ├── app/                        # 앱 진입점 (main.cpp)
 │   ├── core/                       # 핵심 데이터 구조
 │   │   ├── dicom/                  # DICOM 로딩 및 시리즈 조립
 │   │   ├── image/                  # 이미지 처리 및 HU 변환
-│   │   └── data/                   # 환자 데이터 관리
+│   │   └── logging/                # spdlog 기반 로깅
 │   ├── services/                   # 서비스 레이어
-│   │   ├── image/                  # 이미지 처리 서비스
-│   │   ├── render/                 # Volume/Surface/MPR 렌더링
-│   │   ├── measurement/            # 측정 도구
-│   │   ├── segmentation/           # 분할 알고리즘 (Threshold, Region Growing)
-│   │   └── pacs/                   # PACS 연결 (C-ECHO, C-FIND 등)
-│   ├── controller/                 # 컨트롤러 레이어
+│   │   ├── render/                 # Volume/Surface/MPR/Oblique 렌더링
+│   │   ├── measurement/            # 측정 및 통계 도구
+│   │   ├── preprocessing/          # 이미지 필터 (Gaussian, N4 등)
+│   │   ├── segmentation/           # 분할 알고리즘 및 라벨 관리
+│   │   ├── pacs/                   # PACS 연결 (C-ECHO, C-FIND 등)
+│   │   ├── export/                 # 리포트 생성, 메시/데이터 내보내기
+│   │   └── coordinate/             # MPR 좌표 변환
 │   └── ui/                         # Qt UI 컴포넌트
-├── tests/                          # 유닛 및 통합 테스트
+│       ├── widgets/                # ViewportWidget, MPRViewWidget, DRViewer
+│       ├── panels/                 # PatientBrowser, ToolsPanel 등
+│       └── dialogs/                # 설정, PACS 구성
+├── tests/                          # 테스트 스위트
+│   ├── unit/                       # 유닛 테스트 (40+ 파일)
+│   ├── integration/                # 통합 테스트
+│   └── data/                       # 테스트 DICOM 데이터
 ├── LICENSE
 └── README.md
 ```

--- a/README.md
+++ b/README.md
@@ -217,38 +217,53 @@ cmake .. \
 ```
 dicom_viewer/
 ├── docs/                           # Documentation
-│   ├── PRD.md                      # Product Requirements Document
-│   ├── SRS.md                      # Software Requirements Specification
-│   ├── SDS.md                      # Software Design Specification
-│   └── reference/                  # Technical Reference Documentation
+│   ├── PRD.md / PRD.kr.md         # Product Requirements Document
+│   ├── SRS.md / SRS.kr.md         # Software Requirements Specification
+│   ├── SDS.md / SDS.kr.md         # Software Design Specification
+│   └── reference/                  # Technical Reference (ITK, VTK, pacs_system)
 ├── include/                        # Header Files
 │   ├── core/                       # Core module headers
 │   │   ├── dicom_loader.hpp        # DICOM file loading
 │   │   ├── series_builder.hpp      # Series assembly and 3D volume
-│   │   ├── transfer_syntax_decoder.hpp  # Transfer syntax decoding support
+│   │   ├── transfer_syntax_decoder.hpp  # Transfer syntax decoding
 │   │   ├── hounsfield_converter.hpp  # CT pixel to HU conversion
-│   │   └── image_converter.hpp     # Image format conversion
-│   └── services/                   # Service layer headers
-│       ├── volume_renderer.hpp     # GPU volume rendering with CPU fallback
-│       ├── transfer_function_manager.hpp  # Transfer function preset management
-│       ├── mpr_renderer.hpp        # MPR (Multi-Planar Reconstruction) views
-│       ├── pacs_config.hpp         # PACS server configuration
-│       └── dicom_echo_scu.hpp      # DICOM C-ECHO connectivity test
+│   │   └── image_converter.hpp     # ITK↔VTK format conversion
+│   ├── services/                   # Service layer headers
+│   │   ├── render/                 # Oblique reslice renderer
+│   │   ├── measurement/            # Linear, area, volume, ROI, shape tools
+│   │   ├── preprocessing/          # Gaussian, anisotropic, N4, resampler
+│   │   ├── segmentation/           # Threshold, region growing, level set, etc.
+│   │   ├── export/                 # Report, mesh, DICOM SR, data export
+│   │   ├── coordinate/             # MPR coordinate transformer
+│   │   ├── volume_renderer.hpp     # GPU volume rendering with CPU fallback
+│   │   ├── surface_renderer.hpp    # Isosurface extraction and rendering
+│   │   ├── mpr_renderer.hpp        # MPR (Multi-Planar Reconstruction) views
+│   │   └── dicom_*_scu.hpp        # PACS services (Echo, Find, Move, Store)
+│   └── ui/                         # UI headers
+│       ├── panels/                 # PatientBrowser, ToolsPanel, etc.
+│       └── dialogs/                # SettingsDialog, PacsConfigDialog
 ├── src/                            # Source Code
+│   ├── app/                        # Application entry point (main.cpp)
 │   ├── core/                       # Core Data Structures
 │   │   ├── dicom/                  # DICOM loading and series assembly
 │   │   ├── image/                  # Image processing and HU conversion
-│   │   └── data/                   # Patient data management
+│   │   └── logging/                # spdlog-based logging
 │   ├── services/                   # Service Layer
-│   │   ├── image/                  # Image processing services
-│   │   ├── render/                 # Volume/Surface/MPR rendering
-│   │   ├── measurement/            # Measurement tools
-│   │   ├── segmentation/           # Segmentation algorithms (Threshold, Region Growing)
-│   │   └── pacs/                   # PACS connectivity (C-ECHO, C-FIND, etc.)
-│   ├── controller/                 # Controller Layer
+│   │   ├── render/                 # Volume/Surface/MPR/Oblique rendering
+│   │   ├── measurement/            # Measurement and statistics tools
+│   │   ├── preprocessing/          # Image filters (Gaussian, N4, etc.)
+│   │   ├── segmentation/           # Segmentation algorithms and label mgmt
+│   │   ├── pacs/                   # PACS connectivity (C-ECHO, C-FIND, etc.)
+│   │   ├── export/                 # Report generation, mesh/data export
+│   │   └── coordinate/             # MPR coordinate transformations
 │   └── ui/                         # Qt UI Components
-├── tests/                          # Unit and Integration Tests
-│   └── unit/                       # Unit tests
+│       ├── widgets/                # ViewportWidget, MPRViewWidget, DRViewer
+│       ├── panels/                 # PatientBrowser, ToolsPanel, etc.
+│       └── dialogs/                # Settings, PACS configuration
+├── tests/                          # Test Suite
+│   ├── unit/                       # Unit tests (40+ test files)
+│   ├── integration/                # Integration tests
+│   └── data/                       # Test DICOM data
 ├── LICENSE
 └── README.md
 ```


### PR DESCRIPTION
## Summary
- Remove phantom directories that no longer exist: `src/controller/`, `src/services/image/`, `src/core/data/`
- Add all actual directories: `preprocessing/`, `segmentation/`, `export/`, `coordinate/` service subdirectories
- Add UI subdirectories: `widgets/`, `panels/`, `dialogs/`
- Add Korean documentation files (`PRD.kr.md`, `SRS.kr.md`, `SDS.kr.md`)
- Add missing test subdirectories: `unit/`, `integration/`, `data/`
- Update both README.md (English) and README.kr.md (Korean)

Closes #139

## Test Plan
- [x] Verify all listed directories exist in the actual codebase
- [x] Confirm removed directories do not exist
- [x] Both English and Korean READMEs are consistent