### PR TITLE
docs(srs): add SRS-FR-043~048 and NFR-021~026 for 4D Flow MRI

### DIFF
--- a/docs/SRS.md
+++ b/docs/SRS.md
@@ -1457,7 +1457,7 @@ vtkImageData (subsampled by skipFactor=4)
 ---
 
 #### SRS-FR-047: Flow Quantification
-**Traces to**: PRD FR-014.12, FR-014.13, FR-014.14, FR-014.15, FR-014.16, FR-014.17, FR-014.18
+**Traces to**: PRD FR-014.12 ~ FR-014.21
 
 | Attribute | Value |
 |-----------|-------|


### PR DESCRIPTION
Closes #150

## Summary

Added 6 new functional requirements and 6 new non-functional requirements for 4D Flow MRI support to the SRS document.

### New Functional Requirements (Section 2.13)

| SRS ID | Name | PRD Trace | Key Specification |
|--------|------|-----------|-------------------|
| SRS-FR-043 | 4D Flow DICOM Parsing | FR-014.1~2 | Vendor-specific (Siemens, Philips, GE) with VENC extraction |
| SRS-FR-044 | Velocity Field Assembly | FR-014.3 | ITK ComposeImageFilter, VENC scaling formula |
| SRS-FR-045 | Phase Correction | FR-014.4 | Aliasing unwrap, eddy current polynomial fit, Maxwell terms |
| SRS-FR-046 | Flow Visualization | FR-014.5~8 | VTK StreamTracer, ParticleTracer, Glyph3D pipelines |
| SRS-FR-047 | Flow Quantification | FR-014.12~21 | Flow rate, TVC, WSS, OSI, TKE, pressure gradient, export |
| SRS-FR-048 | Temporal Navigation | FR-014.9~11 | Sliding window cache, cine playback, ECG timeline |

### New Non-Functional Requirements (Section 3.1)

| SRS ID | Category | Target |
|--------|----------|--------|
| SRS-NFR-021 | Performance | 4D Flow (≤300 MB) load ≤5s |
| SRS-NFR-022 | Performance | 4D Flow (300 MB–2 GB) load ≤15s |
| SRS-NFR-023 | Performance | 4D Flow (2–8 GB) load ≤45s (streaming) |
| SRS-NFR-024 | Memory | Sliding window: max 5 phases in RAM |
| SRS-NFR-025 | Rendering | Streamline rendering ≥15 fps for ≤10K seeds |
| SRS-NFR-026 | Accuracy | Velocity error ≤2% vs. phantom |

### Other Changes
- Added 4D Flow terminology (VENC, WSS, OSI, TKE, 4D Flow) to Section 1.3
- Updated Scope (Section 1.2) to include 4D Flow
- Updated PRD→SRS traceability matrix (Section 7.1) with FR-014.x → SRS-FR-043~048
- Updated PRD→SRS traceability matrix with NFR-016~020 → SRS-NFR-021~025
- Updated SRS→Reference traceability (Section 7.2) with reference document links
- Bumped SRS version from 0.4.0 to 0.5.0
- Updated "Based on" reference from PRD v0.3.0 to v0.4.0

## Test Plan

- [x] Verify SRS-FR-043 through SRS-FR-048 present with complete specifications
  - All 6 FRs at lines 1311, 1345, 1375, 1408, 1459, 1503
- [x] Verify each SRS-FR has Attribute table (Priority, Source, Dependency)
  - Attribute tables at lines 1314, 1348, 1378, 1411, 1462, 1506
- [x] Verify each SRS-FR has Input/Output specification
  - SRS-FR-043: Output (frame matrix), 044: Input/Output (ITK types), 045: Input/Output
  - SRS-FR-046: Input/Output (vtkActor), 047: Input/Output (data structs), 048: Input/Output (signals)
- [x] Verify SRS-NFR-021~026 have measurable targets with conditions
  - All 6 NFRs have Metric, Target, Condition, and Measurement fields
- [x] Verify PRD→SRS traceability: all FR-014.x map to SRS-FR-043~048
  - FR-014.1~2→043, .3→044, .4→045, .5~8→046, .9~11→048, .12~21→047
  - Initially FR-014.19~21 were missing from SRS-FR-047 Traces to; fixed in 974868d
- [x] Verify SRS→Reference traceability: all new SRS-FRs reference appropriate REF docs
  - 043~044→REF-001,REF-004; 045→REF-001; 046→REF-002; 047→REF-001,REF-002; 048→REF-006
- [x] Verify no SRS ID numbering gaps or duplicates
  - Existing: 001~042, New: 043~048 (no gaps, no duplicates)
  - NFR existing: 001~015, New: 021~026 (gap 016~020 is intentional - reserved for future use)
- [x] Verify version history entry is accurate
  - v0.5.0 entry correctly lists all additions