### PR TITLE
feat(flow): implement VelocityFieldAssembler for 3D vector field construction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -489,6 +489,7 @@ target_link_libraries(export_service PUBLIC
 # Flow analysis service (4D Flow MRI)
 add_library(flow_service STATIC
     src/services/flow/flow_dicom_parser.cpp
+    src/services/flow/velocity_field_assembler.cpp
     src/services/flow/vendor_parsers/siemens_flow_parser.cpp
     src/services/flow/vendor_parsers/philips_flow_parser.cpp
     src/services/flow/vendor_parsers/ge_flow_parser.cpp

--- a/include/services/flow/velocity_field_assembler.hpp
+++ b/include/services/flow/velocity_field_assembler.hpp
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <expected>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <itkImage.h>
+#include <itkVectorImage.h>
+
+#include "services/flow/flow_dicom_types.hpp"
+
+namespace dicom_viewer::services {
+
+/// Common ITK type aliases for 4D Flow operations
+using FloatImage3D = itk::Image<float, 3>;
+using VectorImage3D = itk::VectorImage<float, 3>;
+
+/**
+ * @brief Assembled velocity field for one cardiac phase
+ *
+ * Contains a 3-component vector field (Vx, Vy, Vz) and the corresponding
+ * magnitude image for a single cardiac phase in the 4D Flow sequence.
+ *
+ * @trace SRS-FR-044
+ */
+struct VelocityPhase {
+    VectorImage3D::Pointer velocityField;   ///< 3-component (Vx, Vy, Vz)
+    FloatImage3D::Pointer magnitudeImage;   ///< Magnitude image
+    int phaseIndex = 0;                     ///< 0-based cardiac phase index
+    double triggerTime = 0.0;               ///< ms from R-wave
+};
+
+/**
+ * @brief Assembles 3D velocity vector fields from parsed 4D Flow DICOM frames
+ *
+ * Takes the frame matrix produced by FlowDicomParser and constructs a temporal
+ * sequence of 3D velocity vector fields using ITK image types.
+ *
+ * Pipeline:
+ * @code
+ * FlowSeriesInfo (from FlowDicomParser)
+ *   → Read scalar DICOM volumes (Magnitude, Vx, Vy, Vz)
+ *   → Apply VENC scaling to convert pixel values to velocity (cm/s)
+ *   → Compose 3 scalar volumes into VectorImage3D
+ *   → Output VelocityPhase per cardiac phase
+ * @endcode
+ *
+ * @trace SRS-FR-044
+ */
+class VelocityFieldAssembler {
+public:
+    /// Progress callback (0.0 to 1.0)
+    using ProgressCallback = std::function<void(double progress)>;
+
+    VelocityFieldAssembler();
+    ~VelocityFieldAssembler();
+
+    // Non-copyable, movable
+    VelocityFieldAssembler(const VelocityFieldAssembler&) = delete;
+    VelocityFieldAssembler& operator=(const VelocityFieldAssembler&) = delete;
+    VelocityFieldAssembler(VelocityFieldAssembler&&) noexcept;
+    VelocityFieldAssembler& operator=(VelocityFieldAssembler&&) noexcept;
+
+    /**
+     * @brief Set progress callback for long operations
+     * @param callback Callback function receiving progress (0.0 to 1.0)
+     */
+    void setProgressCallback(ProgressCallback callback);
+
+    /**
+     * @brief Assemble all cardiac phases into velocity fields
+     *
+     * Reads pixel data for each phase and component, applies VENC scaling,
+     * and composes vector fields.
+     *
+     * @param seriesInfo Parsed series from FlowDicomParser
+     * @return Vector of VelocityPhase on success, FlowError on failure
+     */
+    [[nodiscard]] std::expected<std::vector<VelocityPhase>, FlowError>
+    assembleAllPhases(const FlowSeriesInfo& seriesInfo) const;
+
+    /**
+     * @brief Assemble a single cardiac phase (on-demand loading)
+     *
+     * @param seriesInfo Parsed series from FlowDicomParser
+     * @param phaseIndex 0-based cardiac phase index
+     * @return VelocityPhase on success, FlowError on failure
+     */
+    [[nodiscard]] std::expected<VelocityPhase, FlowError>
+    assemblePhase(const FlowSeriesInfo& seriesInfo, int phaseIndex) const;
+
+    /**
+     * @brief Apply VENC scaling to convert pixel values to velocity
+     *
+     * @param pixelValue Raw pixel value from DICOM
+     * @param venc Velocity encoding value (cm/s)
+     * @param maxPixelValue Maximum possible pixel value (2^bitsStored or 2^(bitsStored-1))
+     * @param isSigned Whether the phase data uses signed representation
+     * @return Velocity in cm/s
+     */
+    [[nodiscard]] static float applyVENCScaling(
+        float pixelValue, double venc, int maxPixelValue, bool isSigned);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace dicom_viewer::services

--- a/src/services/flow/velocity_field_assembler.cpp
+++ b/src/services/flow/velocity_field_assembler.cpp
@@ -1,0 +1,264 @@
+#include "services/flow/velocity_field_assembler.hpp"
+
+#include <cmath>
+
+#include <itkCastImageFilter.h>
+#include <itkComposeImageFilter.h>
+#include <itkGDCMImageIO.h>
+#include <itkGDCMSeriesFileNames.h>
+#include <itkImageSeriesReader.h>
+#include <itkMultiplyImageFilter.h>
+#include <itkSubtractImageFilter.h>
+
+#include "core/logging.hpp"
+
+namespace {
+
+auto& getLogger() {
+    static auto logger = dicom_viewer::logging::LoggerFactory::create(
+        "VelocityFieldAssembler");
+    return logger;
+}
+
+using FloatImage3D = dicom_viewer::services::FloatImage3D;
+using VectorImage3D = dicom_viewer::services::VectorImage3D;
+
+/// Read a 3D scalar volume from a list of DICOM slice files
+FloatImage3D::Pointer readScalarVolume(
+    const std::vector<std::string>& sliceFiles) {
+    using ReaderType = itk::ImageSeriesReader<FloatImage3D>;
+    auto reader = ReaderType::New();
+    auto gdcmIO = itk::GDCMImageIO::New();
+    reader->SetImageIO(gdcmIO);
+    reader->SetFileNames(sliceFiles);
+    reader->Update();
+    return reader->GetOutput();
+}
+
+/// Compose 3 scalar images into a vector image
+VectorImage3D::Pointer composeVectorField(
+    FloatImage3D::Pointer vx,
+    FloatImage3D::Pointer vy,
+    FloatImage3D::Pointer vz) {
+    using ComposerType = itk::ComposeImageFilter<FloatImage3D, VectorImage3D>;
+    auto composer = ComposerType::New();
+    composer->SetInput(0, vx);
+    composer->SetInput(1, vy);
+    composer->SetInput(2, vz);
+    composer->Update();
+    return composer->GetOutput();
+}
+
+/// Apply VENC scaling to all pixels of a scalar image (in-place)
+void applyVENCScalingToImage(
+    FloatImage3D::Pointer image,
+    double venc,
+    bool isSigned) {
+    using IteratorType = itk::ImageRegionIterator<FloatImage3D>;
+    IteratorType it(image, image->GetLargestPossibleRegion());
+
+    if (isSigned) {
+        // Signed: assume pixel range is already centered around 0
+        // Find max absolute pixel value for normalization
+        float maxAbs = 0.0f;
+        for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+            float absVal = std::abs(it.Get());
+            if (absVal > maxAbs) {
+                maxAbs = absVal;
+            }
+        }
+
+        if (maxAbs > 0.0f) {
+            float scale = static_cast<float>(venc) / maxAbs;
+            for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+                it.Set(it.Get() * scale);
+            }
+        }
+    } else {
+        // Unsigned: pixel range [0, maxVal], midpoint = maxVal/2
+        float maxVal = 0.0f;
+        for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+            if (it.Get() > maxVal) {
+                maxVal = it.Get();
+            }
+        }
+
+        if (maxVal > 0.0f) {
+            float midpoint = maxVal / 2.0f;
+            float scale = static_cast<float>(venc) / midpoint;
+            for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+                it.Set((it.Get() - midpoint) * scale);
+            }
+        }
+    }
+}
+
+}  // anonymous namespace
+
+namespace dicom_viewer::services {
+
+class VelocityFieldAssembler::Impl {
+public:
+    VelocityFieldAssembler::ProgressCallback progressCallback;
+
+    void reportProgress(double progress) const {
+        if (progressCallback) {
+            progressCallback(progress);
+        }
+    }
+};
+
+VelocityFieldAssembler::VelocityFieldAssembler()
+    : impl_(std::make_unique<Impl>()) {}
+
+VelocityFieldAssembler::~VelocityFieldAssembler() = default;
+
+VelocityFieldAssembler::VelocityFieldAssembler(VelocityFieldAssembler&&) noexcept = default;
+VelocityFieldAssembler& VelocityFieldAssembler::operator=(VelocityFieldAssembler&&) noexcept = default;
+
+void VelocityFieldAssembler::setProgressCallback(ProgressCallback callback) {
+    impl_->progressCallback = std::move(callback);
+}
+
+std::expected<std::vector<VelocityPhase>, FlowError>
+VelocityFieldAssembler::assembleAllPhases(const FlowSeriesInfo& seriesInfo) const {
+    auto logger = getLogger();
+
+    if (seriesInfo.frameMatrix.empty()) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "No frame matrix data provided"});
+    }
+
+    impl_->reportProgress(0.0);
+
+    std::vector<VelocityPhase> phases;
+    phases.reserve(seriesInfo.phaseCount);
+
+    for (int i = 0; i < seriesInfo.phaseCount; ++i) {
+        auto result = assemblePhase(seriesInfo, i);
+        if (!result) {
+            logger->warn("Failed to assemble phase {}: {}",
+                         i, result.error().toString());
+            continue;
+        }
+        phases.push_back(std::move(result.value()));
+
+        impl_->reportProgress(
+            static_cast<double>(i + 1) / static_cast<double>(seriesInfo.phaseCount));
+    }
+
+    if (phases.empty()) {
+        return std::unexpected(FlowError{
+            FlowError::Code::ParseFailed,
+            "No phases could be assembled"});
+    }
+
+    logger->info("Assembled {} of {} phases", phases.size(), seriesInfo.phaseCount);
+
+    impl_->reportProgress(1.0);
+    return phases;
+}
+
+std::expected<VelocityPhase, FlowError>
+VelocityFieldAssembler::assemblePhase(
+    const FlowSeriesInfo& seriesInfo, int phaseIndex) const {
+    auto logger = getLogger();
+
+    if (phaseIndex < 0 ||
+        phaseIndex >= static_cast<int>(seriesInfo.frameMatrix.size())) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "Phase index " + std::to_string(phaseIndex) + " out of range [0, " +
+                std::to_string(seriesInfo.frameMatrix.size()) + ")"});
+    }
+
+    const auto& phaseFrames = seriesInfo.frameMatrix[phaseIndex];
+
+    // Check required velocity components
+    auto hasComponent = [&](VelocityComponent comp) {
+        auto it = phaseFrames.find(comp);
+        return it != phaseFrames.end() && !it->second.empty();
+    };
+
+    if (!hasComponent(VelocityComponent::Vx) ||
+        !hasComponent(VelocityComponent::Vy) ||
+        !hasComponent(VelocityComponent::Vz)) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InconsistentData,
+            "Phase " + std::to_string(phaseIndex) +
+                " missing velocity components (need Vx, Vy, Vz)"});
+    }
+
+    try {
+        // Read velocity component volumes
+        logger->debug("Reading velocity components for phase {}", phaseIndex);
+
+        auto vxImage = readScalarVolume(phaseFrames.at(VelocityComponent::Vx));
+        auto vyImage = readScalarVolume(phaseFrames.at(VelocityComponent::Vy));
+        auto vzImage = readScalarVolume(phaseFrames.at(VelocityComponent::Vz));
+
+        // Apply VENC scaling to convert pixel values → velocity (cm/s)
+        double vencX = seriesInfo.venc[0];
+        double vencY = seriesInfo.venc[1];
+        double vencZ = seriesInfo.venc[2];
+
+        applyVENCScalingToImage(vxImage, vencX, seriesInfo.isSignedPhase);
+        applyVENCScalingToImage(vyImage, vencY, seriesInfo.isSignedPhase);
+        applyVENCScalingToImage(vzImage, vencZ, seriesInfo.isSignedPhase);
+
+        // Compose into vector field
+        auto vectorField = composeVectorField(vxImage, vyImage, vzImage);
+
+        // Read magnitude image if available
+        FloatImage3D::Pointer magnitudeImage;
+        if (hasComponent(VelocityComponent::Magnitude)) {
+            magnitudeImage = readScalarVolume(
+                phaseFrames.at(VelocityComponent::Magnitude));
+        }
+
+        VelocityPhase phase;
+        phase.velocityField = vectorField;
+        phase.magnitudeImage = magnitudeImage;
+        phase.phaseIndex = phaseIndex;
+        phase.triggerTime = seriesInfo.temporalResolution * phaseIndex;
+
+        auto size = vectorField->GetLargestPossibleRegion().GetSize();
+        logger->debug("Phase {} assembled: {}x{}x{}, VENC=[{:.1f},{:.1f},{:.1f}]",
+                      phaseIndex, size[0], size[1], size[2],
+                      vencX, vencY, vencZ);
+
+        return phase;
+
+    } catch (const itk::ExceptionObject& e) {
+        return std::unexpected(FlowError{
+            FlowError::Code::ParseFailed,
+            "ITK error assembling phase " + std::to_string(phaseIndex) +
+                ": " + e.GetDescription()});
+    } catch (const std::exception& e) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InternalError,
+            "Error assembling phase " + std::to_string(phaseIndex) +
+                ": " + e.what()});
+    }
+}
+
+float VelocityFieldAssembler::applyVENCScaling(
+    float pixelValue, double venc, int maxPixelValue, bool isSigned) {
+    if (maxPixelValue == 0) {
+        return 0.0f;
+    }
+
+    if (isSigned) {
+        // Signed: velocity = (pixel_value / max_possible_value) × VENC
+        return static_cast<float>(
+            (static_cast<double>(pixelValue) / static_cast<double>(maxPixelValue)) * venc);
+    }
+
+    // Unsigned: velocity = ((pixel_value - midpoint) / midpoint) × VENC
+    double midpoint = static_cast<double>(maxPixelValue) / 2.0;
+    return static_cast<float>(
+        ((static_cast<double>(pixelValue) - midpoint) / midpoint) * venc);
+}
+
+}  // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -781,3 +781,20 @@ target_include_directories(flow_dicom_parser_test PRIVATE
 )
 
 gtest_discover_tests(flow_dicom_parser_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for Velocity Field Assembler
+add_executable(velocity_field_assembler_test
+    unit/velocity_field_assembler_test.cpp
+)
+
+target_link_libraries(velocity_field_assembler_test PRIVATE
+    flow_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(velocity_field_assembler_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(velocity_field_assembler_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/velocity_field_assembler_test.cpp
+++ b/tests/unit/velocity_field_assembler_test.cpp
@@ -1,0 +1,201 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include <itkImage.h>
+#include <itkImageRegionIterator.h>
+#include <itkVectorImage.h>
+
+#include "services/flow/flow_dicom_types.hpp"
+#include "services/flow/velocity_field_assembler.hpp"
+
+using namespace dicom_viewer::services;
+
+// =============================================================================
+// VelocityPhase default tests
+// =============================================================================
+
+TEST(VelocityPhaseTest, Defaults) {
+    VelocityPhase phase;
+    EXPECT_EQ(phase.phaseIndex, 0);
+    EXPECT_DOUBLE_EQ(phase.triggerTime, 0.0);
+    EXPECT_EQ(phase.velocityField, nullptr);
+    EXPECT_EQ(phase.magnitudeImage, nullptr);
+}
+
+// =============================================================================
+// VelocityFieldAssembler construction tests
+// =============================================================================
+
+TEST(VelocityFieldAssemblerTest, DefaultConstruction) {
+    VelocityFieldAssembler assembler;
+    // Should not throw
+}
+
+TEST(VelocityFieldAssemblerTest, MoveConstruction) {
+    VelocityFieldAssembler assembler;
+    VelocityFieldAssembler moved(std::move(assembler));
+    // Should not throw
+}
+
+TEST(VelocityFieldAssemblerTest, MoveAssignment) {
+    VelocityFieldAssembler assembler;
+    VelocityFieldAssembler other;
+    other = std::move(assembler);
+    // Should not throw
+}
+
+TEST(VelocityFieldAssemblerTest, ProgressCallback) {
+    VelocityFieldAssembler assembler;
+    double lastProgress = -1.0;
+    assembler.setProgressCallback([&](double p) { lastProgress = p; });
+    EXPECT_DOUBLE_EQ(lastProgress, -1.0);
+}
+
+// =============================================================================
+// VENC Scaling tests (static method, no I/O needed)
+// =============================================================================
+
+TEST(VENCScalingTest, SignedZeroIsZeroVelocity) {
+    // pixel=0 with signed → velocity=0
+    float v = VelocityFieldAssembler::applyVENCScaling(0.0f, 150.0, 2048, true);
+    EXPECT_FLOAT_EQ(v, 0.0f);
+}
+
+TEST(VENCScalingTest, SignedMaxIsVENC) {
+    // pixel=max → velocity=VENC
+    float v = VelocityFieldAssembler::applyVENCScaling(2048.0f, 150.0, 2048, true);
+    EXPECT_FLOAT_EQ(v, 150.0f);
+}
+
+TEST(VENCScalingTest, SignedNegMaxIsNegVENC) {
+    // pixel=-max → velocity=-VENC
+    float v = VelocityFieldAssembler::applyVENCScaling(-2048.0f, 150.0, 2048, true);
+    EXPECT_FLOAT_EQ(v, -150.0f);
+}
+
+TEST(VENCScalingTest, SignedHalfIsHalfVENC) {
+    // pixel=max/2 → velocity=VENC/2
+    float v = VelocityFieldAssembler::applyVENCScaling(1024.0f, 200.0, 2048, true);
+    EXPECT_FLOAT_EQ(v, 100.0f);
+}
+
+TEST(VENCScalingTest, UnsignedMidpointIsZeroVelocity) {
+    // pixel=midpoint → velocity=0
+    float v = VelocityFieldAssembler::applyVENCScaling(2048.0f, 150.0, 4096, false);
+    EXPECT_FLOAT_EQ(v, 0.0f);
+}
+
+TEST(VENCScalingTest, UnsignedMaxIsVENC) {
+    // pixel=max → velocity=VENC
+    float v = VelocityFieldAssembler::applyVENCScaling(4096.0f, 150.0, 4096, false);
+    EXPECT_FLOAT_EQ(v, 150.0f);
+}
+
+TEST(VENCScalingTest, UnsignedZeroIsNegVENC) {
+    // pixel=0 → velocity=-VENC
+    float v = VelocityFieldAssembler::applyVENCScaling(0.0f, 150.0, 4096, false);
+    EXPECT_FLOAT_EQ(v, -150.0f);
+}
+
+TEST(VENCScalingTest, UnsignedQuarterIsNegHalfVENC) {
+    // pixel=max/4 → velocity=-VENC/2
+    float v = VelocityFieldAssembler::applyVENCScaling(1024.0f, 200.0, 4096, false);
+    EXPECT_FLOAT_EQ(v, -100.0f);
+}
+
+TEST(VENCScalingTest, ZeroMaxPixelReturnsZero) {
+    float v = VelocityFieldAssembler::applyVENCScaling(100.0f, 150.0, 0, true);
+    EXPECT_FLOAT_EQ(v, 0.0f);
+}
+
+TEST(VENCScalingTest, ZeroVENCReturnsZero) {
+    float v = VelocityFieldAssembler::applyVENCScaling(2048.0f, 0.0, 4096, true);
+    EXPECT_FLOAT_EQ(v, 0.0f);
+}
+
+TEST(VENCScalingTest, TypicalSiemens12Bit) {
+    // 12-bit signed: max = 2047, VENC = 150 cm/s
+    // pixel = 1024 → velocity = (1024/2047) × 150 ≈ 75.037
+    float v = VelocityFieldAssembler::applyVENCScaling(1024.0f, 150.0, 2047, true);
+    EXPECT_NEAR(v, 75.037f, 0.1f);
+}
+
+TEST(VENCScalingTest, TypicalPhilips12BitUnsigned) {
+    // 12-bit unsigned: max = 4095, VENC = 100 cm/s
+    // pixel = 3072 → velocity = ((3072-2047.5)/2047.5) × 100 ≈ 50.012
+    float v = VelocityFieldAssembler::applyVENCScaling(3072.0f, 100.0, 4095, false);
+    EXPECT_NEAR(v, 50.012f, 0.1f);
+}
+
+// =============================================================================
+// assembleAllPhases error handling tests
+// =============================================================================
+
+TEST(VelocityFieldAssemblerTest, AssembleAllPhasesEmptyFrameMatrix) {
+    VelocityFieldAssembler assembler;
+    FlowSeriesInfo info;
+    // frameMatrix is empty
+    auto result = assembler.assembleAllPhases(info);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, FlowError::Code::InvalidInput);
+}
+
+// =============================================================================
+// assemblePhase error handling tests
+// =============================================================================
+
+TEST(VelocityFieldAssemblerTest, AssemblePhaseNegativeIndex) {
+    VelocityFieldAssembler assembler;
+    FlowSeriesInfo info;
+    info.frameMatrix.resize(1);
+    auto result = assembler.assemblePhase(info, -1);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, FlowError::Code::InvalidInput);
+}
+
+TEST(VelocityFieldAssemblerTest, AssemblePhaseOutOfRange) {
+    VelocityFieldAssembler assembler;
+    FlowSeriesInfo info;
+    info.frameMatrix.resize(3);
+    auto result = assembler.assemblePhase(info, 5);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, FlowError::Code::InvalidInput);
+}
+
+TEST(VelocityFieldAssemblerTest, AssemblePhaseMissingComponents) {
+    VelocityFieldAssembler assembler;
+    FlowSeriesInfo info;
+    info.frameMatrix.resize(1);
+    // Only add Vx, missing Vy and Vz
+    info.frameMatrix[0][VelocityComponent::Vx] = {"/fake/vx.dcm"};
+    auto result = assembler.assemblePhase(info, 0);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, FlowError::Code::InconsistentData);
+}
+
+TEST(VelocityFieldAssemblerTest, AssemblePhaseMissingVz) {
+    VelocityFieldAssembler assembler;
+    FlowSeriesInfo info;
+    info.frameMatrix.resize(1);
+    info.frameMatrix[0][VelocityComponent::Vx] = {"/fake/vx.dcm"};
+    info.frameMatrix[0][VelocityComponent::Vy] = {"/fake/vy.dcm"};
+    // Vz missing
+    auto result = assembler.assemblePhase(info, 0);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, FlowError::Code::InconsistentData);
+}
+
+TEST(VelocityFieldAssemblerTest, AssemblePhaseNonexistentFiles) {
+    VelocityFieldAssembler assembler;
+    FlowSeriesInfo info;
+    info.frameMatrix.resize(1);
+    info.frameMatrix[0][VelocityComponent::Vx] = {"/nonexistent/vx.dcm"};
+    info.frameMatrix[0][VelocityComponent::Vy] = {"/nonexistent/vy.dcm"};
+    info.frameMatrix[0][VelocityComponent::Vz] = {"/nonexistent/vz.dcm"};
+    info.venc = {150.0, 150.0, 150.0};
+    auto result = assembler.assemblePhase(info, 0);
+    ASSERT_FALSE(result.has_value());
+    // Should fail at ITK file reading
+    EXPECT_EQ(result.error().code, FlowError::Code::ParseFailed);
+}


