### PR TITLE
feat(flow): implement FlowVisualizer for streamline, pathline, and glyph rendering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ find_package(VTK REQUIRED COMPONENTS
     CommonExecutionModel
     CommonTransforms
     FiltersCore
+    FiltersFlowPaths
     FiltersGeneral
     FiltersGeometry
     FiltersSources
@@ -492,6 +493,7 @@ add_library(flow_service STATIC
     src/services/flow/velocity_field_assembler.cpp
     src/services/flow/phase_corrector.cpp
     src/services/flow/temporal_navigator.cpp
+    src/services/flow/flow_visualizer.cpp
     src/services/flow/vendor_parsers/siemens_flow_parser.cpp
     src/services/flow/vendor_parsers/philips_flow_parser.cpp
     src/services/flow/vendor_parsers/ge_flow_parser.cpp
@@ -500,6 +502,7 @@ add_library(flow_service STATIC
 target_link_libraries(flow_service PUBLIC
     dicom_viewer_core
     ${ITK_LIBRARIES}
+    ${VTK_LIBRARIES}
 )
 
 # UI library

--- a/include/services/flow/flow_visualizer.hpp
+++ b/include/services/flow/flow_visualizer.hpp
@@ -1,0 +1,219 @@
+#pragma once
+
+#include <array>
+#include <expected>
+#include <memory>
+#include <vector>
+
+#include <vtkSmartPointer.h>
+
+#include "services/flow/flow_dicom_types.hpp"
+#include "services/flow/velocity_field_assembler.hpp"
+
+class vtkPolyData;
+class vtkImageData;
+class vtkLookupTable;
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Visualization type for velocity field rendering
+ *
+ * @trace SRS-FR-046
+ */
+enum class VisualizationType {
+    Streamlines,   ///< Instantaneous flow trajectories (tangent to velocity)
+    Pathlines,     ///< Time-resolved particle paths across phases
+    VectorGlyphs   ///< Arrow markers at discrete sample points
+};
+
+/**
+ * @brief Color mapping mode for velocity visualization
+ *
+ * @trace SRS-FR-046
+ */
+enum class ColorMode {
+    VelocityMagnitude,  ///< |V| mapped to rainbow colormap [0, VENC]
+    VelocityComponent,  ///< Single component with diverging colormap [-VENC, VENC]
+    FlowDirection,      ///< RGB-encoded direction
+    TriggerTime         ///< Time from R-wave with sequential colormap
+};
+
+/**
+ * @brief Parameters for streamline generation
+ */
+struct StreamlineParams {
+    int maxSeedPoints = 5000;
+    double stepLength = 0.5;         ///< Integration step in mm
+    int maxSteps = 2000;
+    double terminalSpeed = 0.1;      ///< Stop threshold in cm/s
+    double tubeRadius = 0.5;         ///< Tube filter radius in mm
+    int tubeSides = 8;
+};
+
+/**
+ * @brief Parameters for vector glyph rendering
+ */
+struct GlyphParams {
+    double scaleFactor = 1.0;
+    int skipFactor = 4;              ///< Sample every Nth voxel
+    double minMagnitude = 1.0;       ///< Minimum velocity threshold in cm/s
+};
+
+/**
+ * @brief Parameters for pathline generation
+ */
+struct PathlineParams {
+    int maxSeedPoints = 1000;
+    int maxSteps = 2000;
+    double terminalSpeed = 0.1;      ///< cm/s
+    double tubeRadius = 0.5;         ///< mm
+    int tubeSides = 8;
+};
+
+/**
+ * @brief Seed region for streamline and pathline origins
+ */
+struct SeedRegion {
+    enum class Type { Plane, Volume, Points };
+    Type type = Type::Volume;
+    std::array<double, 6> bounds = {0, 0, 0, 0, 0, 0};       ///< xmin,xmax,ymin,ymax,zmin,zmax
+    std::array<double, 3> planeOrigin = {0, 0, 0};
+    std::array<double, 3> planeNormal = {0, 0, 1};
+    double planeRadius = 50.0;
+    int numSeedPoints = 5000;
+};
+
+/**
+ * @brief Flow visualization pipeline for 4D Flow MRI velocity data
+ *
+ * Renders velocity vector fields as streamlines, pathlines, and vector
+ * glyphs using VTK visualization pipeline. Supports 4 color mapping modes
+ * for encoding velocity magnitude, component, direction, or trigger time.
+ *
+ * This is a service-layer class without Qt dependency. The VTK pipeline
+ * produces vtkPolyData output that can be attached to any VTK renderer.
+ *
+ * Pipeline Architecture:
+ * @code
+ * ITK VectorImage → vtkImageData (via velocityFieldToVTK)
+ *                        ↓
+ *         ┌──────────────┼──────────────┐
+ *     Streamlines    Pathlines     VectorGlyphs
+ *   (vtkStreamTracer) (RK4 manual)  (vtkGlyph3D)
+ *         ↓              ↓              ↓
+ *    vtkTubeFilter    vtkPolyLine   vtkArrowSource
+ *         ↓              ↓              ↓
+ *      vtkPolyData    vtkPolyData   vtkPolyData
+ * @endcode
+ *
+ * @trace SRS-FR-046
+ */
+class FlowVisualizer {
+public:
+    FlowVisualizer();
+    ~FlowVisualizer();
+
+    // Non-copyable, movable
+    FlowVisualizer(const FlowVisualizer&) = delete;
+    FlowVisualizer& operator=(const FlowVisualizer&) = delete;
+    FlowVisualizer(FlowVisualizer&&) noexcept;
+    FlowVisualizer& operator=(FlowVisualizer&&) noexcept;
+
+    /**
+     * @brief Set velocity field for visualization
+     * @param phase Assembled velocity phase with 3-component vector field
+     * @return void on success, FlowError if velocity field is null or invalid
+     */
+    std::expected<void, FlowError> setVelocityField(const VelocityPhase& phase);
+
+    /**
+     * @brief Set seed region for streamline/pathline origins
+     * @param region Seed region configuration
+     */
+    void setSeedRegion(const SeedRegion& region);
+
+    /**
+     * @brief Generate streamlines from current velocity field
+     *
+     * Uses vtkStreamTracer with RK45 integrator and vtkTubeFilter
+     * for 3D tube rendering of flow trajectories.
+     *
+     * @param params Streamline generation parameters
+     * @return PolyData with streamline geometry, or FlowError
+     */
+    [[nodiscard]] std::expected<vtkSmartPointer<vtkPolyData>, FlowError>
+    generateStreamlines(const StreamlineParams& params = {}) const;
+
+    /**
+     * @brief Generate pathlines across multiple cardiac phases
+     *
+     * Traces particle motion through temporal velocity fields using
+     * Euler integration across phases. Each seed point produces one
+     * polyline connecting positions across time.
+     *
+     * @param allPhases Vector of all cardiac phases
+     * @param params Pathline generation parameters
+     * @return PolyData with pathline geometry, or FlowError
+     */
+    [[nodiscard]] std::expected<vtkSmartPointer<vtkPolyData>, FlowError>
+    generatePathlines(const std::vector<VelocityPhase>& allPhases,
+                      const PathlineParams& params = {}) const;
+
+    /**
+     * @brief Generate vector glyphs from current velocity field
+     *
+     * Subsamples the velocity field and places oriented arrow glyphs
+     * at each sample point, scaled by velocity magnitude.
+     *
+     * @param params Glyph generation parameters
+     * @return PolyData with glyph geometry, or FlowError
+     */
+    [[nodiscard]] std::expected<vtkSmartPointer<vtkPolyData>, FlowError>
+    generateGlyphs(const GlyphParams& params = {}) const;
+
+    /**
+     * @brief Set color mapping mode
+     */
+    void setColorMode(ColorMode mode);
+
+    /**
+     * @brief Set velocity range for color mapping
+     * @param minVel Minimum velocity (cm/s)
+     * @param maxVel Maximum velocity (cm/s)
+     */
+    void setVelocityRange(double minVel, double maxVel);
+
+    /**
+     * @brief Create VTK lookup table for current color mode
+     * @return Configured lookup table
+     */
+    [[nodiscard]] vtkSmartPointer<vtkLookupTable> createLookupTable() const;
+
+    // --- State queries ---
+
+    [[nodiscard]] bool hasVelocityField() const;
+    [[nodiscard]] ColorMode colorMode() const;
+    [[nodiscard]] SeedRegion seedRegion() const;
+
+    // --- Utility ---
+
+    /**
+     * @brief Convert ITK VectorImage to VTK ImageData
+     *
+     * Copies the 3-component velocity data from ITK VectorImage into
+     * a vtkImageData with vectors set as active point vectors and
+     * magnitude as active scalars.
+     *
+     * @param phase Velocity phase with ITK vector image
+     * @return vtkImageData with velocity vectors, or FlowError
+     */
+    [[nodiscard]] static std::expected<vtkSmartPointer<vtkImageData>, FlowError>
+    velocityFieldToVTK(const VelocityPhase& phase);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace dicom_viewer::services

--- a/src/services/flow/flow_visualizer.cpp
+++ b/src/services/flow/flow_visualizer.cpp
@@ -1,0 +1,525 @@
+#include "services/flow/flow_visualizer.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include <vtkArrowSource.h>
+#include <vtkCellArray.h>
+#include <vtkFloatArray.h>
+#include <vtkGlyph3D.h>
+#include <vtkImageData.h>
+#include <vtkLookupTable.h>
+#include <vtkPointData.h>
+#include <vtkPointSource.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+#include <vtkPolyLine.h>
+#include <vtkRungeKutta45.h>
+#include <vtkStreamTracer.h>
+#include <vtkTubeFilter.h>
+
+#include "core/logging.hpp"
+
+namespace {
+
+auto& getLogger() {
+    static auto logger =
+        dicom_viewer::logging::LoggerFactory::create("FlowVisualizer");
+    return logger;
+}
+
+}  // anonymous namespace
+
+namespace dicom_viewer::services {
+
+// =============================================================================
+// FlowVisualizer::Impl
+// =============================================================================
+
+class FlowVisualizer::Impl {
+public:
+    vtkSmartPointer<vtkImageData> velocityData;
+    SeedRegion seed;
+    ColorMode colorMode_ = ColorMode::VelocityMagnitude;
+    double velocityMin = 0.0;
+    double velocityMax = 100.0;  // cm/s default
+    bool hasField = false;
+
+    vtkSmartPointer<vtkPointSource> createSeedSource(int numPoints) const {
+        auto source = vtkSmartPointer<vtkPointSource>::New();
+        source->SetNumberOfPoints(numPoints);
+
+        if (seed.type == SeedRegion::Type::Volume && velocityData) {
+            double center[3] = {
+                (seed.bounds[0] + seed.bounds[1]) / 2.0,
+                (seed.bounds[2] + seed.bounds[3]) / 2.0,
+                (seed.bounds[4] + seed.bounds[5]) / 2.0
+            };
+            double radius = std::max({
+                seed.bounds[1] - seed.bounds[0],
+                seed.bounds[3] - seed.bounds[2],
+                seed.bounds[5] - seed.bounds[4]
+            }) / 2.0;
+            source->SetCenter(center);
+            source->SetRadius(std::max(radius, 1.0));
+        } else if (seed.type == SeedRegion::Type::Plane) {
+            source->SetCenter(seed.planeOrigin.data());
+            source->SetRadius(seed.planeRadius);
+        } else if (velocityData) {
+            // Fallback: use image data bounds
+            double bounds[6];
+            velocityData->GetBounds(bounds);
+            double center[3] = {
+                (bounds[0] + bounds[1]) / 2.0,
+                (bounds[2] + bounds[3]) / 2.0,
+                (bounds[4] + bounds[5]) / 2.0
+            };
+            double radius = std::max({
+                bounds[1] - bounds[0],
+                bounds[3] - bounds[2],
+                bounds[5] - bounds[4]
+            }) / 2.0;
+            source->SetCenter(center);
+            source->SetRadius(std::max(radius, 1.0));
+        }
+
+        source->Update();
+        return source;
+    }
+};
+
+// =============================================================================
+// Lifecycle
+// =============================================================================
+
+FlowVisualizer::FlowVisualizer()
+    : impl_(std::make_unique<Impl>()) {}
+
+FlowVisualizer::~FlowVisualizer() = default;
+
+FlowVisualizer::FlowVisualizer(FlowVisualizer&&) noexcept = default;
+FlowVisualizer& FlowVisualizer::operator=(FlowVisualizer&&) noexcept = default;
+
+// =============================================================================
+// Data setup
+// =============================================================================
+
+std::expected<void, FlowError>
+FlowVisualizer::setVelocityField(const VelocityPhase& phase) {
+    auto vtkData = velocityFieldToVTK(phase);
+    if (!vtkData) {
+        return std::unexpected(vtkData.error());
+    }
+
+    impl_->velocityData = vtkData.value();
+    impl_->hasField = true;
+
+    // Auto-set seed region to image bounds if not configured
+    bool boundsEmpty = (impl_->seed.bounds == std::array<double, 6>{0, 0, 0, 0, 0, 0});
+    if (boundsEmpty) {
+        double bounds[6];
+        impl_->velocityData->GetBounds(bounds);
+        for (int i = 0; i < 6; ++i) {
+            impl_->seed.bounds[i] = bounds[i];
+        }
+    }
+
+    getLogger()->debug("Velocity field set for phase {}", phase.phaseIndex);
+    return {};
+}
+
+void FlowVisualizer::setSeedRegion(const SeedRegion& region) {
+    impl_->seed = region;
+}
+
+// =============================================================================
+// Streamline generation
+// =============================================================================
+
+std::expected<vtkSmartPointer<vtkPolyData>, FlowError>
+FlowVisualizer::generateStreamlines(const StreamlineParams& params) const {
+    if (!impl_->hasField || !impl_->velocityData) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "No velocity field set for streamline generation"});
+    }
+
+    // Create seed points
+    auto seedSource = impl_->createSeedSource(params.maxSeedPoints);
+
+    // Configure stream tracer with RK45 integrator
+    auto tracer = vtkSmartPointer<vtkStreamTracer>::New();
+    tracer->SetInputData(impl_->velocityData);
+    tracer->SetSourceConnection(seedSource->GetOutputPort());
+
+    auto integrator = vtkSmartPointer<vtkRungeKutta45>::New();
+    tracer->SetIntegrator(integrator);
+
+    tracer->SetMaximumPropagation(params.maxSteps * params.stepLength);
+    tracer->SetInitialIntegrationStep(params.stepLength);
+    tracer->SetIntegrationDirectionToBoth();
+    tracer->SetTerminalSpeed(params.terminalSpeed);
+    tracer->SetMaximumNumberOfSteps(params.maxSteps);
+    tracer->Update();
+
+    // Apply tube filter for 3D appearance
+    auto tubeFilter = vtkSmartPointer<vtkTubeFilter>::New();
+    tubeFilter->SetInputConnection(tracer->GetOutputPort());
+    tubeFilter->SetRadius(params.tubeRadius);
+    tubeFilter->SetNumberOfSides(params.tubeSides);
+    tubeFilter->CappingOn();
+    tubeFilter->Update();
+
+    auto output = vtkSmartPointer<vtkPolyData>::New();
+    output->DeepCopy(tubeFilter->GetOutput());
+
+    getLogger()->info("Streamlines: {} cells, {} points",
+                      output->GetNumberOfCells(),
+                      output->GetNumberOfPoints());
+    return output;
+}
+
+// =============================================================================
+// Pathline generation (manual Euler integration across phases)
+// =============================================================================
+
+std::expected<vtkSmartPointer<vtkPolyData>, FlowError>
+FlowVisualizer::generatePathlines(const std::vector<VelocityPhase>& allPhases,
+                                  const PathlineParams& params) const {
+    if (allPhases.empty()) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "No phases provided for pathline generation"});
+    }
+
+    // Convert all phases to VTK
+    std::vector<vtkSmartPointer<vtkImageData>> phaseData;
+    phaseData.reserve(allPhases.size());
+    for (const auto& phase : allPhases) {
+        auto vtkResult = velocityFieldToVTK(phase);
+        if (!vtkResult) {
+            return std::unexpected(vtkResult.error());
+        }
+        phaseData.push_back(vtkResult.value());
+    }
+
+    // Create seed points
+    auto seedSource = impl_->createSeedSource(params.maxSeedPoints);
+    auto seedPoints = seedSource->GetOutput()->GetPoints();
+    if (!seedPoints || seedPoints->GetNumberOfPoints() == 0) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InternalError,
+            "Failed to generate seed points"});
+    }
+
+    auto output = vtkSmartPointer<vtkPolyData>::New();
+    auto points = vtkSmartPointer<vtkPoints>::New();
+    auto lines = vtkSmartPointer<vtkCellArray>::New();
+
+    auto timeScalars = vtkSmartPointer<vtkFloatArray>::New();
+    timeScalars->SetName("TriggerTime");
+
+    auto magnitudeScalars = vtkSmartPointer<vtkFloatArray>::New();
+    magnitudeScalars->SetName("VelocityMagnitude");
+
+    int numSeeds = static_cast<int>(seedPoints->GetNumberOfPoints());
+    for (int s = 0; s < numSeeds; ++s) {
+        double pos[3];
+        seedPoints->GetPoint(s, pos);
+
+        auto polyLine = vtkSmartPointer<vtkPolyLine>::New();
+        bool active = true;
+
+        for (size_t p = 0; p < phaseData.size() && active; ++p) {
+            auto* imageData = phaseData[p].Get();
+            int dims[3];
+            imageData->GetDimensions(dims);
+
+            // Check if position is within image bounds
+            int ijk[3];
+            double pcoords[3];
+            int inBounds = imageData->ComputeStructuredCoordinates(pos, ijk, pcoords);
+            if (!inBounds) {
+                break;
+            }
+
+            auto* vectors = imageData->GetPointData()->GetVectors();
+            if (!vectors) break;
+
+            vtkIdType ptId = ijk[0] + dims[0] * (ijk[1] + dims[1] * ijk[2]);
+            double vel[3];
+            vectors->GetTuple(ptId, vel);
+
+            double mag = std::sqrt(vel[0] * vel[0] + vel[1] * vel[1] + vel[2] * vel[2]);
+            if (mag < params.terminalSpeed) {
+                break;
+            }
+
+            // Record current position
+            vtkIdType pid = points->InsertNextPoint(pos);
+            polyLine->GetPointIds()->InsertNextId(pid);
+            timeScalars->InsertNextValue(
+                static_cast<float>(allPhases[p].triggerTime));
+            magnitudeScalars->InsertNextValue(static_cast<float>(mag));
+
+            // Advance position with Euler integration
+            // Scale velocity by spacing to convert cm/s to mm displacement
+            double spacing[3];
+            imageData->GetSpacing(spacing);
+            pos[0] += vel[0] * spacing[0];
+            pos[1] += vel[1] * spacing[1];
+            pos[2] += vel[2] * spacing[2];
+        }
+
+        if (polyLine->GetPointIds()->GetNumberOfIds() >= 2) {
+            lines->InsertNextCell(polyLine);
+        }
+    }
+
+    output->SetPoints(points);
+    output->SetLines(lines);
+    output->GetPointData()->AddArray(timeScalars);
+    output->GetPointData()->AddArray(magnitudeScalars);
+
+    getLogger()->info("Pathlines: {} lines, {} points from {} seeds",
+                      output->GetNumberOfCells(),
+                      output->GetNumberOfPoints(), numSeeds);
+    return output;
+}
+
+// =============================================================================
+// Vector glyph generation
+// =============================================================================
+
+std::expected<vtkSmartPointer<vtkPolyData>, FlowError>
+FlowVisualizer::generateGlyphs(const GlyphParams& params) const {
+    if (!impl_->hasField || !impl_->velocityData) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "No velocity field set for glyph generation"});
+    }
+
+    auto* imageData = impl_->velocityData.Get();
+    int dims[3];
+    imageData->GetDimensions(dims);
+
+    auto* vectors = imageData->GetPointData()->GetVectors();
+    if (!vectors) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InternalError,
+            "Velocity data has no vector field"});
+    }
+
+    // Subsample the velocity field
+    auto sampledPoints = vtkSmartPointer<vtkPoints>::New();
+    auto sampledVectors = vtkSmartPointer<vtkFloatArray>::New();
+    sampledVectors->SetNumberOfComponents(3);
+    sampledVectors->SetName("velocity");
+
+    auto magnitudes = vtkSmartPointer<vtkFloatArray>::New();
+    magnitudes->SetName("VelocityMagnitude");
+
+    int skip = std::max(1, params.skipFactor);
+    for (int z = 0; z < dims[2]; z += skip) {
+        for (int y = 0; y < dims[1]; y += skip) {
+            for (int x = 0; x < dims[0]; x += skip) {
+                vtkIdType ptId = x + dims[0] * (y + dims[1] * z);
+
+                double vel[3];
+                vectors->GetTuple(ptId, vel);
+
+                double mag = std::sqrt(vel[0] * vel[0] + vel[1] * vel[1] + vel[2] * vel[2]);
+                if (mag < params.minMagnitude) continue;
+
+                double pt[3];
+                imageData->GetPoint(ptId, pt);
+
+                sampledPoints->InsertNextPoint(pt);
+                sampledVectors->InsertNextTuple(vel);
+                magnitudes->InsertNextValue(static_cast<float>(mag));
+            }
+        }
+    }
+
+    auto sampledPolyData = vtkSmartPointer<vtkPolyData>::New();
+    sampledPolyData->SetPoints(sampledPoints);
+    sampledPolyData->GetPointData()->SetVectors(sampledVectors);
+    sampledPolyData->GetPointData()->SetScalars(magnitudes);
+
+    // Create arrow glyph source
+    auto arrowSource = vtkSmartPointer<vtkArrowSource>::New();
+    arrowSource->SetTipResolution(8);
+    arrowSource->SetShaftResolution(8);
+
+    // Apply glyph filter
+    auto glyphFilter = vtkSmartPointer<vtkGlyph3D>::New();
+    glyphFilter->SetInputData(sampledPolyData);
+    glyphFilter->SetSourceConnection(arrowSource->GetOutputPort());
+    glyphFilter->SetScaleFactor(params.scaleFactor);
+    glyphFilter->OrientOn();
+    glyphFilter->SetVectorModeToUseVector();
+    glyphFilter->SetScaleModeToScaleByVector();
+    glyphFilter->Update();
+
+    auto output = vtkSmartPointer<vtkPolyData>::New();
+    output->DeepCopy(glyphFilter->GetOutput());
+
+    getLogger()->info("Glyphs: {} cells from {} sampled points",
+                      output->GetNumberOfCells(),
+                      sampledPoints->GetNumberOfPoints());
+    return output;
+}
+
+// =============================================================================
+// Color mapping
+// =============================================================================
+
+void FlowVisualizer::setColorMode(ColorMode mode) {
+    impl_->colorMode_ = mode;
+}
+
+void FlowVisualizer::setVelocityRange(double minVel, double maxVel) {
+    impl_->velocityMin = minVel;
+    impl_->velocityMax = maxVel;
+}
+
+vtkSmartPointer<vtkLookupTable>
+FlowVisualizer::createLookupTable() const {
+    auto lut = vtkSmartPointer<vtkLookupTable>::New();
+    lut->SetNumberOfTableValues(256);
+
+    switch (impl_->colorMode_) {
+        case ColorMode::VelocityMagnitude:
+            // Rainbow: blue (low) → red (high)
+            lut->SetRange(impl_->velocityMin, impl_->velocityMax);
+            lut->SetHueRange(0.667, 0.0);
+            lut->SetSaturationRange(1.0, 1.0);
+            lut->SetValueRange(1.0, 1.0);
+            break;
+
+        case ColorMode::VelocityComponent:
+            // Diverging: blue → white → red
+            lut->SetRange(-impl_->velocityMax, impl_->velocityMax);
+            for (int i = 0; i < 256; ++i) {
+                double t = i / 255.0;
+                double r, g, b;
+                if (t < 0.5) {
+                    double s = t * 2.0;
+                    r = s; g = s; b = 1.0;
+                } else {
+                    double s = (t - 0.5) * 2.0;
+                    r = 1.0; g = 1.0 - s; b = 1.0 - s;
+                }
+                lut->SetTableValue(i, r, g, b, 1.0);
+            }
+            break;
+
+        case ColorMode::FlowDirection:
+            // RGB direction encoding
+            lut->SetRange(0.0, 1.0);
+            for (int i = 0; i < 256; ++i) {
+                double t = i / 255.0;
+                lut->SetTableValue(i, t, 1.0 - t, 0.5, 1.0);
+            }
+            break;
+
+        case ColorMode::TriggerTime:
+            // Viridis-like sequential: dark purple → yellow
+            lut->SetRange(0.0, 1000.0);
+            for (int i = 0; i < 256; ++i) {
+                double t = i / 255.0;
+                double r = 0.267 + t * (0.993 - 0.267);
+                double g = 0.004 + t * (0.906 - 0.004);
+                double b = 0.329 + t * (0.143 - 0.329);
+                lut->SetTableValue(i, r, g, b, 1.0);
+            }
+            break;
+    }
+
+    lut->Build();
+    return lut;
+}
+
+// =============================================================================
+// State queries
+// =============================================================================
+
+bool FlowVisualizer::hasVelocityField() const {
+    return impl_->hasField;
+}
+
+ColorMode FlowVisualizer::colorMode() const {
+    return impl_->colorMode_;
+}
+
+SeedRegion FlowVisualizer::seedRegion() const {
+    return impl_->seed;
+}
+
+// =============================================================================
+// ITK VectorImage → VTK ImageData conversion
+// =============================================================================
+
+std::expected<vtkSmartPointer<vtkImageData>, FlowError>
+FlowVisualizer::velocityFieldToVTK(const VelocityPhase& phase) {
+    if (!phase.velocityField) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "VelocityPhase has null velocity field"});
+    }
+
+    auto itkImage = phase.velocityField;
+    auto region = itkImage->GetLargestPossibleRegion();
+    auto size = region.GetSize();
+    auto spacing = itkImage->GetSpacing();
+    auto origin = itkImage->GetOrigin();
+
+    if (itkImage->GetNumberOfComponentsPerPixel() != 3) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "Expected 3-component vector image, got " +
+                std::to_string(itkImage->GetNumberOfComponentsPerPixel())});
+    }
+
+    auto vtkImage = vtkSmartPointer<vtkImageData>::New();
+    vtkImage->SetDimensions(
+        static_cast<int>(size[0]),
+        static_cast<int>(size[1]),
+        static_cast<int>(size[2]));
+    vtkImage->SetSpacing(spacing[0], spacing[1], spacing[2]);
+    vtkImage->SetOrigin(origin[0], origin[1], origin[2]);
+
+    vtkIdType numPoints = static_cast<vtkIdType>(size[0] * size[1] * size[2]);
+
+    // Copy velocity vectors: ITK VectorImage buffer is interleaved [Vx,Vy,Vz,...]
+    auto velocityArray = vtkSmartPointer<vtkFloatArray>::New();
+    velocityArray->SetNumberOfComponents(3);
+    velocityArray->SetName("velocity");
+    velocityArray->SetNumberOfTuples(numPoints);
+
+    auto* itkBuffer = itkImage->GetBufferPointer();
+    for (vtkIdType i = 0; i < numPoints; ++i) {
+        velocityArray->SetTuple3(i,
+            itkBuffer[i * 3],
+            itkBuffer[i * 3 + 1],
+            itkBuffer[i * 3 + 2]);
+    }
+    vtkImage->GetPointData()->SetVectors(velocityArray);
+
+    // Add velocity magnitude as scalar data
+    auto magnitudeArray = vtkSmartPointer<vtkFloatArray>::New();
+    magnitudeArray->SetName("VelocityMagnitude");
+    magnitudeArray->SetNumberOfTuples(numPoints);
+
+    for (vtkIdType i = 0; i < numPoints; ++i) {
+        float vx = itkBuffer[i * 3];
+        float vy = itkBuffer[i * 3 + 1];
+        float vz = itkBuffer[i * 3 + 2];
+        magnitudeArray->SetValue(i, std::sqrt(vx * vx + vy * vy + vz * vz));
+    }
+    vtkImage->GetPointData()->SetScalars(magnitudeArray);
+
+    return vtkImage;
+}
+
+}  // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -832,3 +832,21 @@ target_include_directories(temporal_navigator_test PRIVATE
 )
 
 gtest_discover_tests(temporal_navigator_test DISCOVERY_TIMEOUT 60)
