### PR TITLE
feat(flow): implement TemporalNavigator for cardiac phase navigation and cine playback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,6 +491,7 @@ add_library(flow_service STATIC
     src/services/flow/flow_dicom_parser.cpp
     src/services/flow/velocity_field_assembler.cpp
     src/services/flow/phase_corrector.cpp
+    src/services/flow/temporal_navigator.cpp
     src/services/flow/vendor_parsers/siemens_flow_parser.cpp
     src/services/flow/vendor_parsers/philips_flow_parser.cpp
     src/services/flow/vendor_parsers/ge_flow_parser.cpp

--- a/include/services/flow/temporal_navigator.hpp
+++ b/include/services/flow/temporal_navigator.hpp
@@ -1,0 +1,228 @@
+#pragma once
+
+#include <expected>
+#include <functional>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "services/flow/flow_dicom_types.hpp"
+#include "services/flow/velocity_field_assembler.hpp"
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Cache status information for monitoring
+ *
+ * @trace SRS-FR-048
+ */
+struct CacheStatus {
+    int cachedCount = 0;
+    int totalPhases = 0;
+    size_t memoryUsageBytes = 0;
+    int windowSize = 0;
+};
+
+/**
+ * @brief Playback state for cine mode
+ *
+ * @trace SRS-FR-048
+ */
+struct PlaybackState {
+    bool isPlaying = false;
+    double fps = 15.0;
+    double speedMultiplier = 1.0;
+    bool looping = true;
+    int currentPhase = 0;
+    double currentTimeMs = 0.0;
+};
+
+/**
+ * @brief LRU sliding window cache for velocity phase data
+ *
+ * Manages memory by keeping only a configurable number of phases
+ * in memory, evicting least-recently-used phases when the window
+ * size is exceeded.
+ *
+ * @trace SRS-FR-048
+ */
+class PhaseCache {
+public:
+    /**
+     * @brief Construct cache with window size
+     * @param windowSize Maximum number of phases to keep in memory
+     */
+    explicit PhaseCache(int windowSize = 5);
+
+    /**
+     * @brief Set the phase loader function
+     *
+     * The loader is called when a phase is not in cache and needs
+     * to be loaded from disk.
+     *
+     * @param loader Function that loads a phase by index
+     */
+    void setPhaseLoader(
+        std::function<std::expected<VelocityPhase, FlowError>(int)> loader);
+
+    /**
+     * @brief Get a phase, loading if not cached
+     * @param phaseIndex 0-based phase index
+     * @return VelocityPhase on success, FlowError on failure
+     */
+    [[nodiscard]] std::expected<VelocityPhase, FlowError>
+    getPhase(int phaseIndex);
+
+    /**
+     * @brief Check if a phase is currently cached
+     */
+    [[nodiscard]] bool isCached(int phaseIndex) const;
+
+    /**
+     * @brief Get all currently cached phase indices
+     */
+    [[nodiscard]] std::vector<int> getCachedPhases() const;
+
+    /**
+     * @brief Get cache statistics
+     */
+    [[nodiscard]] CacheStatus getStatus() const;
+
+    /**
+     * @brief Set total number of phases (for status reporting)
+     */
+    void setTotalPhases(int total);
+
+    /**
+     * @brief Clear all cached phases
+     */
+    void clear();
+
+    /**
+     * @brief Get the window size
+     */
+    [[nodiscard]] int windowSize() const noexcept;
+
+private:
+    void evictIfNeeded();
+    void touchPhase(int phaseIndex);
+
+    int windowSize_;
+    int totalPhases_ = 0;
+    std::unordered_map<int, VelocityPhase> cache_;
+    std::list<int> accessOrder_;  // Front = most recent
+    std::function<std::expected<VelocityPhase, FlowError>(int)> loader_;
+    mutable std::mutex mutex_;
+};
+
+/**
+ * @brief Cardiac phase navigation controller for 4D Flow MRI
+ *
+ * Provides phase-by-phase navigation, cine playback controls,
+ * and LRU cache management for temporal 4D Flow sequences.
+ *
+ * This is a service-layer class without Qt dependency. UI integration
+ * (QTimer, signals/slots) is handled by the UI layer.
+ *
+ * @trace SRS-FR-048
+ */
+class TemporalNavigator {
+public:
+    /// Callback when phase changes
+    using PhaseChangedCallback = std::function<void(int phaseIndex)>;
+    /// Callback when playback state changes
+    using PlaybackChangedCallback = std::function<void(const PlaybackState& state)>;
+    /// Callback for cache status updates
+    using CacheStatusCallback = std::function<void(const CacheStatus& status)>;
+
+    TemporalNavigator();
+    ~TemporalNavigator();
+
+    // Non-copyable, movable
+    TemporalNavigator(const TemporalNavigator&) = delete;
+    TemporalNavigator& operator=(const TemporalNavigator&) = delete;
+    TemporalNavigator(TemporalNavigator&&) noexcept;
+    TemporalNavigator& operator=(TemporalNavigator&&) noexcept;
+
+    /**
+     * @brief Initialize with series information
+     * @param phaseCount Total number of cardiac phases
+     * @param temporalResolution Time between phases (ms)
+     * @param cacheWindowSize Number of phases to keep in memory
+     */
+    void initialize(int phaseCount, double temporalResolution,
+                    int cacheWindowSize = 5);
+
+    /**
+     * @brief Set the phase loader for cache
+     */
+    void setPhaseLoader(
+        std::function<std::expected<VelocityPhase, FlowError>(int)> loader);
+
+    // --- Navigation ---
+
+    /**
+     * @brief Go to a specific phase
+     * @return The loaded phase data, or error
+     */
+    [[nodiscard]] std::expected<VelocityPhase, FlowError>
+    goToPhase(int phaseIndex);
+
+    /** @brief Advance to next phase (wraps if looping) */
+    [[nodiscard]] std::expected<VelocityPhase, FlowError> nextPhase();
+
+    /** @brief Go to previous phase (wraps if looping) */
+    [[nodiscard]] std::expected<VelocityPhase, FlowError> previousPhase();
+
+    // --- Playback control ---
+
+    /** @brief Start cine playback */
+    void play(double fps = 15.0);
+
+    /** @brief Pause playback */
+    void pause();
+
+    /** @brief Stop and reset to phase 0 */
+    void stop();
+
+    /** @brief Set playback speed multiplier (0.25x - 4x) */
+    void setPlaybackSpeed(double multiplier);
+
+    /** @brief Set looping mode */
+    void setLooping(bool loop);
+
+    /**
+     * @brief Advance one tick in playback mode
+     *
+     * Call this method from a timer (e.g., QTimer) at the configured
+     * frame rate. Returns the next phase to display.
+     *
+     * @return Next phase data, or error, or nullopt if not playing
+     */
+    [[nodiscard]] std::expected<VelocityPhase, FlowError> tick();
+
+    // --- State queries ---
+
+    [[nodiscard]] int currentPhase() const;
+    [[nodiscard]] int phaseCount() const;
+    [[nodiscard]] double temporalResolution() const;
+    [[nodiscard]] double currentTimeMs() const;
+    [[nodiscard]] PlaybackState playbackState() const;
+    [[nodiscard]] CacheStatus cacheStatus() const;
+    [[nodiscard]] bool isInitialized() const;
+
+    // --- Callbacks ---
+
+    void setPhaseChangedCallback(PhaseChangedCallback callback);
+    void setPlaybackChangedCallback(PlaybackChangedCallback callback);
+    void setCacheStatusCallback(CacheStatusCallback callback);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace dicom_viewer::services

--- a/src/services/flow/temporal_navigator.cpp
+++ b/src/services/flow/temporal_navigator.cpp
@@ -1,0 +1,366 @@
+#include "services/flow/temporal_navigator.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "core/logging.hpp"
+
+namespace {
+
+auto& getLogger() {
+    static auto logger =
+        dicom_viewer::logging::LoggerFactory::create("TemporalNavigator");
+    return logger;
+}
+
+}  // anonymous namespace
+
+namespace dicom_viewer::services {
+
+// =============================================================================
+// PhaseCache implementation
+// =============================================================================
+
+PhaseCache::PhaseCache(int windowSize)
+    : windowSize_(std::max(1, windowSize)) {}
+
+void PhaseCache::setPhaseLoader(
+    std::function<std::expected<VelocityPhase, FlowError>(int)> loader) {
+    std::lock_guard lock(mutex_);
+    loader_ = std::move(loader);
+}
+
+std::expected<VelocityPhase, FlowError>
+PhaseCache::getPhase(int phaseIndex) {
+    std::lock_guard lock(mutex_);
+
+    // Check cache first
+    auto it = cache_.find(phaseIndex);
+    if (it != cache_.end()) {
+        touchPhase(phaseIndex);
+        return it->second;
+    }
+
+    // Load from disk
+    if (!loader_) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InternalError,
+            "No phase loader configured"});
+    }
+
+    auto result = loader_(phaseIndex);
+    if (!result) {
+        return result;
+    }
+
+    // Evict if needed before inserting
+    evictIfNeeded();
+
+    cache_[phaseIndex] = result.value();
+    accessOrder_.push_front(phaseIndex);
+
+    return result;
+}
+
+bool PhaseCache::isCached(int phaseIndex) const {
+    std::lock_guard lock(mutex_);
+    return cache_.contains(phaseIndex);
+}
+
+std::vector<int> PhaseCache::getCachedPhases() const {
+    std::lock_guard lock(mutex_);
+    std::vector<int> phases;
+    phases.reserve(cache_.size());
+    for (const auto& [idx, _] : cache_) {
+        phases.push_back(idx);
+    }
+    std::sort(phases.begin(), phases.end());
+    return phases;
+}
+
+CacheStatus PhaseCache::getStatus() const {
+    std::lock_guard lock(mutex_);
+    CacheStatus status;
+    status.cachedCount = static_cast<int>(cache_.size());
+    status.totalPhases = totalPhases_;
+    status.windowSize = windowSize_;
+
+    // Estimate memory: each VelocityPhase holds a VectorImage3D + FloatImage3D
+    // Rough estimation only — actual size depends on image dimensions
+    status.memoryUsageBytes = cache_.size() * 50 * 1024 * 1024;  // ~50MB/phase estimate
+
+    return status;
+}
+
+void PhaseCache::setTotalPhases(int total) {
+    std::lock_guard lock(mutex_);
+    totalPhases_ = total;
+}
+
+void PhaseCache::clear() {
+    std::lock_guard lock(mutex_);
+    cache_.clear();
+    accessOrder_.clear();
+}
+
+int PhaseCache::windowSize() const noexcept {
+    return windowSize_;
+}
+
+void PhaseCache::evictIfNeeded() {
+    // Already holding mutex
+    while (static_cast<int>(cache_.size()) >= windowSize_ &&
+           !accessOrder_.empty()) {
+        int oldest = accessOrder_.back();
+        accessOrder_.pop_back();
+        cache_.erase(oldest);
+    }
+}
+
+void PhaseCache::touchPhase(int phaseIndex) {
+    // Already holding mutex — move to front of access order
+    accessOrder_.remove(phaseIndex);
+    accessOrder_.push_front(phaseIndex);
+}
+
+// =============================================================================
+// TemporalNavigator implementation
+// =============================================================================
+
+class TemporalNavigator::Impl {
+public:
+    std::unique_ptr<PhaseCache> cache = std::make_unique<PhaseCache>(5);
+    int phaseCount_ = 0;
+    double temporalResolution_ = 0.0;
+    int currentPhase_ = 0;
+    bool initialized_ = false;
+
+    PlaybackState playback;
+
+    PhaseChangedCallback phaseChangedCb;
+    PlaybackChangedCallback playbackChangedCb;
+    CacheStatusCallback cacheStatusCb;
+
+    void notifyPhaseChanged(int phase) {
+        if (phaseChangedCb) {
+            phaseChangedCb(phase);
+        }
+    }
+
+    void notifyPlaybackChanged() {
+        if (playbackChangedCb) {
+            playbackChangedCb(playback);
+        }
+    }
+
+    void notifyCacheStatus() {
+        if (cacheStatusCb) {
+            cacheStatusCb(cache->getStatus());
+        }
+    }
+
+    int wrapPhase(int phase) const {
+        if (phaseCount_ <= 0) return 0;
+        if (playback.looping) {
+            return ((phase % phaseCount_) + phaseCount_) % phaseCount_;
+        }
+        return std::clamp(phase, 0, phaseCount_ - 1);
+    }
+};
+
+TemporalNavigator::TemporalNavigator()
+    : impl_(std::make_unique<Impl>()) {}
+
+TemporalNavigator::~TemporalNavigator() = default;
+
+TemporalNavigator::TemporalNavigator(TemporalNavigator&&) noexcept = default;
+TemporalNavigator& TemporalNavigator::operator=(TemporalNavigator&&) noexcept = default;
+
+void TemporalNavigator::initialize(
+    int phaseCount, double temporalResolution, int cacheWindowSize) {
+    impl_->phaseCount_ = phaseCount;
+    impl_->temporalResolution_ = temporalResolution;
+    impl_->currentPhase_ = 0;
+    impl_->initialized_ = true;
+
+    impl_->cache = std::make_unique<PhaseCache>(cacheWindowSize);
+    impl_->cache->setTotalPhases(phaseCount);
+
+    impl_->playback = PlaybackState{};
+    impl_->playback.currentPhase = 0;
+    impl_->playback.currentTimeMs = 0.0;
+
+    getLogger()->info("Initialized: {} phases, {:.1f} ms/phase, cache={}",
+                      phaseCount, temporalResolution, cacheWindowSize);
+}
+
+void TemporalNavigator::setPhaseLoader(
+    std::function<std::expected<VelocityPhase, FlowError>(int)> loader) {
+    impl_->cache->setPhaseLoader(std::move(loader));
+}
+
+std::expected<VelocityPhase, FlowError>
+TemporalNavigator::goToPhase(int phaseIndex) {
+    if (!impl_->initialized_) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "TemporalNavigator not initialized"});
+    }
+
+    if (phaseIndex < 0 || phaseIndex >= impl_->phaseCount_) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "Phase index " + std::to_string(phaseIndex) + " out of range [0, " +
+                std::to_string(impl_->phaseCount_) + ")"});
+    }
+
+    auto result = impl_->cache->getPhase(phaseIndex);
+    if (result) {
+        impl_->currentPhase_ = phaseIndex;
+        impl_->playback.currentPhase = phaseIndex;
+        impl_->playback.currentTimeMs =
+            phaseIndex * impl_->temporalResolution_;
+
+        impl_->notifyPhaseChanged(phaseIndex);
+        impl_->notifyCacheStatus();
+    }
+
+    return result;
+}
+
+std::expected<VelocityPhase, FlowError>
+TemporalNavigator::nextPhase() {
+    if (!impl_->initialized_) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "TemporalNavigator not initialized"});
+    }
+
+    int next = impl_->currentPhase_ + 1;
+    if (next >= impl_->phaseCount_) {
+        if (impl_->playback.looping) {
+            next = 0;
+        } else {
+            next = impl_->phaseCount_ - 1;
+        }
+    }
+
+    return goToPhase(next);
+}
+
+std::expected<VelocityPhase, FlowError>
+TemporalNavigator::previousPhase() {
+    if (!impl_->initialized_) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "TemporalNavigator not initialized"});
+    }
+
+    int prev = impl_->currentPhase_ - 1;
+    if (prev < 0) {
+        if (impl_->playback.looping) {
+            prev = impl_->phaseCount_ - 1;
+        } else {
+            prev = 0;
+        }
+    }
+
+    return goToPhase(prev);
+}
+
+void TemporalNavigator::play(double fps) {
+    impl_->playback.isPlaying = true;
+    impl_->playback.fps = std::clamp(fps, 1.0, 60.0);
+    impl_->notifyPlaybackChanged();
+    getLogger()->debug("Playback started: {:.1f} fps", fps);
+}
+
+void TemporalNavigator::pause() {
+    impl_->playback.isPlaying = false;
+    impl_->notifyPlaybackChanged();
+}
+
+void TemporalNavigator::stop() {
+    impl_->playback.isPlaying = false;
+    impl_->currentPhase_ = 0;
+    impl_->playback.currentPhase = 0;
+    impl_->playback.currentTimeMs = 0.0;
+    impl_->notifyPlaybackChanged();
+    impl_->notifyPhaseChanged(0);
+}
+
+void TemporalNavigator::setPlaybackSpeed(double multiplier) {
+    impl_->playback.speedMultiplier = std::clamp(multiplier, 0.25, 4.0);
+    impl_->notifyPlaybackChanged();
+}
+
+void TemporalNavigator::setLooping(bool loop) {
+    impl_->playback.looping = loop;
+    impl_->notifyPlaybackChanged();
+}
+
+std::expected<VelocityPhase, FlowError>
+TemporalNavigator::tick() {
+    if (!impl_->playback.isPlaying) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "Not in playback mode"});
+    }
+
+    int next = impl_->currentPhase_ + 1;
+    if (next >= impl_->phaseCount_) {
+        if (impl_->playback.looping) {
+            next = 0;
+        } else {
+            pause();
+            return std::unexpected(FlowError{
+                FlowError::Code::InvalidInput,
+                "Reached end of sequence"});
+        }
+    }
+
+    return goToPhase(next);
+}
+
+int TemporalNavigator::currentPhase() const {
+    return impl_->currentPhase_;
+}
+
+int TemporalNavigator::phaseCount() const {
+    return impl_->phaseCount_;
+}
+
+double TemporalNavigator::temporalResolution() const {
+    return impl_->temporalResolution_;
+}
+
+double TemporalNavigator::currentTimeMs() const {
+    return impl_->currentPhase_ * impl_->temporalResolution_;
+}
+
+PlaybackState TemporalNavigator::playbackState() const {
+    return impl_->playback;
+}
+
+CacheStatus TemporalNavigator::cacheStatus() const {
+    return impl_->cache->getStatus();
+}
+
+bool TemporalNavigator::isInitialized() const {
+    return impl_->initialized_;
+}
+
+void TemporalNavigator::setPhaseChangedCallback(PhaseChangedCallback callback) {
+    impl_->phaseChangedCb = std::move(callback);
+}
+
+void TemporalNavigator::setPlaybackChangedCallback(
+    PlaybackChangedCallback callback) {
+    impl_->playbackChangedCb = std::move(callback);
+}
+
+void TemporalNavigator::setCacheStatusCallback(CacheStatusCallback callback) {
+    impl_->cacheStatusCb = std::move(callback);
+}
+
+}  // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -815,3 +815,20 @@ target_include_directories(phase_corrector_test PRIVATE
 )
 
 gtest_discover_tests(phase_corrector_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for Temporal Navigator
+add_executable(temporal_navigator_test
+    unit/temporal_navigator_test.cpp
+)
+
+target_link_libraries(temporal_navigator_test PRIVATE
+    flow_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(temporal_navigator_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(temporal_navigator_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/temporal_navigator_test.cpp
+++ b/tests/unit/temporal_navigator_test.cpp
@@ -1,0 +1,444 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "services/flow/temporal_navigator.hpp"
+
+using namespace dicom_viewer::services;
+
+namespace {
+
+/// Create a mock phase loader that returns synthetic VelocityPhase data
+auto createMockLoader(int maxPhases) {
+    return [maxPhases](int phaseIndex)
+               -> std::expected<VelocityPhase, FlowError> {
+        if (phaseIndex < 0 || phaseIndex >= maxPhases) {
+            return std::unexpected(FlowError{
+                FlowError::Code::InvalidInput,
+                "Phase " + std::to_string(phaseIndex) + " out of range"});
+        }
+        VelocityPhase phase;
+        phase.phaseIndex = phaseIndex;
+        phase.triggerTime = phaseIndex * 40.0;  // 40ms per phase
+        // velocityField is null — fine for navigation tests
+        return phase;
+    };
+}
+
+}  // anonymous namespace
+
+// =============================================================================
+// CacheStatus / PlaybackState defaults
+// =============================================================================
+
+TEST(CacheStatusTest, Defaults) {
+    CacheStatus status;
+    EXPECT_EQ(status.cachedCount, 0);
+    EXPECT_EQ(status.totalPhases, 0);
+    EXPECT_EQ(status.memoryUsageBytes, 0);
+    EXPECT_EQ(status.windowSize, 0);
+}
+
+TEST(PlaybackStateTest, Defaults) {
+    PlaybackState state;
+    EXPECT_FALSE(state.isPlaying);
+    EXPECT_DOUBLE_EQ(state.fps, 15.0);
+    EXPECT_DOUBLE_EQ(state.speedMultiplier, 1.0);
+    EXPECT_TRUE(state.looping);
+    EXPECT_EQ(state.currentPhase, 0);
+    EXPECT_DOUBLE_EQ(state.currentTimeMs, 0.0);
+}
+
+// =============================================================================
+// PhaseCache tests
+// =============================================================================
+
+TEST(PhaseCacheTest, DefaultWindowSize) {
+    PhaseCache cache;
+    EXPECT_EQ(cache.windowSize(), 5);
+}
+
+TEST(PhaseCacheTest, CustomWindowSize) {
+    PhaseCache cache(10);
+    EXPECT_EQ(cache.windowSize(), 10);
+}
+
+TEST(PhaseCacheTest, MinimumWindowSize) {
+    PhaseCache cache(0);
+    EXPECT_EQ(cache.windowSize(), 1);
+    PhaseCache cache2(-5);
+    EXPECT_EQ(cache2.windowSize(), 1);
+}
+
+TEST(PhaseCacheTest, GetPhaseWithoutLoader) {
+    PhaseCache cache(5);
+    auto result = cache.getPhase(0);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, FlowError::Code::InternalError);
+}
+
+TEST(PhaseCacheTest, GetPhaseWithLoader) {
+    PhaseCache cache(5);
+    cache.setPhaseLoader(createMockLoader(20));
+    cache.setTotalPhases(20);
+
+    auto result = cache.getPhase(3);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->phaseIndex, 3);
+}
+
+TEST(PhaseCacheTest, CachesLoadedPhases) {
+    PhaseCache cache(5);
+    cache.setPhaseLoader(createMockLoader(20));
+
+    EXPECT_FALSE(cache.isCached(3));
+    cache.getPhase(3);
+    EXPECT_TRUE(cache.isCached(3));
+}
+
+TEST(PhaseCacheTest, LRUEviction) {
+    PhaseCache cache(3);  // Max 3 phases
+    cache.setPhaseLoader(createMockLoader(20));
+
+    cache.getPhase(0);
+    cache.getPhase(1);
+    cache.getPhase(2);
+    EXPECT_TRUE(cache.isCached(0));
+    EXPECT_TRUE(cache.isCached(1));
+    EXPECT_TRUE(cache.isCached(2));
+
+    // Loading phase 3 should evict phase 0 (oldest)
+    cache.getPhase(3);
+    EXPECT_FALSE(cache.isCached(0));
+    EXPECT_TRUE(cache.isCached(1));
+    EXPECT_TRUE(cache.isCached(2));
+    EXPECT_TRUE(cache.isCached(3));
+}
+
+TEST(PhaseCacheTest, LRUTouchReorders) {
+    PhaseCache cache(3);
+    cache.setPhaseLoader(createMockLoader(20));
+
+    cache.getPhase(0);
+    cache.getPhase(1);
+    cache.getPhase(2);
+
+    // Touch phase 0 again — now 1 is the oldest
+    cache.getPhase(0);
+
+    // Loading phase 3 should evict phase 1 (now oldest)
+    cache.getPhase(3);
+    EXPECT_TRUE(cache.isCached(0));   // Recently touched
+    EXPECT_FALSE(cache.isCached(1));  // Evicted
+    EXPECT_TRUE(cache.isCached(2));
+    EXPECT_TRUE(cache.isCached(3));
+}
+
+TEST(PhaseCacheTest, GetCachedPhases) {
+    PhaseCache cache(5);
+    cache.setPhaseLoader(createMockLoader(20));
+
+    cache.getPhase(5);
+    cache.getPhase(2);
+    cache.getPhase(8);
+
+    auto phases = cache.getCachedPhases();
+    ASSERT_EQ(phases.size(), 3);
+    EXPECT_EQ(phases[0], 2);  // Sorted
+    EXPECT_EQ(phases[1], 5);
+    EXPECT_EQ(phases[2], 8);
+}
+
+TEST(PhaseCacheTest, Clear) {
+    PhaseCache cache(5);
+    cache.setPhaseLoader(createMockLoader(20));
+
+    cache.getPhase(0);
+    cache.getPhase(1);
+    EXPECT_EQ(cache.getCachedPhases().size(), 2);
+
+    cache.clear();
+    EXPECT_EQ(cache.getCachedPhases().size(), 0);
+    EXPECT_FALSE(cache.isCached(0));
+}
+
+TEST(PhaseCacheTest, Status) {
+    PhaseCache cache(5);
+    cache.setPhaseLoader(createMockLoader(20));
+    cache.setTotalPhases(20);
+
+    cache.getPhase(0);
+    cache.getPhase(1);
+
+    auto status = cache.getStatus();
+    EXPECT_EQ(status.cachedCount, 2);
+    EXPECT_EQ(status.totalPhases, 20);
+    EXPECT_EQ(status.windowSize, 5);
+    EXPECT_GT(status.memoryUsageBytes, 0);
+}
+
+// =============================================================================
+// TemporalNavigator construction tests
+// =============================================================================
+
+TEST(TemporalNavigatorTest, DefaultConstruction) {
+    TemporalNavigator nav;
+    EXPECT_FALSE(nav.isInitialized());
+    EXPECT_EQ(nav.currentPhase(), 0);
+    EXPECT_EQ(nav.phaseCount(), 0);
+}
+
+TEST(TemporalNavigatorTest, MoveConstruction) {
+    TemporalNavigator nav;
+    TemporalNavigator moved(std::move(nav));
+}
+
+TEST(TemporalNavigatorTest, MoveAssignment) {
+    TemporalNavigator nav;
+    TemporalNavigator other;
+    other = std::move(nav);
+}
+
+TEST(TemporalNavigatorTest, Initialize) {
+    TemporalNavigator nav;
+    nav.initialize(25, 40.0, 5);
+    EXPECT_TRUE(nav.isInitialized());
+    EXPECT_EQ(nav.phaseCount(), 25);
+    EXPECT_DOUBLE_EQ(nav.temporalResolution(), 40.0);
+    EXPECT_EQ(nav.currentPhase(), 0);
+}
+
+// =============================================================================
+// Navigation tests
+// =============================================================================
+
+TEST(TemporalNavigatorTest, GoToPhaseNotInitialized) {
+    TemporalNavigator nav;
+    auto result = nav.goToPhase(0);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, FlowError::Code::InvalidInput);
+}
+
+TEST(TemporalNavigatorTest, GoToPhaseOutOfRange) {
+    TemporalNavigator nav;
+    nav.initialize(10, 40.0);
+    nav.setPhaseLoader(createMockLoader(10));
+
+    auto result = nav.goToPhase(15);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, FlowError::Code::InvalidInput);
+}
+
+TEST(TemporalNavigatorTest, GoToPhaseNegative) {
+    TemporalNavigator nav;
+    nav.initialize(10, 40.0);
+    nav.setPhaseLoader(createMockLoader(10));
+
+    auto result = nav.goToPhase(-1);
+    ASSERT_FALSE(result.has_value());
+}
+
+TEST(TemporalNavigatorTest, GoToPhaseSuccess) {
+    TemporalNavigator nav;
+    nav.initialize(10, 40.0);
+    nav.setPhaseLoader(createMockLoader(10));
+
+    auto result = nav.goToPhase(5);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->phaseIndex, 5);
+    EXPECT_EQ(nav.currentPhase(), 5);
+    EXPECT_DOUBLE_EQ(nav.currentTimeMs(), 200.0);  // 5 × 40ms
+}
+
+TEST(TemporalNavigatorTest, NextPhaseWraps) {
+    TemporalNavigator nav;
+    nav.initialize(3, 40.0);
+    nav.setPhaseLoader(createMockLoader(3));
+    nav.setLooping(true);
+
+    nav.goToPhase(2);  // Last phase
+    auto result = nav.nextPhase();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(nav.currentPhase(), 0);  // Wrapped to start
+}
+
+TEST(TemporalNavigatorTest, NextPhaseNoWrap) {
+    TemporalNavigator nav;
+    nav.initialize(3, 40.0);
+    nav.setPhaseLoader(createMockLoader(3));
+    nav.setLooping(false);
+
+    nav.goToPhase(2);
+    auto result = nav.nextPhase();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(nav.currentPhase(), 2);  // Stays at end
+}
+
+TEST(TemporalNavigatorTest, PreviousPhaseWraps) {
+    TemporalNavigator nav;
+    nav.initialize(3, 40.0);
+    nav.setPhaseLoader(createMockLoader(3));
+    nav.setLooping(true);
+
+    // Already at phase 0
+    auto result = nav.previousPhase();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(nav.currentPhase(), 2);  // Wrapped to end
+}
+
+TEST(TemporalNavigatorTest, PreviousPhaseNoWrap) {
+    TemporalNavigator nav;
+    nav.initialize(3, 40.0);
+    nav.setPhaseLoader(createMockLoader(3));
+    nav.setLooping(false);
+
+    auto result = nav.previousPhase();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(nav.currentPhase(), 0);  // Stays at start
+}
+
+// =============================================================================
+// Playback control tests
+// =============================================================================
+
+TEST(TemporalNavigatorTest, PlayPauseStop) {
+    TemporalNavigator nav;
+    nav.initialize(10, 40.0);
+
+    EXPECT_FALSE(nav.playbackState().isPlaying);
+
+    nav.play(20.0);
+    EXPECT_TRUE(nav.playbackState().isPlaying);
+    EXPECT_DOUBLE_EQ(nav.playbackState().fps, 20.0);
+
+    nav.pause();
+    EXPECT_FALSE(nav.playbackState().isPlaying);
+
+    nav.play();
+    nav.stop();
+    EXPECT_FALSE(nav.playbackState().isPlaying);
+    EXPECT_EQ(nav.currentPhase(), 0);  // Reset
+}
+
+TEST(TemporalNavigatorTest, PlaybackSpeedClamp) {
+    TemporalNavigator nav;
+    nav.initialize(10, 40.0);
+
+    nav.setPlaybackSpeed(0.1);  // Below min
+    EXPECT_DOUBLE_EQ(nav.playbackState().speedMultiplier, 0.25);
+
+    nav.setPlaybackSpeed(10.0);  // Above max
+    EXPECT_DOUBLE_EQ(nav.playbackState().speedMultiplier, 4.0);
+
+    nav.setPlaybackSpeed(2.0);
+    EXPECT_DOUBLE_EQ(nav.playbackState().speedMultiplier, 2.0);
+}
+
+TEST(TemporalNavigatorTest, FPSClamp) {
+    TemporalNavigator nav;
+    nav.initialize(10, 40.0);
+
+    nav.play(0.5);  // Below min
+    EXPECT_DOUBLE_EQ(nav.playbackState().fps, 1.0);
+
+    nav.play(100.0);  // Above max
+    EXPECT_DOUBLE_EQ(nav.playbackState().fps, 60.0);
+}
+
+TEST(TemporalNavigatorTest, TickAdvancesPhase) {
+    TemporalNavigator nav;
+    nav.initialize(5, 40.0);
+    nav.setPhaseLoader(createMockLoader(5));
+
+    nav.play();
+    auto result = nav.tick();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(nav.currentPhase(), 1);
+
+    result = nav.tick();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(nav.currentPhase(), 2);
+}
+
+TEST(TemporalNavigatorTest, TickWrapsWithLooping) {
+    TemporalNavigator nav;
+    nav.initialize(3, 40.0);
+    nav.setPhaseLoader(createMockLoader(3));
+    nav.setLooping(true);
+
+    nav.goToPhase(2);
+    nav.play();
+    auto result = nav.tick();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(nav.currentPhase(), 0);
+}
+
+TEST(TemporalNavigatorTest, TickStopsWithoutLooping) {
+    TemporalNavigator nav;
+    nav.initialize(3, 40.0);
+    nav.setPhaseLoader(createMockLoader(3));
+    nav.setLooping(false);
+
+    nav.goToPhase(2);
+    nav.play();
+    auto result = nav.tick();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_FALSE(nav.playbackState().isPlaying);  // Auto-paused
+}
+
+TEST(TemporalNavigatorTest, TickWhenNotPlaying) {
+    TemporalNavigator nav;
+    nav.initialize(5, 40.0);
+    nav.setPhaseLoader(createMockLoader(5));
+
+    auto result = nav.tick();
+    ASSERT_FALSE(result.has_value());
+}
+
+// =============================================================================
+// Callback tests
+// =============================================================================
+
+TEST(TemporalNavigatorTest, PhaseChangedCallback) {
+    TemporalNavigator nav;
+    nav.initialize(10, 40.0);
+    nav.setPhaseLoader(createMockLoader(10));
+
+    int lastPhase = -1;
+    nav.setPhaseChangedCallback([&](int p) { lastPhase = p; });
+
+    nav.goToPhase(7);
+    EXPECT_EQ(lastPhase, 7);
+}
+
+TEST(TemporalNavigatorTest, PlaybackChangedCallback) {
+    TemporalNavigator nav;
+    nav.initialize(10, 40.0);
+
+    PlaybackState lastState;
+    nav.setPlaybackChangedCallback([&](const PlaybackState& s) {
+        lastState = s;
+    });
+
+    nav.play(25.0);
+    EXPECT_TRUE(lastState.isPlaying);
+    EXPECT_DOUBLE_EQ(lastState.fps, 25.0);
+
+    nav.pause();
+    EXPECT_FALSE(lastState.isPlaying);
+}
+
+TEST(TemporalNavigatorTest, CacheStatusCallback) {
+    TemporalNavigator nav;
+    nav.initialize(10, 40.0);
+    nav.setPhaseLoader(createMockLoader(10));
+
+    CacheStatus lastStatus;
+    nav.setCacheStatusCallback([&](const CacheStatus& s) {
+        lastStatus = s;
+    });
+
+    nav.goToPhase(3);
+    EXPECT_EQ(lastStatus.cachedCount, 1);
+    EXPECT_EQ(lastStatus.totalPhases, 10);
+}


