### PR TITLE
docs(prd): add FR-014 4D Flow MRI requirements and tiered NFR targets

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -962,7 +962,8 @@
 | M5.5 | Flow visualization | Streamlines, pathlines, vector glyphs |
 | M5.6 | Flow quantification | Flow rate at cross-section, time-velocity curves |
 | M5.7 | Advanced analysis | WSS, OSI, TKE on vessel boundaries |
-| M5.8 | Integration testing | End-to-end validation with analytical ground truth |
+| M5.8 | Flow export and reporting | CSV export of flow results, PDF report integration |
+| M5.9 | Integration testing | End-to-end validation with analytical ground truth |
 
 ---
 


### PR DESCRIPTION
Closes #149

## Summary
- Added **FR-014** (4D Flow MRI Analysis) with 21 sub-requirements across 6 groups (A-F):
  - A: DICOM Parsing and Data Assembly (FR-014.1~4)
  - B: Flow Visualization (FR-014.5~8)
  - C: Temporal Navigation (FR-014.9~11)
  - D: Flow Quantification (FR-014.12~15)
  - E: Advanced Hemodynamic Analysis (FR-014.16~19)
  - F: Export and Reporting (FR-014.20~21)
- Added **NFR-016~020** tiered performance targets for 4D Flow datasets
- Added **UC-11, UC-12** use cases for flow visualization and WSS analysis
- Added **Milestone 5** (v0.6.0, Week 17-24) for 4D Flow implementation
- Updated release timeline, technical risks, and MR modality description
- Bumped PRD version to **0.4.0**

## Test Plan

- [x] Verify all FR-014.x requirements are properly numbered and categorized
  - FR-014.1~21 sequential, 6 groups (A~F) correctly organized
- [x] Verify NFR-016~020 have measurable targets
  - All 5 NFRs have numeric thresholds (seconds, count, FPS)
- [x] Verify UC-11, UC-12 are consistent with FR-014 requirements
  - UC-11 → FR-014.5 (Streamlines) + FR-014.12 (Flow rate)
  - UC-12 → FR-014.16 (WSS)
- [x] Verify Milestone 5 items map to FR-014 sub-groups
  - M5.1~3 → FR-014.A, M5.4 → FR-014.C, M5.5 → FR-014.B
  - M5.6 → FR-014.D, M5.7 → FR-014.E, M5.8 → FR-014.F, M5.9 → cross-cutting
  - Initially FR-014.F was missing from milestones; fixed in commit a75b3ec
- [x] Verify version history entry is accurate
  - v0.4.0 entry correctly lists FR-014 (21 sub-reqs), NFR-016~020, UC-11/12, M5
- [x] Verify ASCII art diagrams render correctly
  - Pipeline diagram (4D Flow MRI Pipeline) and timeline diagram both properly aligned