### PR TITLE
docs(sds): add SDS-MOD-007 Flow Analysis Module design

### DIFF
--- a/docs/SDS.md
+++ b/docs/SDS.md
@@ -2763,7 +2763,7 @@ sequenceDiagram
 
 ### SDS-SEQ-007: Flow Quantification Sequence
 
-**Traces to**: SRS-FR-047
+**Traces to**: SRS-FR-047, SRS-FR-048
 
 #### Mermaid Version
 
@@ -2921,7 +2921,7 @@ sequenceDiagram
 | SRS-FR-045 | SDS-MOD-007 (PhaseCorrector), SDS-SEQ-005 | Flow Analysis |
 | SRS-FR-046 | SDS-MOD-007 (FlowVisualizer), SDS-SEQ-006 | Flow Analysis |
 | SRS-FR-047 | SDS-MOD-007 (FlowQuantifier, VesselAnalyzer), SDS-SEQ-007 | Flow Analysis |
-| SRS-FR-048 | SDS-MOD-007 (TemporalNavigator), SDS-DATA-006 | Flow Analysis |
+| SRS-FR-048 | SDS-MOD-007 (TemporalNavigator), SDS-DATA-006, SDS-SEQ-006, SDS-SEQ-007 | Flow Analysis |
 
 ---
 


### PR DESCRIPTION
## Summary
- Added SDS-MOD-007 Flow Analysis Module with 7 components: FlowDicomParser, VelocityFieldAssembler, PhaseCorrector, FlowVisualizer, FlowQuantifier, VesselAnalyzer, TemporalNavigator
- Added SDS-DATA-006 flow data structures (FlowSeriesInfo, VelocityPhase, FlowMeasurement, TimeVelocityCurve, WSSResult, HemodynamicResults, CacheStatus)
- Added SDS-SEQ-005 (4D Flow DICOM Load and Assembly), SDS-SEQ-006 (Flow Visualization Pipeline), SDS-SEQ-007 (Flow Quantification) sequence diagrams
- Updated SDS-ARCH-002 layer responsibilities (SRS-FR-001 through SRS-FR-048)
- Updated SDS-ARCH-003 module dependency graph with flow_service
- Updated traceability matrices (7.1, 7.2, 7.3) for FR-014 / SRS-FR-043~048
- Updated Section 8.1 file structure with flow module headers, sources, and test files
- Updated Design Patterns (Strategy: added Vendor Flow Parsers)
- Bumped SDS version from 0.4.0 to 0.5.0; based on SRS v0.5.0, PRD v0.4.0

Closes #151

## Test Plan (Verified)
- [x] SDS-MOD-007 section present with all 7 components in table (lines 1278-1284)
- [x] Mermaid class diagram renders correctly — FlowDicomParser hierarchy, all component classes (lines 1290-1416)
- [x] ASCII architecture diagram shows flow module structure (lines 1421-1464)
- [x] SDS-DATA-006 contains all 10 flow data structures: FlowSeriesInfo, VelocityPhase, PhaseCorrectionConfig, FlowVisualizationParams, FlowMeasurement, TimeVelocityCurve, WSSResult, HemodynamicResults, PlaybackState, CacheStatus (lines 1793-1950)
- [x] SDS-SEQ-005/006/007 sequence diagrams present with both Mermaid and ASCII versions (lines 2577-2869)
- [x] SDS-ARCH-002 traces updated to SRS-FR-048 (line 239)
- [x] SDS-ARCH-003 graph includes flow_service with dependencies on CoreLib, ImgSvc, RndSvc (lines 277, 299, 305-307)
- [x] Section 7.1: FR-014 row present mapping to SRS-FR-043~048 (line 2888)
- [x] Section 7.2: 6 new rows mapping SRS-FR-043~048 to SDS-MOD-007 components (lines 2919-2924)
- [x] Section 7.3: 7 new FR-014.x rows with correct SRS and SDS mappings (lines 2972-2978)
- [x] No references to non-existent SRS-FR-049+ remain (grep verified: 0 matches)
- [x] File structure includes include/services/flow/ and src/services/flow/ directories (lines 3055-3068, 3148-3162)
- [x] Version history shows v0.5.0 entry (lines 22, 3251)

### Post-Verification Fix (af18fcb)
- SDS-SEQ-007 Traces to: added SRS-FR-048 (TemporalNavigator participates via getAllCachedPhases())
- Section 7.2 SRS-FR-048 row: added SDS-SEQ-006 and SDS-SEQ-007 references for consistency