### PR TITLE
docs(readme): fix C++ version badge from C++20 to C++23

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -3,7 +3,7 @@
 > **고성능 의료 영상 뷰어** - CT/MRI 3D 볼륨 렌더링 및 MPR 뷰 지원
 
 [![Version](https://img.shields.io/badge/version-0.3.0--pre-orange)](https://github.com)
-[![C++](https://img.shields.io/badge/C++-20-blue.svg)](https://isocpp.org)
+[![C++](https://img.shields.io/badge/C++-23-blue.svg)](https://isocpp.org)
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-green.svg)](LICENSE)
 
 ## 개요

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > **High-Performance Medical Image Viewer** - CT/MRI 3D Volume Rendering and MPR View Support
 
 [![Version](https://img.shields.io/badge/version-0.3.0--pre-orange)](https://github.com)
-[![C++](https://img.shields.io/badge/C++-20-blue.svg)](https://isocpp.org)
+[![C++](https://img.shields.io/badge/C++-23-blue.svg)](https://isocpp.org)
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-green.svg)](LICENSE)
 
 ## Overview


### PR DESCRIPTION
## Summary
- Fix C++ version badge from C++20 to C++23 in both README.md and README.kr.md
- Badge now matches `CMakeLists.txt` `CMAKE_CXX_STANDARD 23` and the Technology Stack table
- Verified `0.3.0--pre` double hyphen is intentional shields.io escaping (renders as `0.3.0-pre`)

Closes #137

## Test Plan
- [x] Badge shows C++23 (consistent with CMakeLists.txt line 10)
- [x] Technology Stack table shows C++23 (no internal inconsistency)
- [x] Both English and Korean READMEs updated consistently
- [x] pacs_system references correctly remain C++20 (different project)