+
+# Flow visualizer tests
+add_executable(flow_visualizer_test
+    unit/flow_visualizer_test.cpp
+)
+
+target_link_libraries(flow_visualizer_test PRIVATE
+    flow_service
+    ${VTK_LIBRARIES}
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(flow_visualizer_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(flow_visualizer_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/flow_visualizer_test.cpp
+++ b/tests/unit/flow_visualizer_test.cpp
@@ -1,0 +1,512 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+#include <itkVectorImage.h>
+#include <vtkImageData.h>
+#include <vtkLookupTable.h>
+#include <vtkPointData.h>
+#include <vtkPolyData.h>
+
+#include "services/flow/flow_visualizer.hpp"
+
+using namespace dicom_viewer::services;
+
+namespace {
+
+/// Create a synthetic 3-component velocity field with uniform flow
+VelocityPhase createUniformFlowPhase(int dimX, int dimY, int dimZ,
+                                     float vx, float vy, float vz,
+                                     int phaseIndex = 0) {
+    auto image = VectorImage3D::New();
+    VectorImage3D::SizeType size = {{
+        static_cast<VectorImage3D::SizeValueType>(dimX),
+        static_cast<VectorImage3D::SizeValueType>(dimY),
+        static_cast<VectorImage3D::SizeValueType>(dimZ)
+    }};
+    VectorImage3D::IndexType start = {{0, 0, 0}};
+    VectorImage3D::RegionType region(start, size);
+    image->SetRegions(region);
+    image->SetNumberOfComponentsPerPixel(3);
+
+    VectorImage3D::SpacingType spacing;
+    spacing[0] = 1.0; spacing[1] = 1.0; spacing[2] = 1.0;
+    image->SetSpacing(spacing);
+
+    VectorImage3D::PointType origin;
+    origin[0] = 0.0; origin[1] = 0.0; origin[2] = 0.0;
+    image->SetOrigin(origin);
+
+    image->Allocate();
+
+    // Fill with uniform velocity
+    auto* buffer = image->GetBufferPointer();
+    int numPixels = dimX * dimY * dimZ;
+    for (int i = 0; i < numPixels; ++i) {
+        buffer[i * 3]     = vx;
+        buffer[i * 3 + 1] = vy;
+        buffer[i * 3 + 2] = vz;
+    }
+
+    VelocityPhase phase;
+    phase.velocityField = image;
+    phase.phaseIndex = phaseIndex;
+    phase.triggerTime = phaseIndex * 40.0;
+    return phase;
+}
+
+/// Create a phase with parabolic pipe flow (for testing non-uniform fields)
+VelocityPhase createParabolicFlowPhase(int dim, float maxVelocity,
+                                        int phaseIndex = 0) {
+    auto image = VectorImage3D::New();
+    VectorImage3D::SizeType size = {{
+        static_cast<VectorImage3D::SizeValueType>(dim),
+        static_cast<VectorImage3D::SizeValueType>(dim),
+        static_cast<VectorImage3D::SizeValueType>(dim)
+    }};
+    VectorImage3D::IndexType start = {{0, 0, 0}};
+    VectorImage3D::RegionType region(start, size);
+    image->SetRegions(region);
+    image->SetNumberOfComponentsPerPixel(3);
+    VectorImage3D::SpacingType pSpacing;
+    pSpacing[0] = 1.0; pSpacing[1] = 1.0; pSpacing[2] = 1.0;
+    image->SetSpacing(pSpacing);
+    VectorImage3D::PointType pOrigin;
+    pOrigin[0] = 0.0; pOrigin[1] = 0.0; pOrigin[2] = 0.0;
+    image->SetOrigin(pOrigin);
+    image->Allocate();
+
+    auto* buffer = image->GetBufferPointer();
+    double center = (dim - 1) / 2.0;
+    double radius = center;
+
+    for (int z = 0; z < dim; ++z) {
+        for (int y = 0; y < dim; ++y) {
+            for (int x = 0; x < dim; ++x) {
+                int idx = x + dim * (y + dim * z);
+                // Parabolic profile: flow along Z, max at center
+                double dy = y - center;
+                double dx = x - center;
+                double r = std::sqrt(dx * dx + dy * dy);
+                double frac = std::max(0.0, 1.0 - (r * r) / (radius * radius));
+                buffer[idx * 3]     = 0.0f;
+                buffer[idx * 3 + 1] = 0.0f;
+                buffer[idx * 3 + 2] = static_cast<float>(maxVelocity * frac);
+            }
+        }
+    }
+
+    VelocityPhase phase;
+    phase.velocityField = image;
+    phase.phaseIndex = phaseIndex;
+    phase.triggerTime = phaseIndex * 40.0;
+    return phase;
+}
+
+}  // anonymous namespace
+
+// =============================================================================
+// Struct default tests
+// =============================================================================
+
+TEST(StreamlineParamsTest, Defaults) {
+    StreamlineParams params;
+    EXPECT_EQ(params.maxSeedPoints, 5000);
+    EXPECT_DOUBLE_EQ(params.stepLength, 0.5);
+    EXPECT_EQ(params.maxSteps, 2000);
+    EXPECT_DOUBLE_EQ(params.terminalSpeed, 0.1);
+    EXPECT_DOUBLE_EQ(params.tubeRadius, 0.5);
+    EXPECT_EQ(params.tubeSides, 8);
+}
+
+TEST(GlyphParamsTest, Defaults) {
+    GlyphParams params;
+    EXPECT_DOUBLE_EQ(params.scaleFactor, 1.0);
+    EXPECT_EQ(params.skipFactor, 4);
+    EXPECT_DOUBLE_EQ(params.minMagnitude, 1.0);
+}
+
+TEST(PathlineParamsTest, Defaults) {
+    PathlineParams params;
+    EXPECT_EQ(params.maxSeedPoints, 1000);
+    EXPECT_EQ(params.maxSteps, 2000);
+    EXPECT_DOUBLE_EQ(params.terminalSpeed, 0.1);
+    EXPECT_DOUBLE_EQ(params.tubeRadius, 0.5);
+    EXPECT_EQ(params.tubeSides, 8);
+}
+
+TEST(SeedRegionTest, Defaults) {
+    SeedRegion region;
+    EXPECT_EQ(region.type, SeedRegion::Type::Volume);
+    EXPECT_EQ(region.numSeedPoints, 5000);
+    EXPECT_DOUBLE_EQ(region.planeRadius, 50.0);
+}
+
+// =============================================================================
+// FlowVisualizer construction tests
+// =============================================================================
+
+TEST(FlowVisualizerTest, DefaultConstruction) {
+    FlowVisualizer viz;
+    EXPECT_FALSE(viz.hasVelocityField());
+    EXPECT_EQ(viz.colorMode(), ColorMode::VelocityMagnitude);
+}
+
+TEST(FlowVisualizerTest, MoveConstruction) {
+    FlowVisualizer viz;
+    FlowVisualizer moved(std::move(viz));
+    EXPECT_FALSE(moved.hasVelocityField());
+}
+
+TEST(FlowVisualizerTest, MoveAssignment) {
+    FlowVisualizer viz;
+    FlowVisualizer other;
+    other = std::move(viz);
+}
+
+// =============================================================================
+// ITK → VTK conversion tests
+// =============================================================================
+
+TEST(FlowVisualizerTest, VelocityFieldToVTK_NullField) {
+    VelocityPhase phase;  // null velocityField
+    auto result = FlowVisualizer::velocityFieldToVTK(phase);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, FlowError::Code::InvalidInput);
+}
+
+TEST(FlowVisualizerTest, VelocityFieldToVTK_UniformFlow) {
+    auto phase = createUniformFlowPhase(8, 8, 8, 10.0f, 5.0f, 3.0f);
+    auto result = FlowVisualizer::velocityFieldToVTK(phase);
+    ASSERT_TRUE(result.has_value());
+
+    auto vtkImage = result.value();
+    int dims[3];
+    vtkImage->GetDimensions(dims);
+    EXPECT_EQ(dims[0], 8);
+    EXPECT_EQ(dims[1], 8);
+    EXPECT_EQ(dims[2], 8);
+
+    // Check vector data is present
+    auto* vectors = vtkImage->GetPointData()->GetVectors();
+    ASSERT_NE(vectors, nullptr);
+    EXPECT_EQ(vectors->GetNumberOfComponents(), 3);
+    EXPECT_EQ(vectors->GetNumberOfTuples(), 8 * 8 * 8);
+
+    // Check first vector value
+    double vel[3];
+    vectors->GetTuple(0, vel);
+    EXPECT_FLOAT_EQ(static_cast<float>(vel[0]), 10.0f);
+    EXPECT_FLOAT_EQ(static_cast<float>(vel[1]), 5.0f);
+    EXPECT_FLOAT_EQ(static_cast<float>(vel[2]), 3.0f);
+
+    // Check magnitude scalar
+    auto* scalars = vtkImage->GetPointData()->GetScalars();
+    ASSERT_NE(scalars, nullptr);
+    double expectedMag = std::sqrt(10.0 * 10.0 + 5.0 * 5.0 + 3.0 * 3.0);
+    EXPECT_NEAR(scalars->GetTuple1(0), expectedMag, 0.01);
+}
+
+TEST(FlowVisualizerTest, VelocityFieldToVTK_SpacingAndOrigin) {
+    auto image = VectorImage3D::New();
+    VectorImage3D::SizeType size = {{4, 4, 4}};
+    VectorImage3D::IndexType start = {{0, 0, 0}};
+    image->SetRegions(VectorImage3D::RegionType(start, size));
+    image->SetNumberOfComponentsPerPixel(3);
+    VectorImage3D::SpacingType spacing;
+    spacing[0] = 2.0; spacing[1] = 3.0; spacing[2] = 1.5;
+    image->SetSpacing(spacing);
+    VectorImage3D::PointType origin;
+    origin[0] = 10.0; origin[1] = 20.0; origin[2] = 30.0;
+    image->SetOrigin(origin);
+    image->Allocate(true);
+
+    VelocityPhase phase;
+    phase.velocityField = image;
+    auto result = FlowVisualizer::velocityFieldToVTK(phase);
+    ASSERT_TRUE(result.has_value());
+
+    auto vtkImage = result.value();
+    double* vtkSpacing = vtkImage->GetSpacing();
+    double* vtkOrigin = vtkImage->GetOrigin();
+
+    EXPECT_DOUBLE_EQ(vtkSpacing[0], 2.0);
+    EXPECT_DOUBLE_EQ(vtkSpacing[1], 3.0);
+    EXPECT_DOUBLE_EQ(vtkSpacing[2], 1.5);
+    EXPECT_DOUBLE_EQ(vtkOrigin[0], 10.0);
+    EXPECT_DOUBLE_EQ(vtkOrigin[1], 20.0);
+    EXPECT_DOUBLE_EQ(vtkOrigin[2], 30.0);
+}
+
+TEST(FlowVisualizerTest, VelocityFieldToVTK_WrongComponents) {
+    auto image = VectorImage3D::New();
+    VectorImage3D::SizeType size = {{4, 4, 4}};
+    VectorImage3D::IndexType start = {{0, 0, 0}};
+    image->SetRegions(VectorImage3D::RegionType(start, size));
+    image->SetNumberOfComponentsPerPixel(2);  // Wrong: should be 3
+    image->Allocate();
+
+    VelocityPhase phase;
+    phase.velocityField = image;
+    auto result = FlowVisualizer::velocityFieldToVTK(phase);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, FlowError::Code::InvalidInput);
+}
+
+// =============================================================================
+// SetVelocityField tests
+// =============================================================================
+
+TEST(FlowVisualizerTest, SetVelocityField_Success) {
+    FlowVisualizer viz;
+    auto phase = createUniformFlowPhase(8, 8, 8, 1.0f, 0.0f, 0.0f);
+    auto result = viz.setVelocityField(phase);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(viz.hasVelocityField());
+}
+
+TEST(FlowVisualizerTest, SetVelocityField_NullField) {
+    FlowVisualizer viz;
+    VelocityPhase phase;
+    auto result = viz.setVelocityField(phase);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_FALSE(viz.hasVelocityField());
+}
+
+TEST(FlowVisualizerTest, SetVelocityField_AutoSetsBounds) {
+    FlowVisualizer viz;
+    auto phase = createUniformFlowPhase(10, 10, 10, 1.0f, 0.0f, 0.0f);
+    viz.setVelocityField(phase);
+
+    auto seed = viz.seedRegion();
+    // Bounds should be auto-set to image bounds (0-9 with spacing 1.0)
+    EXPECT_GE(seed.bounds[1], 0.0);  // xmax > 0
+}
+
+// =============================================================================
+// Seed region tests
+// =============================================================================
+
+TEST(FlowVisualizerTest, SetSeedRegion) {
+    FlowVisualizer viz;
+    SeedRegion region;
+    region.type = SeedRegion::Type::Plane;
+    region.planeOrigin = {5.0, 5.0, 5.0};
+    region.planeNormal = {1.0, 0.0, 0.0};
+    region.planeRadius = 25.0;
+    region.numSeedPoints = 1000;
+
+    viz.setSeedRegion(region);
+
+    auto retrieved = viz.seedRegion();
+    EXPECT_EQ(retrieved.type, SeedRegion::Type::Plane);
+    EXPECT_DOUBLE_EQ(retrieved.planeRadius, 25.0);
+    EXPECT_EQ(retrieved.numSeedPoints, 1000);
+}
+
+// =============================================================================
+// Streamline generation tests
+// =============================================================================
+
+TEST(FlowVisualizerTest, GenerateStreamlines_NoField) {
+    FlowVisualizer viz;
+    auto result = viz.generateStreamlines();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, FlowError::Code::InvalidInput);
+}
+
+TEST(FlowVisualizerTest, GenerateStreamlines_UniformFlow) {
+    FlowVisualizer viz;
+    auto phase = createUniformFlowPhase(10, 10, 10, 5.0f, 0.0f, 0.0f);
+    viz.setVelocityField(phase);
+
+    StreamlineParams params;
+    params.maxSeedPoints = 50;  // Small for test performance
+    params.maxSteps = 100;
+    params.stepLength = 0.5;
+
+    auto result = viz.generateStreamlines(params);
+    ASSERT_TRUE(result.has_value());
+
+    auto polyData = result.value();
+    EXPECT_GT(polyData->GetNumberOfPoints(), 0);
+}
+
+TEST(FlowVisualizerTest, GenerateStreamlines_ParabolicFlow) {
+    FlowVisualizer viz;
+    auto phase = createParabolicFlowPhase(10, 50.0f);
+    viz.setVelocityField(phase);
+
+    StreamlineParams params;
+    params.maxSeedPoints = 20;
+    params.maxSteps = 50;
+
+    auto result = viz.generateStreamlines(params);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_GE(result.value()->GetNumberOfPoints(), 0);
+}
+
+// =============================================================================
+// Glyph generation tests
+// =============================================================================
+
+TEST(FlowVisualizerTest, GenerateGlyphs_NoField) {
+    FlowVisualizer viz;
+    auto result = viz.generateGlyphs();
+    ASSERT_FALSE(result.has_value());
+}
+
+TEST(FlowVisualizerTest, GenerateGlyphs_UniformFlow) {
+    FlowVisualizer viz;
+    auto phase = createUniformFlowPhase(8, 8, 8, 10.0f, 0.0f, 0.0f);
+    viz.setVelocityField(phase);
+
+    GlyphParams params;
+    params.skipFactor = 2;
+    params.minMagnitude = 0.5;
+    params.scaleFactor = 0.5;
+
+    auto result = viz.generateGlyphs(params);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_GT(result.value()->GetNumberOfCells(), 0);
+}
+
+TEST(FlowVisualizerTest, GenerateGlyphs_HighMinMagnitude) {
+    FlowVisualizer viz;
+    // Uniform flow with magnitude = sqrt(1+1+1) ≈ 1.73 cm/s
+    auto phase = createUniformFlowPhase(8, 8, 8, 1.0f, 1.0f, 1.0f);
+    viz.setVelocityField(phase);
+
+    GlyphParams params;
+    params.minMagnitude = 100.0;  // Higher than actual magnitude
+
+    auto result = viz.generateGlyphs(params);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value()->GetNumberOfCells(), 0);  // All filtered out
+}
+
+// =============================================================================
+// Pathline generation tests
+// =============================================================================
+
+TEST(FlowVisualizerTest, GeneratePathlines_NoPhases) {
+    FlowVisualizer viz;
+    std::vector<VelocityPhase> empty;
+    auto result = viz.generatePathlines(empty);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, FlowError::Code::InvalidInput);
+}
+
+TEST(FlowVisualizerTest, GeneratePathlines_MultiPhase) {
+    FlowVisualizer viz;
+    auto phase0 = createUniformFlowPhase(8, 8, 8, 1.0f, 0.0f, 0.0f, 0);
+    viz.setVelocityField(phase0);
+
+    std::vector<VelocityPhase> phases;
+    for (int i = 0; i < 5; ++i) {
+        phases.push_back(
+            createUniformFlowPhase(8, 8, 8, 1.0f, 0.0f, 0.0f, i));
+    }
+
+    PathlineParams params;
+    params.maxSeedPoints = 20;
+
+    auto result = viz.generatePathlines(phases, params);
+    ASSERT_TRUE(result.has_value());
+
+    auto polyData = result.value();
+    // Should have TriggerTime and VelocityMagnitude arrays
+    EXPECT_NE(polyData->GetPointData()->GetArray("TriggerTime"), nullptr);
+    EXPECT_NE(polyData->GetPointData()->GetArray("VelocityMagnitude"), nullptr);
+}
+
+TEST(FlowVisualizerTest, GeneratePathlines_NullPhaseInSequence) {
+    FlowVisualizer viz;
+    auto phase0 = createUniformFlowPhase(8, 8, 8, 1.0f, 0.0f, 0.0f, 0);
+    viz.setVelocityField(phase0);
+
+    std::vector<VelocityPhase> phases;
+    phases.push_back(createUniformFlowPhase(8, 8, 8, 1.0f, 0.0f, 0.0f, 0));
+    phases.push_back(VelocityPhase{});  // Null field
+
+    auto result = viz.generatePathlines(phases);
+    ASSERT_FALSE(result.has_value());  // Should fail on null phase
+}
+
+// =============================================================================
+// Color mapping tests
+// =============================================================================
+
+TEST(FlowVisualizerTest, ColorMode_Default) {
+    FlowVisualizer viz;
+    EXPECT_EQ(viz.colorMode(), ColorMode::VelocityMagnitude);
+}
+
+TEST(FlowVisualizerTest, SetColorMode) {
+    FlowVisualizer viz;
+    viz.setColorMode(ColorMode::VelocityComponent);
+    EXPECT_EQ(viz.colorMode(), ColorMode::VelocityComponent);
+
+    viz.setColorMode(ColorMode::FlowDirection);
+    EXPECT_EQ(viz.colorMode(), ColorMode::FlowDirection);
+
+    viz.setColorMode(ColorMode::TriggerTime);
+    EXPECT_EQ(viz.colorMode(), ColorMode::TriggerTime);
+}
+
+TEST(FlowVisualizerTest, CreateLookupTable_VelocityMagnitude) {
+    FlowVisualizer viz;
+    viz.setColorMode(ColorMode::VelocityMagnitude);
+    viz.setVelocityRange(0.0, 150.0);
+
+    auto lut = viz.createLookupTable();
+    ASSERT_NE(lut, nullptr);
+    EXPECT_EQ(lut->GetNumberOfTableValues(), 256);
+
+    double* range = lut->GetRange();
+    EXPECT_DOUBLE_EQ(range[0], 0.0);
+    EXPECT_DOUBLE_EQ(range[1], 150.0);
+}
+
+TEST(FlowVisualizerTest, CreateLookupTable_VelocityComponent) {
+    FlowVisualizer viz;
+    viz.setColorMode(ColorMode::VelocityComponent);
+    viz.setVelocityRange(0.0, 100.0);
+
+    auto lut = viz.createLookupTable();
+    ASSERT_NE(lut, nullptr);
+
+    double* range = lut->GetRange();
+    // Diverging: [-max, +max]
+    EXPECT_DOUBLE_EQ(range[0], -100.0);
+    EXPECT_DOUBLE_EQ(range[1], 100.0);
+
+    // Check middle value is white-ish (blue→white→red)
+    double rgba[4];
+    lut->GetTableValue(128, rgba);
+    EXPECT_GT(rgba[0], 0.9);  // Near white
+    EXPECT_GT(rgba[1], 0.9);
+    EXPECT_GT(rgba[2], 0.9);
+}
+
+TEST(FlowVisualizerTest, CreateLookupTable_FlowDirection) {
+    FlowVisualizer viz;
+    viz.setColorMode(ColorMode::FlowDirection);
+
+    auto lut = viz.createLookupTable();
+    ASSERT_NE(lut, nullptr);
+    EXPECT_EQ(lut->GetNumberOfTableValues(), 256);
+}
+
+TEST(FlowVisualizerTest, CreateLookupTable_TriggerTime) {
+    FlowVisualizer viz;
+    viz.setColorMode(ColorMode::TriggerTime);
+
+    auto lut = viz.createLookupTable();
+    ASSERT_NE(lut, nullptr);
+
+    double* range = lut->GetRange();
+    EXPECT_DOUBLE_EQ(range[0], 0.0);
+    EXPECT_DOUBLE_EQ(range[1], 1000.0);
+}


