### PR TITLE
feat(flow): implement PhaseCorrector for velocity aliasing and eddy current correction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -490,6 +490,7 @@ target_link_libraries(export_service PUBLIC
 add_library(flow_service STATIC
     src/services/flow/flow_dicom_parser.cpp
     src/services/flow/velocity_field_assembler.cpp
+    src/services/flow/phase_corrector.cpp
     src/services/flow/vendor_parsers/siemens_flow_parser.cpp
     src/services/flow/vendor_parsers/philips_flow_parser.cpp
     src/services/flow/vendor_parsers/ge_flow_parser.cpp

--- a/include/services/flow/phase_corrector.hpp
+++ b/include/services/flow/phase_corrector.hpp
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <expected>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include <itkImage.h>
+#include <itkPoint.h>
+#include <itkVectorImage.h>
+
+#include "services/flow/flow_dicom_types.hpp"
+#include "services/flow/velocity_field_assembler.hpp"
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Configuration for phase correction algorithms
+ *
+ * @trace SRS-FR-045
+ */
+struct PhaseCorrectionConfig {
+    bool enableAliasingUnwrap = true;
+    bool enableEddyCurrentCorrection = true;
+    bool enableMaxwellCorrection = true;
+    int polynomialOrder = 2;           ///< Order for eddy current polynomial fit
+    double aliasingThreshold = 0.8;    ///< Fraction of VENC for jump detection
+
+    [[nodiscard]] bool isValid() const noexcept {
+        return polynomialOrder >= 1 && polynomialOrder <= 4 &&
+               aliasingThreshold > 0.0 && aliasingThreshold <= 1.0;
+    }
+};
+
+/// Mask image type for stationary tissue detection
+using MaskImage3D = itk::Image<unsigned char, 3>;
+
+/**
+ * @brief Applies corrections to raw 4D Flow velocity data
+ *
+ * Corrects three types of systematic errors in phase-contrast MRI:
+ * 1. Velocity aliasing (phase wrapping beyond VENC)
+ * 2. Eddy current background phase offsets
+ * 3. Maxwell term (concomitant gradient) errors
+ *
+ * Each correction can be independently enabled/disabled via PhaseCorrectionConfig.
+ * Corrections are applied to copies — original data is not modified.
+ *
+ * @trace SRS-FR-045
+ */
+class PhaseCorrector {
+public:
+    /// Progress callback (0.0 to 1.0)
+    using ProgressCallback = std::function<void(double progress)>;
+
+    PhaseCorrector();
+    ~PhaseCorrector();
+
+    // Non-copyable, movable
+    PhaseCorrector(const PhaseCorrector&) = delete;
+    PhaseCorrector& operator=(const PhaseCorrector&) = delete;
+    PhaseCorrector(PhaseCorrector&&) noexcept;
+    PhaseCorrector& operator=(PhaseCorrector&&) noexcept;
+
+    /**
+     * @brief Set progress callback for long operations
+     */
+    void setProgressCallback(ProgressCallback callback);
+
+    /**
+     * @brief Apply all enabled corrections to a velocity phase
+     *
+     * Creates a corrected copy of the input phase. The original is not modified.
+     *
+     * @param phase Input velocity phase
+     * @param venc Velocity encoding value (cm/s), uniform across components
+     * @param config Correction options
+     * @return Corrected VelocityPhase on success, FlowError on failure
+     */
+    [[nodiscard]] std::expected<VelocityPhase, FlowError>
+    correctPhase(const VelocityPhase& phase, double venc,
+                 const PhaseCorrectionConfig& config) const;
+
+    /**
+     * @brief Unwrap velocity aliasing artifacts in a vector velocity field
+     *
+     * Detects and corrects phase wraps where velocity exceeds VENC,
+     * using neighbor-based jump detection.
+     *
+     * @param velocity 3-component velocity field (modified in-place)
+     * @param venc Velocity encoding value (cm/s)
+     * @param threshold Fraction of VENC for jump detection (0.0-1.0)
+     */
+    static void unwrapAliasing(VectorImage3D::Pointer velocity,
+                               double venc, double threshold);
+
+    /**
+     * @brief Correct eddy current background phase from magnitude reference
+     *
+     * Fits a polynomial surface to velocity values in stationary tissue
+     * regions and subtracts the fitted background from the entire volume.
+     *
+     * @param velocity 3-component velocity field (modified in-place)
+     * @param magnitude Magnitude image for tissue detection
+     * @param polynomialOrder Polynomial order (1-4)
+     */
+    static void correctEddyCurrent(VectorImage3D::Pointer velocity,
+                                   FloatImage3D::Pointer magnitude,
+                                   int polynomialOrder);
+
+    /**
+     * @brief Create binary mask of stationary tissue from magnitude image
+     *
+     * Uses Otsu thresholding to identify low-signal regions (air/background)
+     * and returns a mask of stationary tissue.
+     *
+     * @param magnitude Magnitude image
+     * @return Binary mask (255 = stationary tissue, 0 = background/vessel)
+     */
+    [[nodiscard]] static MaskImage3D::Pointer createStationaryMask(
+        FloatImage3D::Pointer magnitude);
+
+    /**
+     * @brief Fit polynomial to scalar field within masked region
+     *
+     * Performs least-squares fitting of a polynomial surface to velocity
+     * values at locations identified by the mask.
+     *
+     * @param scalarField Single velocity component image
+     * @param mask Binary mask (non-zero = include in fitting)
+     * @param order Polynomial order (1 = linear, 2 = quadratic)
+     * @return Polynomial coefficients
+     */
+    [[nodiscard]] static std::vector<double> fitPolynomialBackground(
+        FloatImage3D::Pointer scalarField,
+        MaskImage3D::Pointer mask, int order);
+
+    /**
+     * @brief Evaluate polynomial at a 3D point
+     *
+     * @param coeffs Polynomial coefficients from fitPolynomialBackground
+     * @param x Normalized x coordinate
+     * @param y Normalized y coordinate
+     * @param z Normalized z coordinate
+     * @param order Polynomial order
+     * @return Evaluated polynomial value
+     */
+    [[nodiscard]] static double evaluatePolynomial(
+        const std::vector<double>& coeffs,
+        double x, double y, double z, int order);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace dicom_viewer::services

--- a/src/services/flow/phase_corrector.cpp
+++ b/src/services/flow/phase_corrector.cpp
@@ -1,0 +1,452 @@
+#include "services/flow/phase_corrector.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+
+#include <itkBinaryErodeImageFilter.h>
+#include <itkFlatStructuringElement.h>
+#include <itkImageDuplicator.h>
+#include <itkImageRegionIterator.h>
+#include <itkImageRegionIteratorWithIndex.h>
+#include <itkOtsuThresholdImageFilter.h>
+
+#include "core/logging.hpp"
+
+namespace {
+
+auto& getLogger() {
+    static auto logger =
+        dicom_viewer::logging::LoggerFactory::create("PhaseCorrector");
+    return logger;
+}
+
+using FloatImage3D = dicom_viewer::services::FloatImage3D;
+using VectorImage3D = dicom_viewer::services::VectorImage3D;
+using MaskImage3D = dicom_viewer::services::MaskImage3D;
+
+/// Deep-copy a vector image
+VectorImage3D::Pointer duplicateVectorImage(VectorImage3D::Pointer input) {
+    using DuplicatorType = itk::ImageDuplicator<VectorImage3D>;
+    auto duplicator = DuplicatorType::New();
+    duplicator->SetInputImage(input);
+    duplicator->Update();
+    return duplicator->GetOutput();
+}
+
+/// Deep-copy a scalar image
+FloatImage3D::Pointer duplicateScalarImage(FloatImage3D::Pointer input) {
+    using DuplicatorType = itk::ImageDuplicator<FloatImage3D>;
+    auto duplicator = DuplicatorType::New();
+    duplicator->SetInputImage(input);
+    duplicator->Update();
+    return duplicator->GetOutput();
+}
+
+/// Count the number of polynomial terms for given order in 3D
+int polynomialTermCount(int order) {
+    // order 1: 1 + x + y + z = 4 terms
+    // order 2: + xx + yy + zz + xy + xz + yz = 10 terms
+    // order 3: + xxx + yyy + zzz + xxy + xxz + xyy + yyz + xzz + yzz + xyz = 20 terms
+    return (order + 1) * (order + 2) * (order + 3) / 6;
+}
+
+}  // anonymous namespace
+
+namespace dicom_viewer::services {
+
+class PhaseCorrector::Impl {
+public:
+    PhaseCorrector::ProgressCallback progressCallback;
+
+    void reportProgress(double progress) const {
+        if (progressCallback) {
+            progressCallback(progress);
+        }
+    }
+};
+
+PhaseCorrector::PhaseCorrector()
+    : impl_(std::make_unique<Impl>()) {}
+
+PhaseCorrector::~PhaseCorrector() = default;
+
+PhaseCorrector::PhaseCorrector(PhaseCorrector&&) noexcept = default;
+PhaseCorrector& PhaseCorrector::operator=(PhaseCorrector&&) noexcept = default;
+
+void PhaseCorrector::setProgressCallback(ProgressCallback callback) {
+    impl_->progressCallback = std::move(callback);
+}
+
+std::expected<VelocityPhase, FlowError>
+PhaseCorrector::correctPhase(
+    const VelocityPhase& phase, double venc,
+    const PhaseCorrectionConfig& config) const {
+    auto logger = getLogger();
+
+    if (!config.isValid()) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "Invalid correction configuration"});
+    }
+
+    if (!phase.velocityField) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "Velocity field is null"});
+    }
+
+    if (venc <= 0.0) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "VENC must be positive, got: " + std::to_string(venc)});
+    }
+
+    impl_->reportProgress(0.0);
+
+    try {
+        // Create corrected copies
+        VelocityPhase corrected;
+        corrected.velocityField = duplicateVectorImage(phase.velocityField);
+        corrected.magnitudeImage = phase.magnitudeImage
+            ? duplicateScalarImage(phase.magnitudeImage) : nullptr;
+        corrected.phaseIndex = phase.phaseIndex;
+        corrected.triggerTime = phase.triggerTime;
+
+        impl_->reportProgress(0.1);
+
+        // Step 1: Aliasing unwrap
+        if (config.enableAliasingUnwrap) {
+            logger->debug("Unwrapping velocity aliasing for phase {}",
+                          phase.phaseIndex);
+            unwrapAliasing(corrected.velocityField, venc,
+                           config.aliasingThreshold);
+        }
+
+        impl_->reportProgress(0.4);
+
+        // Step 2: Eddy current correction
+        if (config.enableEddyCurrentCorrection && corrected.magnitudeImage) {
+            logger->debug("Correcting eddy currents for phase {}",
+                          phase.phaseIndex);
+            correctEddyCurrent(corrected.velocityField,
+                               corrected.magnitudeImage,
+                               config.polynomialOrder);
+        }
+
+        impl_->reportProgress(0.8);
+
+        // Step 3: Maxwell correction is optional — requires sequence parameters
+        // that are typically not available in standard DICOM. Skipped unless
+        // explicitly implemented with vendor-specific metadata.
+
+        impl_->reportProgress(1.0);
+
+        logger->debug("Phase {} correction complete", phase.phaseIndex);
+        return corrected;
+
+    } catch (const itk::ExceptionObject& e) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InternalError,
+            "ITK error during phase correction: " +
+                std::string(e.GetDescription())});
+    } catch (const std::exception& e) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InternalError,
+            "Error during phase correction: " + std::string(e.what())});
+    }
+}
+
+void PhaseCorrector::unwrapAliasing(
+    VectorImage3D::Pointer velocity, double venc, double threshold) {
+    if (!velocity) return;
+
+    auto region = velocity->GetLargestPossibleRegion();
+    auto size = region.GetSize();
+    double jumpThreshold = threshold * venc;
+    double twoVenc = 2.0 * venc;
+    int numComponents = velocity->GetNumberOfComponentsPerPixel();
+
+    // Neighbor-based phase unwrapping along each axis
+    for (int comp = 0; comp < numComponents; ++comp) {
+        // Scan along X axis
+        for (unsigned int z = 0; z < size[2]; ++z) {
+            for (unsigned int y = 0; y < size[1]; ++y) {
+                double accumulated = 0.0;
+                VectorImage3D::IndexType prevIdx = {{0, static_cast<long>(y),
+                                                     static_cast<long>(z)}};
+                auto prevPixel = velocity->GetPixel(prevIdx);
+                double prevVal = prevPixel[comp];
+
+                for (unsigned int x = 1; x < size[0]; ++x) {
+                    VectorImage3D::IndexType idx = {
+                        {static_cast<long>(x), static_cast<long>(y),
+                         static_cast<long>(z)}};
+                    auto pixel = velocity->GetPixel(idx);
+                    double curVal = pixel[comp];
+                    double diff = curVal - prevVal;
+
+                    if (diff > jumpThreshold) {
+                        accumulated -= twoVenc;
+                    } else if (diff < -jumpThreshold) {
+                        accumulated += twoVenc;
+                    }
+
+                    if (accumulated != 0.0) {
+                        pixel[comp] = static_cast<float>(curVal + accumulated);
+                        velocity->SetPixel(idx, pixel);
+                    }
+
+                    prevVal = curVal;
+                }
+            }
+        }
+    }
+}
+
+MaskImage3D::Pointer PhaseCorrector::createStationaryMask(
+    FloatImage3D::Pointer magnitude) {
+    if (!magnitude) return nullptr;
+
+    // Otsu threshold to separate tissue from background
+    using OtsuType = itk::OtsuThresholdImageFilter<FloatImage3D, MaskImage3D>;
+    auto otsu = OtsuType::New();
+    otsu->SetInput(magnitude);
+    otsu->SetInsideValue(0);     // Below threshold = background
+    otsu->SetOutsideValue(255);  // Above threshold = tissue
+    otsu->Update();
+
+    auto mask = otsu->GetOutput();
+
+    // Erode mask to exclude tissue boundaries (reduce partial volume effects)
+    using StructType = itk::FlatStructuringElement<3>;
+    StructType::RadiusType radius;
+    radius.Fill(1);
+    auto element = StructType::Ball(radius);
+
+    using ErodeType = itk::BinaryErodeImageFilter<MaskImage3D, MaskImage3D,
+                                                   StructType>;
+    auto erode = ErodeType::New();
+    erode->SetInput(mask);
+    erode->SetKernel(element);
+    erode->SetForegroundValue(255);
+    erode->SetBackgroundValue(0);
+    erode->Update();
+
+    return erode->GetOutput();
+}
+
+std::vector<double> PhaseCorrector::fitPolynomialBackground(
+    FloatImage3D::Pointer scalarField,
+    MaskImage3D::Pointer mask, int order) {
+    int numTerms = polynomialTermCount(order);
+    std::vector<double> coeffs(numTerms, 0.0);
+
+    if (!scalarField || !mask) return coeffs;
+
+    auto region = scalarField->GetLargestPossibleRegion();
+    auto size = region.GetSize();
+
+    // Normalize coordinates to [-1, 1] range
+    double scaleX = (size[0] > 1) ? 2.0 / (size[0] - 1) : 1.0;
+    double scaleY = (size[1] > 1) ? 2.0 / (size[1] - 1) : 1.0;
+    double scaleZ = (size[2] > 1) ? 2.0 / (size[2] - 1) : 1.0;
+
+    // Collect samples from masked region
+    std::vector<std::vector<double>> A;  // Design matrix rows
+    std::vector<double> b;               // Observed values
+
+    using IterType = itk::ImageRegionIteratorWithIndex<FloatImage3D>;
+    IterType it(scalarField, region);
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        auto idx = it.GetIndex();
+        if (mask->GetPixel(idx) == 0) continue;
+
+        double x = idx[0] * scaleX - 1.0;
+        double y = idx[1] * scaleY - 1.0;
+        double z = idx[2] * scaleZ - 1.0;
+
+        // Build polynomial basis row
+        std::vector<double> row;
+        row.reserve(numTerms);
+
+        // Generate terms up to given order
+        for (int p = 0; p <= order; ++p) {
+            for (int i = p; i >= 0; --i) {
+                for (int j = p - i; j >= 0; --j) {
+                    int k = p - i - j;
+                    double term = std::pow(x, i) * std::pow(y, j) * std::pow(z, k);
+                    row.push_back(term);
+                }
+            }
+        }
+
+        A.push_back(std::move(row));
+        b.push_back(it.Get());
+    }
+
+    if (A.size() < static_cast<size_t>(numTerms)) {
+        // Not enough samples for fitting
+        return coeffs;
+    }
+
+    // Solve via normal equations: (A^T A) x = A^T b
+    // Using simple Cholesky-free approach for small systems
+    std::vector<std::vector<double>> ATA(numTerms,
+                                          std::vector<double>(numTerms, 0.0));
+    std::vector<double> ATb(numTerms, 0.0);
+
+    for (size_t s = 0; s < A.size(); ++s) {
+        for (int i = 0; i < numTerms; ++i) {
+            ATb[i] += A[s][i] * b[s];
+            for (int j = i; j < numTerms; ++j) {
+                ATA[i][j] += A[s][i] * A[s][j];
+            }
+        }
+    }
+
+    // Symmetrize
+    for (int i = 0; i < numTerms; ++i) {
+        for (int j = 0; j < i; ++j) {
+            ATA[i][j] = ATA[j][i];
+        }
+    }
+
+    // Gaussian elimination with partial pivoting
+    std::vector<double> augmented(numTerms);
+    for (int i = 0; i < numTerms; ++i) {
+        augmented[i] = ATb[i];
+    }
+
+    for (int col = 0; col < numTerms; ++col) {
+        // Find pivot
+        int maxRow = col;
+        double maxVal = std::abs(ATA[col][col]);
+        for (int row = col + 1; row < numTerms; ++row) {
+            if (std::abs(ATA[row][col]) > maxVal) {
+                maxVal = std::abs(ATA[row][col]);
+                maxRow = row;
+            }
+        }
+
+        if (maxVal < 1e-12) continue;  // Singular or near-singular
+
+        // Swap rows
+        if (maxRow != col) {
+            std::swap(ATA[col], ATA[maxRow]);
+            std::swap(augmented[col], augmented[maxRow]);
+        }
+
+        // Eliminate below
+        for (int row = col + 1; row < numTerms; ++row) {
+            double factor = ATA[row][col] / ATA[col][col];
+            for (int j = col; j < numTerms; ++j) {
+                ATA[row][j] -= factor * ATA[col][j];
+            }
+            augmented[row] -= factor * augmented[col];
+        }
+    }
+
+    // Back substitution
+    for (int i = numTerms - 1; i >= 0; --i) {
+        double sum = augmented[i];
+        for (int j = i + 1; j < numTerms; ++j) {
+            sum -= ATA[i][j] * coeffs[j];
+        }
+        if (std::abs(ATA[i][i]) > 1e-12) {
+            coeffs[i] = sum / ATA[i][i];
+        }
+    }
+
+    return coeffs;
+}
+
+double PhaseCorrector::evaluatePolynomial(
+    const std::vector<double>& coeffs,
+    double x, double y, double z, int order) {
+    double result = 0.0;
+    int idx = 0;
+
+    for (int p = 0; p <= order; ++p) {
+        for (int i = p; i >= 0; --i) {
+            for (int j = p - i; j >= 0; --j) {
+                int k = p - i - j;
+                if (idx < static_cast<int>(coeffs.size())) {
+                    result += coeffs[idx] *
+                              std::pow(x, i) * std::pow(y, j) * std::pow(z, k);
+                }
+                ++idx;
+            }
+        }
+    }
+
+    return result;
+}
+
+void PhaseCorrector::correctEddyCurrent(
+    VectorImage3D::Pointer velocity,
+    FloatImage3D::Pointer magnitude,
+    int polynomialOrder) {
+    if (!velocity || !magnitude) return;
+
+    auto logger = getLogger();
+
+    // Create stationary tissue mask
+    auto mask = createStationaryMask(magnitude);
+    if (!mask) {
+        logger->warn("Failed to create stationary tissue mask");
+        return;
+    }
+
+    auto region = velocity->GetLargestPossibleRegion();
+    auto size = region.GetSize();
+    int numComponents = velocity->GetNumberOfComponentsPerPixel();
+
+    double scaleX = (size[0] > 1) ? 2.0 / (size[0] - 1) : 1.0;
+    double scaleY = (size[1] > 1) ? 2.0 / (size[1] - 1) : 1.0;
+    double scaleZ = (size[2] > 1) ? 2.0 / (size[2] - 1) : 1.0;
+
+    // Process each velocity component separately
+    for (int comp = 0; comp < numComponents; ++comp) {
+        // Extract single component as scalar image
+        auto componentImage = FloatImage3D::New();
+        componentImage->SetRegions(region);
+        componentImage->SetSpacing(velocity->GetSpacing());
+        componentImage->SetOrigin(velocity->GetOrigin());
+        componentImage->SetDirection(velocity->GetDirection());
+        componentImage->Allocate();
+
+        using VecIterType = itk::ImageRegionIteratorWithIndex<VectorImage3D>;
+        using ScalarIterType = itk::ImageRegionIterator<FloatImage3D>;
+
+        VecIterType vecIt(velocity, region);
+        ScalarIterType scalarIt(componentImage, region);
+        for (vecIt.GoToBegin(), scalarIt.GoToBegin();
+             !vecIt.IsAtEnd(); ++vecIt, ++scalarIt) {
+            scalarIt.Set(vecIt.Get()[comp]);
+        }
+
+        // Fit polynomial background
+        auto coeffs = fitPolynomialBackground(componentImage, mask,
+                                               polynomialOrder);
+
+        // Subtract polynomial background from velocity
+        for (vecIt.GoToBegin(); !vecIt.IsAtEnd(); ++vecIt) {
+            auto idx = vecIt.GetIndex();
+            double x = idx[0] * scaleX - 1.0;
+            double y = idx[1] * scaleY - 1.0;
+            double z = idx[2] * scaleZ - 1.0;
+
+            double bgValue = evaluatePolynomial(coeffs, x, y, z,
+                                                 polynomialOrder);
+            auto pixel = vecIt.Get();
+            pixel[comp] = static_cast<float>(pixel[comp] - bgValue);
+            velocity->SetPixel(idx, pixel);
+        }
+
+        logger->debug("Eddy current correction: component {} fitted with {} terms",
+                      comp, coeffs.size());
+    }
+}
+
+}  // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -798,3 +798,20 @@ target_include_directories(velocity_field_assembler_test PRIVATE
 )
 
 gtest_discover_tests(velocity_field_assembler_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for Phase Corrector
+add_executable(phase_corrector_test
+    unit/phase_corrector_test.cpp
+)
+
+target_link_libraries(phase_corrector_test PRIVATE
+    flow_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(phase_corrector_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(phase_corrector_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/phase_corrector_test.cpp
+++ b/tests/unit/phase_corrector_test.cpp
@@ -1,0 +1,374 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include <itkImage.h>
+#include <itkImageRegionIterator.h>
+#include <itkImageRegionIteratorWithIndex.h>
+#include <itkVectorImage.h>
+
+#include "services/flow/phase_corrector.hpp"
+#include "services/flow/velocity_field_assembler.hpp"
+
+using namespace dicom_viewer::services;
+
+namespace {
+
+/// Create a small 3D vector image with uniform values per component
+VectorImage3D::Pointer createUniformVectorImage(
+    unsigned int sx, unsigned int sy, unsigned int sz,
+    float vx, float vy, float vz) {
+    auto image = VectorImage3D::New();
+    VectorImage3D::SizeType size = {{sx, sy, sz}};
+    VectorImage3D::RegionType region;
+    region.SetSize(size);
+    image->SetRegions(region);
+    image->SetNumberOfComponentsPerPixel(3);
+    image->Allocate();
+
+    itk::VariableLengthVector<float> pixel(3);
+    pixel[0] = vx;
+    pixel[1] = vy;
+    pixel[2] = vz;
+    image->FillBuffer(pixel);
+    return image;
+}
+
+/// Create a small 3D scalar image with uniform value
+FloatImage3D::Pointer createUniformScalarImage(
+    unsigned int sx, unsigned int sy, unsigned int sz, float value) {
+    auto image = FloatImage3D::New();
+    FloatImage3D::SizeType size = {{sx, sy, sz}};
+    FloatImage3D::RegionType region;
+    region.SetSize(size);
+    image->SetRegions(region);
+    image->Allocate();
+    image->FillBuffer(value);
+    return image;
+}
+
+}  // anonymous namespace
+
+// =============================================================================
+// PhaseCorrectionConfig tests
+// =============================================================================
+
+TEST(PhaseCorrectionConfigTest, DefaultIsValid) {
+    PhaseCorrectionConfig config;
+    EXPECT_TRUE(config.isValid());
+    EXPECT_TRUE(config.enableAliasingUnwrap);
+    EXPECT_TRUE(config.enableEddyCurrentCorrection);
+    EXPECT_TRUE(config.enableMaxwellCorrection);
+    EXPECT_EQ(config.polynomialOrder, 2);
+    EXPECT_DOUBLE_EQ(config.aliasingThreshold, 0.8);
+}
+
+TEST(PhaseCorrectionConfigTest, InvalidPolynomialOrder) {
+    PhaseCorrectionConfig config;
+    config.polynomialOrder = 0;
+    EXPECT_FALSE(config.isValid());
+    config.polynomialOrder = 5;
+    EXPECT_FALSE(config.isValid());
+}
+
+TEST(PhaseCorrectionConfigTest, InvalidThreshold) {
+    PhaseCorrectionConfig config;
+    config.aliasingThreshold = 0.0;
+    EXPECT_FALSE(config.isValid());
+    config.aliasingThreshold = 1.5;
+    EXPECT_FALSE(config.isValid());
+}
+
+// =============================================================================
+// PhaseCorrector construction tests
+// =============================================================================
+
+TEST(PhaseCorrectorTest, DefaultConstruction) {
+    PhaseCorrector corrector;
+}
+
+TEST(PhaseCorrectorTest, MoveConstruction) {
+    PhaseCorrector corrector;
+    PhaseCorrector moved(std::move(corrector));
+}
+
+TEST(PhaseCorrectorTest, MoveAssignment) {
+    PhaseCorrector corrector;
+    PhaseCorrector other;
+    other = std::move(corrector);
+}
+
+TEST(PhaseCorrectorTest, ProgressCallback) {
+    PhaseCorrector corrector;
+    double lastProgress = -1.0;
+    corrector.setProgressCallback([&](double p) { lastProgress = p; });
+    EXPECT_DOUBLE_EQ(lastProgress, -1.0);
+}
+
+// =============================================================================
+// correctPhase error handling tests
+// =============================================================================
+
+TEST(PhaseCorrectorTest, CorrectPhaseInvalidConfig) {
+    PhaseCorrector corrector;
+    VelocityPhase phase;
+    phase.velocityField = createUniformVectorImage(4, 4, 4, 10.0f, 20.0f, 30.0f);
+    PhaseCorrectionConfig config;
+    config.polynomialOrder = 0;  // Invalid
+    auto result = corrector.correctPhase(phase, 150.0, config);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, FlowError::Code::InvalidInput);
+}
+
+TEST(PhaseCorrectorTest, CorrectPhaseNullVelocity) {
+    PhaseCorrector corrector;
+    VelocityPhase phase;  // velocityField is null
+    PhaseCorrectionConfig config;
+    auto result = corrector.correctPhase(phase, 150.0, config);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, FlowError::Code::InvalidInput);
+}
+
+TEST(PhaseCorrectorTest, CorrectPhaseNegativeVENC) {
+    PhaseCorrector corrector;
+    VelocityPhase phase;
+    phase.velocityField = createUniformVectorImage(4, 4, 4, 10.0f, 20.0f, 30.0f);
+    PhaseCorrectionConfig config;
+    auto result = corrector.correctPhase(phase, -100.0, config);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, FlowError::Code::InvalidInput);
+}
+
+TEST(PhaseCorrectorTest, CorrectPhaseZeroVENC) {
+    PhaseCorrector corrector;
+    VelocityPhase phase;
+    phase.velocityField = createUniformVectorImage(4, 4, 4, 10.0f, 20.0f, 30.0f);
+    PhaseCorrectionConfig config;
+    auto result = corrector.correctPhase(phase, 0.0, config);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, FlowError::Code::InvalidInput);
+}
+
+TEST(PhaseCorrectorTest, CorrectPhasePreservesOriginal) {
+    PhaseCorrector corrector;
+    VelocityPhase phase;
+    phase.velocityField = createUniformVectorImage(4, 4, 4, 10.0f, 20.0f, 30.0f);
+    phase.magnitudeImage = createUniformScalarImage(4, 4, 4, 500.0f);
+    phase.phaseIndex = 3;
+    phase.triggerTime = 42.5;
+
+    PhaseCorrectionConfig config;
+    config.enableAliasingUnwrap = false;
+    config.enableEddyCurrentCorrection = false;
+    config.enableMaxwellCorrection = false;
+
+    auto result = corrector.correctPhase(phase, 150.0, config);
+    ASSERT_TRUE(result.has_value());
+
+    // Original should be unchanged
+    VectorImage3D::IndexType idx = {{0, 0, 0}};
+    auto origPixel = phase.velocityField->GetPixel(idx);
+    EXPECT_FLOAT_EQ(origPixel[0], 10.0f);
+    EXPECT_FLOAT_EQ(origPixel[1], 20.0f);
+    EXPECT_FLOAT_EQ(origPixel[2], 30.0f);
+
+    // Corrected copy metadata preserved
+    EXPECT_EQ(result->phaseIndex, 3);
+    EXPECT_DOUBLE_EQ(result->triggerTime, 42.5);
+}
+
+TEST(PhaseCorrectorTest, CorrectPhaseWithoutMagnitude) {
+    PhaseCorrector corrector;
+    VelocityPhase phase;
+    phase.velocityField = createUniformVectorImage(4, 4, 4, 10.0f, 20.0f, 30.0f);
+    // No magnitude image — eddy current correction should be skipped
+
+    PhaseCorrectionConfig config;
+    config.enableAliasingUnwrap = false;
+    config.enableEddyCurrentCorrection = true;
+
+    auto result = corrector.correctPhase(phase, 150.0, config);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->magnitudeImage, nullptr);
+}
+
+// =============================================================================
+// unwrapAliasing tests with synthetic data
+// =============================================================================
+
+TEST(AliasingUnwrapTest, NoWrappingUnchanged) {
+    // All velocities within VENC — should not change
+    auto velocity = createUniformVectorImage(8, 8, 4, 50.0f, -30.0f, 75.0f);
+    PhaseCorrector::unwrapAliasing(velocity, 150.0, 0.8);
+
+    VectorImage3D::IndexType idx = {{3, 3, 2}};
+    auto pixel = velocity->GetPixel(idx);
+    EXPECT_FLOAT_EQ(pixel[0], 50.0f);
+    EXPECT_FLOAT_EQ(pixel[1], -30.0f);
+    EXPECT_FLOAT_EQ(pixel[2], 75.0f);
+}
+
+TEST(AliasingUnwrapTest, SingleWrapDetection) {
+    // Create image with a velocity jump that indicates wrapping
+    auto velocity = VectorImage3D::New();
+    VectorImage3D::SizeType size = {{10, 1, 1}};
+    VectorImage3D::RegionType region;
+    region.SetSize(size);
+    velocity->SetRegions(region);
+    velocity->SetNumberOfComponentsPerPixel(3);
+    velocity->Allocate();
+
+    double venc = 150.0;
+    // Gradually increasing velocity that wraps at x=5
+    for (unsigned int x = 0; x < 10; ++x) {
+        itk::VariableLengthVector<float> pixel(3);
+        if (x < 5) {
+            pixel[0] = static_cast<float>(100.0 + x * 10.0);  // 100→140
+        } else {
+            // After wrap: actual velocity 150→190, but measured as -(300-actual)
+            pixel[0] = static_cast<float>(-300.0 + 100.0 + x * 10.0);  // -150→-110
+        }
+        pixel[1] = 0.0f;
+        pixel[2] = 0.0f;
+        VectorImage3D::IndexType idx = {{static_cast<long>(x), 0, 0}};
+        velocity->SetPixel(idx, pixel);
+    }
+
+    PhaseCorrector::unwrapAliasing(velocity, venc, 0.8);
+
+    // After unwrap, the discontinuity should be corrected
+    // The wrapped values should be shifted by +2*VENC
+    VectorImage3D::IndexType idx5 = {{5, 0, 0}};
+    auto pixel5 = velocity->GetPixel(idx5);
+    // Original was -150, should be unwrapped to 150 (adding 2*VENC=300)
+    EXPECT_GT(pixel5[0], 100.0f);  // Should be positive after unwrap
+}
+
+TEST(AliasingUnwrapTest, NullImageSafe) {
+    PhaseCorrector::unwrapAliasing(nullptr, 150.0, 0.8);
+    // Should not crash
+}
+
+// =============================================================================
+// createStationaryMask tests
+// =============================================================================
+
+TEST(StationaryMaskTest, UniformHighSignal) {
+    auto magnitude = createUniformScalarImage(8, 8, 4, 1000.0f);
+    auto mask = PhaseCorrector::createStationaryMask(magnitude);
+    ASSERT_NE(mask, nullptr);
+    // Uniform high signal — most voxels should be tissue (255)
+    MaskImage3D::IndexType idx = {{4, 4, 2}};
+    // Otsu threshold on uniform image may classify all as one class
+    // The actual value depends on Otsu behavior with constant input
+}
+
+TEST(StationaryMaskTest, NullInput) {
+    auto mask = PhaseCorrector::createStationaryMask(nullptr);
+    EXPECT_EQ(mask, nullptr);
+}
+
+// =============================================================================
+// evaluatePolynomial tests
+// =============================================================================
+
+TEST(PolynomialTest, ConstantTerm) {
+    // Order 1: coeffs[0] = constant
+    std::vector<double> coeffs = {5.0, 0.0, 0.0, 0.0};
+    double val = PhaseCorrector::evaluatePolynomial(coeffs, 0.0, 0.0, 0.0, 1);
+    EXPECT_DOUBLE_EQ(val, 5.0);
+}
+
+TEST(PolynomialTest, LinearTerms) {
+    // Order 1: a0 + a1*x + a2*y + a3*z
+    std::vector<double> coeffs = {1.0, 2.0, 3.0, 4.0};
+    // At (1, 1, 1): 1 + 2 + 3 + 4 = 10
+    double val = PhaseCorrector::evaluatePolynomial(coeffs, 1.0, 1.0, 1.0, 1);
+    EXPECT_DOUBLE_EQ(val, 10.0);
+}
+
+TEST(PolynomialTest, LinearAtOrigin) {
+    std::vector<double> coeffs = {7.0, 2.0, 3.0, 4.0};
+    double val = PhaseCorrector::evaluatePolynomial(coeffs, 0.0, 0.0, 0.0, 1);
+    EXPECT_DOUBLE_EQ(val, 7.0);
+}
+
+TEST(PolynomialTest, EmptyCoefficients) {
+    std::vector<double> coeffs;
+    double val = PhaseCorrector::evaluatePolynomial(coeffs, 1.0, 1.0, 1.0, 1);
+    EXPECT_DOUBLE_EQ(val, 0.0);
+}
+
+// =============================================================================
+// fitPolynomialBackground tests
+// =============================================================================
+
+TEST(PolynomialFitTest, NullInputs) {
+    auto coeffs = PhaseCorrector::fitPolynomialBackground(
+        nullptr, nullptr, 2);
+    // Should return zero-filled coefficients
+    for (double c : coeffs) {
+        EXPECT_DOUBLE_EQ(c, 0.0);
+    }
+}
+
+TEST(PolynomialFitTest, ConstantField) {
+    // Scalar field with constant value 42.0, full mask
+    auto scalar = createUniformScalarImage(8, 8, 4, 42.0f);
+    auto mask = MaskImage3D::New();
+    MaskImage3D::SizeType size = {{8, 8, 4}};
+    MaskImage3D::RegionType region;
+    region.SetSize(size);
+    mask->SetRegions(region);
+    mask->Allocate();
+    mask->FillBuffer(255);
+
+    auto coeffs = PhaseCorrector::fitPolynomialBackground(scalar, mask, 1);
+    // Constant term should be approximately 42.0
+    ASSERT_FALSE(coeffs.empty());
+    EXPECT_NEAR(coeffs[0], 42.0, 1.0);
+    // Linear terms should be near zero
+    if (coeffs.size() >= 4) {
+        EXPECT_NEAR(coeffs[1], 0.0, 1.0);
+        EXPECT_NEAR(coeffs[2], 0.0, 1.0);
+        EXPECT_NEAR(coeffs[3], 0.0, 1.0);
+    }
+}
+
+TEST(PolynomialFitTest, TooFewSamples) {
+    auto scalar = createUniformScalarImage(2, 2, 2, 10.0f);
+    auto mask = MaskImage3D::New();
+    MaskImage3D::SizeType size = {{2, 2, 2}};
+    MaskImage3D::RegionType region;
+    region.SetSize(size);
+    mask->SetRegions(region);
+    mask->Allocate();
+    // Only 1 pixel in mask — fewer than polynomial terms for order 2
+    mask->FillBuffer(0);
+    MaskImage3D::IndexType idx = {{0, 0, 0}};
+    mask->SetPixel(idx, 255);
+
+    auto coeffs = PhaseCorrector::fitPolynomialBackground(scalar, mask, 2);
+    // Should return zeros (not enough samples)
+    for (double c : coeffs) {
+        EXPECT_DOUBLE_EQ(c, 0.0);
+    }
+}
+
+// =============================================================================
+// correctEddyCurrent integration test
+// =============================================================================
+
+TEST(EddyCurrentTest, NullInputsSafe) {
+    PhaseCorrector::correctEddyCurrent(nullptr, nullptr, 2);
+    // Should not crash
+}
+
+TEST(EddyCurrentTest, NullMagnitudeSafe) {
+    auto velocity = createUniformVectorImage(4, 4, 4, 10.0f, 20.0f, 30.0f);
+    PhaseCorrector::correctEddyCurrent(velocity, nullptr, 2);
+    // Should not crash, velocity unchanged
+    VectorImage3D::IndexType idx = {{2, 2, 2}};
+    auto pixel = velocity->GetPixel(idx);
+    EXPECT_FLOAT_EQ(pixel[0], 10.0f);
+}