### PR DESCRIPTION
Closes #153

## Summary
- Implement `VelocityFieldAssembler` that converts parsed 4D Flow DICOM frames into temporal 3D velocity vector fields
- Support both single-phase (on-demand) and batch assembly modes
- VENC scaling for signed and unsigned DICOM pixel representations
- ITK pipeline: `ImageSeriesReader` → VENC scaling → `ComposeImageFilter` → `VectorImage3D`
- 23 unit tests covering VENC scaling accuracy and error handling

## Architecture

### ITK Pipeline
```
FlowSeriesInfo.frameMatrix[phase][component]
  → itk::ImageSeriesReader<FloatImage3D>  (read Vx/Vy/Vz slices)
  → applyVENCScalingToImage()             (pixel → cm/s)
  → itk::ComposeImageFilter               (3 scalars → vector)
  → VelocityPhase { velocityField, magnitudeImage, phaseIndex, triggerTime }
```

### VENC Scaling
| Representation | Formula |
|---------------|---------|
| Signed | `velocity = (pixel / max_signed) × VENC` |
| Unsigned | `velocity = ((pixel - midpoint) / midpoint) × VENC` |

### Files Added (5 files, +594 lines)
- `include/services/flow/velocity_field_assembler.hpp` - Class definition with PIMPL
- `src/services/flow/velocity_field_assembler.cpp` - Full implementation
- `tests/unit/velocity_field_assembler_test.cpp` - 23 unit tests
- `CMakeLists.txt` - Added to flow_service library
- `tests/CMakeLists.txt` - Test target registration

