### PR TITLE
docs(sds): fix SDS-MOD-006 UI component implementation status markers

### DIFF
--- a/docs/SDS.kr.md
+++ b/docs/SDS.kr.md
@@ -1143,8 +1143,8 @@ classDiagram
 | ViewportWidget | QVTKOpenGLNativeWidget 기반 VTK 렌더링 위젯 | SRS-FR-056 | ✅ 구현됨 |
 | PatientBrowser | 검색 기능이 있는 환자/검사/시리즈 트리 브라우저 | SRS-FR-057 | ✅ 구현됨 |
 | ToolsPanel | Window/Level 컨트롤, 프리셋, 시각화 모드 | SRS-FR-058 | ✅ 구현됨 |
-| SegmentationPanel | 분할 도구 패널 | SRS-FR-024 | ⏳ 계획됨 |
-| MeasurementPanel | 측정 도구 패널 | SRS-FR-036 | ⏳ 계획됨 |
+| SegmentationPanel | 분할 도구 패널 (브러시, 지우개, 채우기, 폴리곤, 스마트 가위) | SRS-FR-024 | ✅ 구현됨 |
+| StatisticsPanel | ROI 통계 표시, 히스토그램, 다중 ROI 비교, CSV 내보내기 | SRS-FR-028 | ✅ 구현됨 |
 
 **Widget Hierarchy**:
 

--- a/docs/SDS.md
+++ b/docs/SDS.md
@@ -1143,8 +1143,8 @@ classDiagram
 | ViewportWidget | VTK rendering widget with QVTKOpenGLNativeWidget | SRS-FR-056 | ✅ Implemented |
 | PatientBrowser | Patient/study/series tree browser with search | SRS-FR-057 | ✅ Implemented |
 | ToolsPanel | Window/level controls, presets, visualization modes | SRS-FR-058 | ✅ Implemented |
-| SegmentationPanel | Segmentation tools panel | SRS-FR-024 | ⏳ Planned |
-| MeasurementPanel | Measurement tools panel | SRS-FR-036 | ⏳ Planned |
+| SegmentationPanel | Segmentation tools panel (brush, eraser, fill, polygon, smart scissors) | SRS-FR-024 | ✅ Implemented |
+| StatisticsPanel | ROI statistics display, histogram, multi-ROI comparison, CSV export | SRS-FR-028 | ✅ Implemented |
 
 **Widget Hierarchy**:
 


### PR DESCRIPTION
## Summary
- Update `SegmentationPanel` status from `Planned` to `Implemented` — class exists at `include/ui/panels/segmentation_panel.hpp` and `src/ui/panels/segmentation_panel.cpp`
- Replace non-existent `MeasurementPanel` with actual `StatisticsPanel` class — handles ROI statistics display, histogram visualization, multi-ROI comparison, and CSV export
- Update traceability from SRS-FR-036 to SRS-FR-028 (matching StatisticsPanel's actual trace)
- Add detailed component descriptions matching actual implementation
- Both English (SDS.md) and Korean (SDS.kr.md) versions updated consistently

### Design Note
The Widget Hierarchy's "Measurement Panel (QGroupBox)" at line 1227 remains unchanged — it correctly describes a sub-widget group within ToolsPanel, not a standalone panel class. The component table fix resolves the confusion between top-level panel classes and internal QGroupBox sections.

Closes #140

## Test Plan
- [x] Every component in the table has corresponding .hpp and .cpp files
- [x] All 6 components now show Implemented status
- [x] Component names match actual C++ class names
- [x] SRS traceability references verified against actual code annotations
- [x] English and Korean versions are consistent