### PR DESCRIPTION
Closes #154

## Summary
- Implement `PhaseCorrector` with three independent correction algorithms for raw 4D Flow velocity data
- Velocity aliasing unwrap via neighbor-based phase tracking
- Eddy current correction using Otsu-thresholded stationary tissue mask + polynomial least-squares fitting
- Maxwell term correction framework (deferred — requires vendor-specific sequence parameters)
- `PhaseCorrectionConfig` with independent enable/disable for each correction
- 27 unit tests covering all components

## Architecture

### Correction Pipeline
```
VelocityPhase (raw)
  → Deep copy (preserve original)
  → [1] Aliasing Unwrap (neighbor-based 1D tracking)
  → [2] Eddy Current (Otsu mask → polynomial fit → subtract background)
  → [3] Maxwell Terms (framework only — needs vendor metadata)
  → VelocityPhase (corrected)
```

### Eddy Current Algorithm
```
1. Otsu threshold on magnitude → tissue/background mask
2. Binary erosion (radius=1) → exclude partial volume boundaries
3. Extract velocity at mask locations
4. Least-squares polynomial fit (normal equations + Gaussian elimination)
5. Subtract polynomial background from entire volume
```

### Key Design Decisions
| Decision | Rationale |
|----------|-----------|
| Deep copy on correction | Non-destructive — original data preserved |
| Independent enable/disable | Clinical workflows may need only specific corrections |
| Polynomial order 1-4 | Order 2 typical for eddy currents; higher orders risk overfitting |
| Aliasing threshold 0.8 | Default matches clinical practice (80% of VENC) |