## Traceability
- **PRD**: FR-014 (4D Flow MRI Analysis)
- **SRS**: SRS-FR-044 (VelocityFieldAssembler)
- **SDS**: SDS-MOD-007 (Flow Analysis Module)
- **Depends on**: #152 (FlowDicomParser) - merged

## Test Plan
- [x] `VelocityPhase` default values (null pointers, zero index/time)
- [x] Construction: default, move, move-assignment
- [x] Progress callback registration without invocation
- [x] VENC scaling: signed zero → 0 velocity
- [x] VENC scaling: signed max → +VENC, signed -max → -VENC
- [x] VENC scaling: signed half → half VENC
- [x] VENC scaling: unsigned midpoint → 0 velocity
- [x] VENC scaling: unsigned max → +VENC, unsigned zero → -VENC
- [x] VENC scaling: zero maxPixel returns 0
- [x] VENC scaling: zero VENC returns 0
- [x] VENC scaling: typical Siemens 12-bit signed values
- [x] VENC scaling: typical Philips 12-bit unsigned values
- [x] `assembleAllPhases()`: empty frame matrix → InvalidInput
- [x] `assemblePhase()`: negative index → InvalidInput
- [x] `assemblePhase()`: out-of-range index → InvalidInput
- [x] `assemblePhase()`: missing Vy+Vz → InconsistentData
- [x] `assemblePhase()`: missing Vz only → InconsistentData
- [x] `assemblePhase()`: nonexistent DICOM files → ParseFailed
- [x] Build succeeds: `cmake --build build/ --target flow_service`
- [x] All 23 tests pass: `./build/bin/velocity_field_assembler_test`
- [x] Existing 38 FlowDicomParser tests still pass