### PR TITLE
docs(sds): clarify service interface definitions as design-only references

### DIFF
--- a/docs/SDS.kr.md
+++ b/docs/SDS.kr.md
@@ -864,6 +864,9 @@ classDiagram
 | TransferFunctionManager | Transfer Function 프리셋 관리 | SRS-FR-006 |
 | DRViewer | 전용 DR/CR 2D 뷰어 | SRS-FR-042 ~ SRS-FR-044 |
 
+> **구현 참고**: 아래 클래스 다이어그램에는 원래 설계의 `IRenderService` 인터페이스가 포함되어 있습니다.
+> 이 인터페이스는 **구현되지 않았으며** — 컴포넌트에 직접 접근합니다. 자세한 내용은 SDS-IF-001을 참조하세요.
+
 **Class Diagram**:
 
 ```
@@ -955,6 +958,9 @@ classDiagram
 | ROIStatistics | 평균, 표준편차, 최소/최대, 히스토그램 | SRS-FR-046 ~ SRS-FR-048 |
 | ShapeAnalyzer | 구형도, 신장도, 주축 분석 | SRS-FR-049 |
 | MPRCoordinateTransformer | 월드/화면/영상 좌표 변환 | SRS-FR-008 |
+
+> **구현 참고**: 아래 클래스 다이어그램에는 원래 설계의 `IMeasurementService` 인터페이스가 포함되어 있습니다.
+> 이 인터페이스는 **구현되지 않았으며** — 컴포넌트에 직접 접근합니다. 자세한 내용은 SDS-IF-001을 참조하세요.
 
 **Class Diagram**:
 
@@ -1537,20 +1543,36 @@ const std::vector<TransferFunctionPreset> CT_PRESETS = {
 
 ## 5. Interface Design
 
-### SDS-IF-001: Public API Interfaces
+### SDS-IF-001: 서비스 파사드 인터페이스 — 향후 설계 참고
 
 **Traces to**: SRS-IF-001 ~ SRS-IF-010
 
-> **구현 상태**: 아래 인터페이스 클래스 (`IImageService`, `IRenderService`,
-> `IMeasurementService`, `INetworkService`)는 **원래 설계 명세**를 나타냅니다.
-> 현재 코드베이스에서는 추상 인터페이스로 **구현되지 않았으며**, 서비스 파사드 계층 없이
-> **직접 컴포넌트 클래스** (예: `VolumeRenderer`, `ThresholdSegmenter`, `DicomFindSCU`)를
-> 사용합니다. 이 인터페이스 정의는 향후 의존성 주입 리팩터링을 위한 설계 참고로 유지됩니다.
+> **미구현 — 설계 참고 전용**
+>
+> 아래 인터페이스 클래스 (`IImageService`, `IRenderService`, `IMeasurementService`,
+> `INetworkService`)는 현재 코드베이스에 **구현되어 있지 않습니다**. 원래 파사드 패턴 설계를
+> 나타내며, 향후 의존성 주입 리팩터링을 위한 참고로 유지됩니다.
+>
+> **현재 아키텍처**: 코드베이스는 **직접 컴포넌트 접근** 방식을 사용합니다 — UI와 서비스 코드가
+> 파사드 계층 없이 개별 컴포넌트 클래스를 직접 인스턴스화합니다.
+> 실제 컴포넌트 헤더는 `include/services/`를 참조하세요.
+
+**설계 인터페이스 → 실제 컴포넌트 매핑**:
+
+| 설계 인터페이스 | 실제 컴포넌트 (직접 접근) |
+|----------------|--------------------------|
+| `IImageService` | `DicomLoader`, `SeriesBuilder`, `GaussianSmoother`, `AnisotropicDiffusionFilter`, `N4BiasCorrector`, `IsotropicResampler`, `ThresholdSegmenter`, `RegionGrowingSegmenter`, `LevelSetSegmenter`, `WatershedSegmenter`, `MorphologyProcessor` |
+| `IRenderService` | `VolumeRenderer`, `SurfaceRenderer`, `MprRenderer`, `ObliqueSliceRenderer`, `TransferFunctionManager` |
+| `IMeasurementService` | `LinearMeasurementTool`, `AreaMeasurementTool`, `VolumeMeasurementTool`, `RoiStatistics`, `ShapeAnalyzer`, `ReportGenerator` |
+| `INetworkService` | `DicomEchoScu`, `DicomFindScu`, `DicomMoveScu`, `DicomStoreScp`, `PacsConfig` |
+
+<details>
+<summary><strong>향후 설계 참고 — 인터페이스 정의 (클릭하여 펼치기)</strong></summary>
 
 ```cpp