### PR DESCRIPTION
## Summary
- Implement `FlowVisualizer` with three VTK-based visualization pipelines:
  - **Streamlines**: `vtkStreamTracer` + RK45 integrator + `vtkTubeFilter` for 3D tube rendering
  - **Pathlines**: Manual Euler integration across cardiac phases for time-resolved particle tracing
  - **Vector Glyphs**: `vtkGlyph3D` + `vtkArrowSource` with configurable subsampling and magnitude thresholds
- Implement ITK `VectorImage<float,3>` to VTK `vtkImageData` conversion with velocity vectors and magnitude scalars
- Add 4 color mapping modes with `vtkLookupTable`: VelocityMagnitude (rainbow), VelocityComponent (diverging blue-white-red), FlowDirection (RGB), TriggerTime (viridis-like)
- Add `FiltersFlowPaths` VTK component for `vtkStreamTracer` support
- Add explicit `${VTK_LIBRARIES}` link to flow_service target

## Key Design Decisions
- **Qt-free service layer**: FlowVisualizer produces `vtkPolyData` output without requiring a render window, enabling headless testing and UI-agnostic integration
- **Manual pathline integration**: Uses Euler stepping across phases instead of `vtkParticleTracer` for portability and version compatibility
- **Seed region abstraction**: `SeedRegion` struct supports Volume, Plane, and Points modes for flexible streamline/pathline origins
- **Static conversion**: `velocityFieldToVTK()` is static for direct use without FlowVisualizer instantiation

## Test Plan
- [x] 30 unit tests covering all components
- [x] Struct defaults (StreamlineParams, GlyphParams, PathlineParams, SeedRegion)
- [x] Construction, move semantics
- [x] ITK-to-VTK conversion: null field, uniform flow, spacing/origin preservation, wrong component count
- [x] Velocity field setup: success, null, auto-bounds
- [x] Streamline pipeline: no field error, uniform flow (920 cells/3864 points), parabolic flow
- [x] Glyph pipeline: no field error, uniform flow (1216 cells from 64 samples), magnitude filtering
- [x] Pathline pipeline: no phases error, multi-phase tracing (16 lines from 20 seeds), null phase handling
- [x] Color mapping: 4 modes with range verification, diverging midpoint check
- [x] All 123 existing flow tests still pass (38+23+27+35)

Closes #156