### PR DESCRIPTION
## Summary
- Implement `PhaseCache` with LRU sliding window eviction for memory-efficient phase data management
- Implement `TemporalNavigator` with phase-by-phase navigation (goToPhase/nextPhase/previousPhase)
- Add cine playback controls (play/pause/stop/tick) with configurable FPS (1-60) and speed multiplier (0.25x-4x)
- Qt-free service layer design with callback-based state notifications (PhaseChanged, PlaybackChanged, CacheStatus)
- Thread-safe cache with `std::mutex` and configurable window size

## Key Design Decisions
- **PIMPL pattern** for `TemporalNavigator` to hide implementation details and reduce header dependencies
- **`std::unique_ptr<PhaseCache>`** in Impl (not value type) because `std::mutex` deletes copy assignment
- **`std::function` loader** for lazy phase loading — cache calls the loader only on cache miss
- **LRU eviction** via `std::list<int>` access order — O(n) remove but simple and correct for small window sizes

## Test Plan
- [x] 35 unit tests covering all components
- [x] CacheStatus/PlaybackState default values
- [x] PhaseCache: window size, loader, caching, LRU eviction, touch reordering, getCachedPhases, clear, status
- [x] TemporalNavigator: construction, initialization, navigation (bounds checking, wrap/no-wrap)
- [x] Playback: play/pause/stop, speed clamp, FPS clamp, tick advance/wrap/stop
- [x] Callbacks: phase changed, playback changed, cache status
- [x] All 88 existing tests still pass (38 + 23 + 27)

Closes #155