-// Service Interfaces — 설계 참고 (미구현)
-// 실제 구현은 직접 컴포넌트 접근 패턴을 사용합니다.
-// 현재 API는 include/services/ 내 개별 컴포넌트 헤더를 참조하세요.
+// Service Interfaces — 향후 설계 참고 (미구현)
+// 현재 코드베이스는 이 인터페이스를 사용하지 않습니다.
+// 실제 컴포넌트 클래스는 위의 매핑 테이블을 참조하세요.
 namespace dicom_viewer {
 
 // Image Service Interface
@@ -1686,14 +1708,23 @@ public:
 } // namespace dicom_viewer
 ```
 
+</details>
+
 ---
 
-### SDS-IF-002: Signal/Slot Interfaces (Qt)
+### SDS-IF-002: Signal/Slot 인터페이스 (Qt) — 설계 참고
 
 **Traces to**: SRS-IF-011 ~ SRS-IF-015
 
+> **설계 참고**: 아래 통합 시그널 클래스 (`ViewportSignals`, `PatientBrowserSignals`,
+> `ToolsPanelSignals`)는 별도 클래스로 **구현되어 있지 않습니다**. 현재 코드베이스에서
+> Qt 시그널은 **각 패널/위젯 클래스 내부에 직접 정의**되어 있습니다 (예:
+> `SegmentationPanel::toolChanged`, `StatisticsPanel::exportRequested`,
+> `PatientBrowser::seriesSelected`). 별도의 `signals.hpp` 파일은 존재하지 않습니다.
+
 ```cpp