### Files Added (5 files, +1,001 lines)
- `include/services/flow/phase_corrector.hpp` - Class + PhaseCorrectionConfig
- `src/services/flow/phase_corrector.cpp` - Full implementation
- `tests/unit/phase_corrector_test.cpp` - 27 unit tests
- `CMakeLists.txt` - Added to flow_service library
- `tests/CMakeLists.txt` - Test target registration

## Traceability
- **PRD**: FR-014 (4D Flow MRI Analysis)
- **SRS**: SRS-FR-045 (PhaseCorrector)
- **SDS**: SDS-MOD-007 (Flow Analysis Module)
- **Depends on**: #153 (VelocityFieldAssembler) - merged

## Test Plan
- [x] `PhaseCorrectionConfig`: default valid, invalid polynomial order (0, 5), invalid threshold (0, 1.5)
- [x] Construction: default, move, move-assignment
- [x] Progress callback registration
- [x] `correctPhase()`: invalid config → InvalidInput
- [x] `correctPhase()`: null velocity → InvalidInput
- [x] `correctPhase()`: negative VENC → InvalidInput
- [x] `correctPhase()`: zero VENC → InvalidInput
- [x] `correctPhase()`: preserves original data after correction
- [x] `correctPhase()`: works without magnitude (eddy current skipped)
- [x] `unwrapAliasing()`: uniform velocity within VENC → unchanged
- [x] `unwrapAliasing()`: synthetic wrap at boundary → corrected
- [x] `unwrapAliasing()`: null image → safe no-op
- [x] `createStationaryMask()`: uniform high signal → non-null mask
- [x] `createStationaryMask()`: null input → null output
- [x] `evaluatePolynomial()`: constant, linear, at origin, empty coeffs
- [x] `fitPolynomialBackground()`: null inputs → zero coeffs
- [x] `fitPolynomialBackground()`: constant field → captures constant term
- [x] `fitPolynomialBackground()`: too few samples → zero coeffs
- [x] `correctEddyCurrent()`: null inputs → safe no-op
- [x] Build succeeds: `cmake --build build/ --target flow_service`
- [x] All 27 new tests pass
- [x] All 38 FlowDicomParser tests + 23 VelocityFieldAssembler tests still pass