-// UI Signal/Slot Interfaces (include/ui/signals.hpp)
+// UI Signal/Slot Interfaces — 설계 참고 (별도 클래스로 미구현)
+// 실제 시그널은 각 패널/위젯 클래스 내부에 정의되어 있습니다.
 namespace dicom_viewer {
 
 // Viewport Signals

--- a/docs/SDS.md
+++ b/docs/SDS.md
@@ -864,6 +864,9 @@ classDiagram
 | TransferFunctionManager | Transfer function preset management | SRS-FR-006 |
 | DRViewer | Dedicated DR/CR 2D viewer | SRS-FR-042 ~ SRS-FR-044 |
 
+> **Implementation Note**: The class diagram below shows an `IRenderService` interface from the original design.
+> This interface is **not implemented** — components are accessed directly. See SDS-IF-001 for details.
+
 **Class Diagram**:
 
 ```
@@ -955,6 +958,9 @@ classDiagram
 | ROIStatistics | Mean, StdDev, Min/Max, histogram for ROI | SRS-FR-046 ~ SRS-FR-048 |
 | ShapeAnalyzer | Sphericity, elongation, principal axes | SRS-FR-049 |
 | MPRCoordinateTransformer | World/screen/image coordinate conversion | SRS-FR-008 |
+
+> **Implementation Note**: The class diagram below shows an `IMeasurementService` interface from the original design.
+> This interface is **not implemented** — components are accessed directly. See SDS-IF-001 for details.
 
 **Class Diagram**:
 
@@ -1563,21 +1569,37 @@ const std::vector<TransferFunctionPreset> CT_PRESETS = {
 
 ## 5. Interface Design
 
-### SDS-IF-001: Public API Interfaces
+### SDS-IF-001: Service Facade Interfaces — Future Design Reference
 
 **Traces to**: SRS-IF-001 ~ SRS-IF-010
 
-> **Implementation Status**: The interface classes below (`IImageService`, `IRenderService`,
-> `IMeasurementService`, `INetworkService`) represent the **original design specification**.
-> They are **not yet implemented** as abstract interfaces. The current codebase uses
-> **direct component classes** (e.g., `VolumeRenderer`, `ThresholdSegmenter`, `DicomFindSCU`)
-> without a service facade layer. These interface definitions are retained as a design reference
-> for potential future refactoring toward dependency injection.
+> **NOT IMPLEMENTED — DESIGN REFERENCE ONLY**
+>
+> The interface classes below (`IImageService`, `IRenderService`, `IMeasurementService`,
+> `INetworkService`) are **not implemented** in the current codebase. They represent the
+> original facade pattern design and are retained as a reference for potential future
+> refactoring toward dependency injection.
+>
+> **Current Architecture**: The codebase uses **direct component access** — UI and service
+> code instantiate individual component classes directly without a facade layer.
+> See `include/services/` for actual component headers.
+
+**Design Interface → Actual Component Mapping**:
+
+| Design Interface | Actual Components (Direct Access) |
+|-----------------|-----------------------------------|
+| `IImageService` | `DicomLoader`, `SeriesBuilder`, `GaussianSmoother`, `AnisotropicDiffusionFilter`, `N4BiasCorrector`, `IsotropicResampler`, `ThresholdSegmenter`, `RegionGrowingSegmenter`, `LevelSetSegmenter`, `WatershedSegmenter`, `MorphologyProcessor` |
+| `IRenderService` | `VolumeRenderer`, `SurfaceRenderer`, `MprRenderer`, `ObliqueSliceRenderer`, `TransferFunctionManager` |
+| `IMeasurementService` | `LinearMeasurementTool`, `AreaMeasurementTool`, `VolumeMeasurementTool`, `RoiStatistics`, `ShapeAnalyzer`, `ReportGenerator` |
+| `INetworkService` | `DicomEchoScu`, `DicomFindScu`, `DicomMoveScu`, `DicomStoreScp`, `PacsConfig` |
+
+<details>
+<summary><strong>Future Design Reference — Interface Definitions (click to expand)</strong></summary>
 
 ```cpp
-// Service Interfaces — DESIGN REFERENCE (not yet implemented)
-// Actual implementation uses direct component access pattern.
-// See individual component headers in include/services/ for current API.
+// Service Interfaces — FUTURE DESIGN REFERENCE (not implemented)
+// The current codebase does NOT use these interfaces.
+// See the mapping table above for actual component classes.
 namespace dicom_viewer {
 
 // Image Service Interface
@@ -1713,14 +1735,23 @@ public:
 } // namespace dicom_viewer
 ```
 
+</details>
+
 ---
 
-### SDS-IF-002: Signal/Slot Interfaces (Qt)
+### SDS-IF-002: Signal/Slot Interfaces (Qt) — Design Reference
 
 **Traces to**: SRS-IF-011 ~ SRS-IF-015
 
+> **Design Reference**: The consolidated signal classes below (`ViewportSignals`,
+> `PatientBrowserSignals`, `ToolsPanelSignals`) are **not implemented** as separate classes.
+> In the current codebase, Qt signals are defined **directly within each panel/widget class**
+> (e.g., `SegmentationPanel::toolChanged`, `StatisticsPanel::exportRequested`,
+> `PatientBrowser::seriesSelected`). No separate `signals.hpp` file exists.
+
 ```cpp
-// UI Signal/Slot Interfaces (include/ui/signals.hpp)
+// UI Signal/Slot Interfaces — DESIGN REFERENCE (not implemented as separate classes)
+// Actual signals are defined within individual panel/widget classes.
 namespace dicom_viewer {
 
 // Viewport Signals


### PR DESCRIPTION
## Summary
- **SDS-IF-001**: Rename to "Service Facade Interfaces - Future Design Reference" with prominent NOT IMPLEMENTED notice
- Add design interface to actual component mapping table showing what classes to use instead
- Wrap ~150 lines of unimplemented interface code in collapsible `<details>` section to reduce visual prominence
- **SDS-IF-002**: Add Design Reference label and note that Signal classes are not separate files — actual signals live within each panel/widget class
- **SDS-MOD-003, MOD-004**: Add Implementation Notes to class diagrams clarifying `IRenderService` and `IMeasurementService` interfaces are not implemented
- All changes applied to both SDS.md (English) and SDS.kr.md (Korean)

### Rationale
Despite the disclaimer added in #127, the full code blocks with method signatures still read as active architecture. The collapsible section, mapping table, and cross-referenced notes across MOD sections eliminate ambiguity for new contributors.

Closes #141

## Test Plan
- [x] SDS-IF-001 clearly marked as Future Design Reference
- [x] Mapping table correctly maps each interface to actual component classes
- [x] Interface code blocks collapsed by default via `<details>`
- [x] SDS-IF-002 noted as design reference with explanation of actual signal locations
- [x] MOD-003 and MOD-004 class diagrams have interface disclaimers
- [x] MOD-002 already had disclaimer (unchanged)
- [x] MOD-005 already had pacs_system migration note (unchanged)
- [x] English and Korean versions consistent