### PR TITLE
feat(flow): implement FlowQuantifier for flow rate and time-velocity curves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,6 +494,7 @@ add_library(flow_service STATIC
     src/services/flow/phase_corrector.cpp
     src/services/flow/temporal_navigator.cpp
     src/services/flow/flow_visualizer.cpp
+    src/services/flow/flow_quantifier.cpp
     src/services/flow/vendor_parsers/siemens_flow_parser.cpp
     src/services/flow/vendor_parsers/philips_flow_parser.cpp
     src/services/flow/vendor_parsers/ge_flow_parser.cpp

--- a/include/services/flow/flow_quantifier.hpp
+++ b/include/services/flow/flow_quantifier.hpp
@@ -1,0 +1,172 @@
+#pragma once
+
+#include <array>
+#include <expected>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "services/flow/flow_dicom_types.hpp"
+#include "services/flow/velocity_field_assembler.hpp"
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Flow measurement result at a single cardiac phase
+ *
+ * @trace SRS-FR-047
+ */
+struct FlowMeasurement {
+    int phaseIndex = 0;
+    double flowRate = 0.0;           ///< mL/s (= cm^3/s)
+    double meanVelocity = 0.0;       ///< cm/s (through-plane mean)
+    double maxVelocity = 0.0;        ///< cm/s (through-plane max)
+    double crossSectionArea = 0.0;   ///< cm^2 (sampled area)
+    int sampleCount = 0;             ///< Number of in-bounds samples
+};
+
+/**
+ * @brief Measurement plane definition for flow quantification
+ */
+struct MeasurementPlane {
+    std::array<double, 3> center = {0, 0, 0};     ///< Plane center in mm
+    std::array<double, 3> normal = {0, 0, 1};     ///< Plane normal (unit vector)
+    double radius = 50.0;                          ///< Sampling radius in mm
+    double sampleSpacing = 1.0;                    ///< Grid spacing in mm
+};
+
+/**
+ * @brief Time-velocity curve across all cardiac phases
+ *
+ * @trace SRS-FR-047
+ */
+struct TimeVelocityCurve {
+    std::vector<double> timePoints;       ///< ms from R-wave
+    std::vector<double> meanVelocities;   ///< cm/s per phase
+    std::vector<double> maxVelocities;    ///< cm/s per phase
+    std::vector<double> flowRates;        ///< mL/s per phase
+
+    double strokeVolume = 0.0;            ///< mL (integral of forward flow)
+    double regurgitantVolume = 0.0;       ///< mL (integral of backward flow)
+    double regurgitantFraction = 0.0;     ///< percentage (0-100)
+};
+
+/**
+ * @brief Quantitative hemodynamic measurement from 4D Flow velocity data
+ *
+ * Computes flow rate, stroke volume, time-velocity curves, and pressure
+ * gradients from velocity fields at user-defined measurement planes.
+ *
+ * Flow Rate Algorithm:
+ * @code
+ * 1. Create grid of sample points on measurement plane
+ * 2. For each sample point within vessel boundary:
+ *    V_through = dot(V(x,y,z), plane_normal)
+ * 3. FlowRate = sum(V_through) × pixel_area  [mL/s]
+ * @endcode
+ *
+ * This is a service-layer class without Qt or VTK dependency.
+ *
+ * @trace SRS-FR-047
+ */
+class FlowQuantifier {
+public:
+    FlowQuantifier();
+    ~FlowQuantifier();
+
+    // Non-copyable, movable
+    FlowQuantifier(const FlowQuantifier&) = delete;
+    FlowQuantifier& operator=(const FlowQuantifier&) = delete;
+    FlowQuantifier(FlowQuantifier&&) noexcept;
+    FlowQuantifier& operator=(FlowQuantifier&&) noexcept;
+
+    /**
+     * @brief Set the measurement plane for flow quantification
+     * @param plane Plane center, normal, radius, and sample spacing
+     */
+    void setMeasurementPlane(const MeasurementPlane& plane);
+
+    /**
+     * @brief Define measurement plane from three points
+     *
+     * Normal is computed as (p2-p1) × (p3-p1), center is centroid.
+     */
+    void setMeasurementPlaneFrom3Points(
+        const std::array<double, 3>& p1,
+        const std::array<double, 3>& p2,
+        const std::array<double, 3>& p3);
+
+    /**
+     * @brief Get current measurement plane
+     */
+    [[nodiscard]] MeasurementPlane measurementPlane() const;
+
+    // --- Core measurements ---
+
+    /**
+     * @brief Measure flow at a single cardiac phase
+     *
+     * Samples the velocity field at grid points on the measurement plane,
+     * computes through-plane velocity component, and integrates to get
+     * flow rate in mL/s.
+     *
+     * @param phase Velocity phase with 3-component vector field
+     * @return FlowMeasurement on success, FlowError on failure
+     */
+    [[nodiscard]] std::expected<FlowMeasurement, FlowError>
+    measureFlow(const VelocityPhase& phase) const;
+
+    /**
+     * @brief Compute time-velocity curve across all cardiac phases
+     *
+     * Calls measureFlow for each phase and computes stroke volume,
+     * regurgitant volume, and regurgitant fraction.
+     *
+     * @param phases All cardiac phases in temporal order
+     * @param temporalResolution Time between phases in ms
+     * @return TimeVelocityCurve on success, FlowError on failure
+     */
+    [[nodiscard]] std::expected<TimeVelocityCurve, FlowError>
+    computeTimeVelocityCurve(
+        const std::vector<VelocityPhase>& phases,
+        double temporalResolution) const;
+
+    /**
+     * @brief Estimate pressure gradient using simplified Bernoulli
+     *
+     * ΔP = 4 × V²_max (mmHg, when V in m/s)
+     *
+     * @param maxVelocityCmPerS Maximum velocity in cm/s
+     * @return Pressure gradient in mmHg
+     */
+    [[nodiscard]] static double estimatePressureGradient(
+        double maxVelocityCmPerS);
+
+    /**
+     * @brief Export time-velocity curve data to CSV file
+     * @param curve Time-velocity curve data
+     * @param filePath Output file path
+     */
+    [[nodiscard]] static std::expected<void, FlowError>
+    exportToCSV(const TimeVelocityCurve& curve,
+                const std::string& filePath);
+
+    // --- Utility ---
+
+    [[nodiscard]] static double dotProduct(
+        const std::array<double, 3>& a,
+        const std::array<double, 3>& b);
+
+    [[nodiscard]] static std::array<double, 3> normalize(
+        const std::array<double, 3>& v);
+
+    [[nodiscard]] static std::array<double, 3> crossProduct(
+        const std::array<double, 3>& a,
+        const std::array<double, 3>& b);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace dicom_viewer::services

--- a/src/services/flow/flow_quantifier.cpp
+++ b/src/services/flow/flow_quantifier.cpp
@@ -1,0 +1,338 @@
+#include "services/flow/flow_quantifier.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <numeric>
+
+#include "core/logging.hpp"
+
+namespace {
+
+auto& getLogger() {
+    static auto logger =
+        dicom_viewer::logging::LoggerFactory::create("FlowQuantifier");
+    return logger;
+}
+
+/// Generate orthogonal basis vectors for a plane given its normal
+void computePlaneBasis(const std::array<double, 3>& normal,
+                       std::array<double, 3>& u,
+                       std::array<double, 3>& v) {
+    using dicom_viewer::services::FlowQuantifier;
+
+    // Pick reference vector not parallel to normal
+    std::array<double, 3> ref = {1.0, 0.0, 0.0};
+    if (std::abs(FlowQuantifier::dotProduct(normal, ref)) > 0.9) {
+        ref = {0.0, 1.0, 0.0};
+    }
+
+    u = FlowQuantifier::normalize(FlowQuantifier::crossProduct(normal, ref));
+    v = FlowQuantifier::normalize(FlowQuantifier::crossProduct(normal, u));
+}
+
+}  // anonymous namespace
+
+namespace dicom_viewer::services {
+
+// =============================================================================
+// FlowQuantifier::Impl
+// =============================================================================
+
+class FlowQuantifier::Impl {
+public:
+    MeasurementPlane plane;
+};
+
+// =============================================================================
+// Lifecycle
+// =============================================================================
+
+FlowQuantifier::FlowQuantifier()
+    : impl_(std::make_unique<Impl>()) {}
+
+FlowQuantifier::~FlowQuantifier() = default;
+
+FlowQuantifier::FlowQuantifier(FlowQuantifier&&) noexcept = default;
+FlowQuantifier& FlowQuantifier::operator=(FlowQuantifier&&) noexcept = default;
+
+// =============================================================================
+// Measurement plane configuration
+// =============================================================================
+
+void FlowQuantifier::setMeasurementPlane(const MeasurementPlane& plane) {
+    impl_->plane = plane;
+    // Ensure normal is unit vector
+    impl_->plane.normal = normalize(plane.normal);
+}
+
+void FlowQuantifier::setMeasurementPlaneFrom3Points(
+    const std::array<double, 3>& p1,
+    const std::array<double, 3>& p2,
+    const std::array<double, 3>& p3) {
+
+    // Edge vectors
+    std::array<double, 3> e1 = {p2[0] - p1[0], p2[1] - p1[1], p2[2] - p1[2]};
+    std::array<double, 3> e2 = {p3[0] - p1[0], p3[1] - p1[1], p3[2] - p1[2]};
+
+    // Normal = e1 × e2
+    auto normal = normalize(crossProduct(e1, e2));
+
+    // Center = centroid
+    std::array<double, 3> center = {
+        (p1[0] + p2[0] + p3[0]) / 3.0,
+        (p1[1] + p2[1] + p3[1]) / 3.0,
+        (p1[2] + p2[2] + p3[2]) / 3.0
+    };
+
+    impl_->plane.center = center;
+    impl_->plane.normal = normal;
+}
+
+MeasurementPlane FlowQuantifier::measurementPlane() const {
+    return impl_->plane;
+}
+
+// =============================================================================
+// Core flow measurement
+// =============================================================================
+
+std::expected<FlowMeasurement, FlowError>
+FlowQuantifier::measureFlow(const VelocityPhase& phase) const {
+    if (!phase.velocityField) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "VelocityPhase has null velocity field"});
+    }
+
+    auto image = phase.velocityField;
+    if (image->GetNumberOfComponentsPerPixel() != 3) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "Expected 3-component velocity field"});
+    }
+
+    const auto& center = impl_->plane.center;
+    const auto& normal = impl_->plane.normal;
+    double radius = impl_->plane.radius;
+    double spacing = std::max(0.1, impl_->plane.sampleSpacing);
+
+    // Compute plane basis vectors
+    std::array<double, 3> u, v;
+    computePlaneBasis(normal, u, v);
+
+    // Sample velocity field at grid points on the plane
+    double sumThroughPlane = 0.0;
+    double maxThroughPlane = 0.0;
+    int sampleCount = 0;
+
+    // Pixel area in cm^2 (spacing in mm → spacing/10 in cm)
+    double pixelAreaCm2 = (spacing / 10.0) * (spacing / 10.0);
+
+    auto region = image->GetLargestPossibleRegion();
+
+    for (double si = -radius; si <= radius; si += spacing) {
+        for (double sj = -radius; sj <= radius; sj += spacing) {
+            // Skip points outside circular sampling region
+            if (si * si + sj * sj > radius * radius) continue;
+
+            // World coordinate of sample point
+            VectorImage3D::PointType point;
+            point[0] = center[0] + si * u[0] + sj * v[0];
+            point[1] = center[1] + si * u[1] + sj * v[1];
+            point[2] = center[2] + si * u[2] + sj * v[2];
+
+            // Transform to image index (nearest-neighbor)
+            VectorImage3D::IndexType index;
+            bool inBounds = image->TransformPhysicalPointToIndex(point, index);
+            if (!inBounds) continue;
+            if (!region.IsInside(index)) continue;
+
+            // Get velocity vector at this point
+            auto pixel = image->GetPixel(index);
+            std::array<double, 3> velocity = {
+                pixel[0], pixel[1], pixel[2]
+            };
+
+            // Through-plane velocity component (dot product with normal)
+            double vThrough = dotProduct(velocity, normal);
+
+            sumThroughPlane += vThrough;
+            maxThroughPlane = std::max(maxThroughPlane, std::abs(vThrough));
+            ++sampleCount;
+        }
+    }
+
+    FlowMeasurement result;
+    result.phaseIndex = phase.phaseIndex;
+    result.sampleCount = sampleCount;
+
+    if (sampleCount > 0) {
+        result.meanVelocity = sumThroughPlane / sampleCount;
+        result.maxVelocity = maxThroughPlane;
+        result.crossSectionArea = sampleCount * pixelAreaCm2;
+        // Flow rate = mean_through_plane_velocity × area
+        result.flowRate = sumThroughPlane * pixelAreaCm2;  // mL/s
+    }
+
+    getLogger()->debug("Phase {}: flow={:.2f} mL/s, mean_v={:.2f} cm/s, "
+                       "max_v={:.2f} cm/s, area={:.2f} cm², samples={}",
+                       result.phaseIndex, result.flowRate,
+                       result.meanVelocity, result.maxVelocity,
+                       result.crossSectionArea, result.sampleCount);
+
+    return result;
+}
+
+// =============================================================================
+// Time-velocity curve computation
+// =============================================================================
+
+std::expected<TimeVelocityCurve, FlowError>
+FlowQuantifier::computeTimeVelocityCurve(
+    const std::vector<VelocityPhase>& phases,
+    double temporalResolution) const {
+
+    if (phases.empty()) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "No phases provided for time-velocity curve"});
+    }
+
+    if (temporalResolution <= 0.0) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "Temporal resolution must be positive"});
+    }
+
+    TimeVelocityCurve tvc;
+    tvc.timePoints.reserve(phases.size());
+    tvc.meanVelocities.reserve(phases.size());
+    tvc.maxVelocities.reserve(phases.size());
+    tvc.flowRates.reserve(phases.size());
+
+    for (const auto& phase : phases) {
+        auto measurement = measureFlow(phase);
+        if (!measurement) {
+            return std::unexpected(measurement.error());
+        }
+
+        tvc.timePoints.push_back(phase.triggerTime);
+        tvc.meanVelocities.push_back(measurement->meanVelocity);
+        tvc.maxVelocities.push_back(measurement->maxVelocity);
+        tvc.flowRates.push_back(measurement->flowRate);
+    }
+
+    // Compute stroke volume and regurgitant volume
+    // dt in seconds = temporalResolution in ms / 1000
+    double dtSeconds = temporalResolution / 1000.0;
+
+    double forwardFlow = 0.0;
+    double backwardFlow = 0.0;
+
+    for (double fr : tvc.flowRates) {
+        if (fr >= 0.0) {
+            forwardFlow += fr * dtSeconds;   // mL
+        } else {
+            backwardFlow += (-fr) * dtSeconds;  // mL (positive value)
+        }
+    }
+
+    tvc.strokeVolume = forwardFlow;
+    tvc.regurgitantVolume = backwardFlow;
+
+    double totalForward = forwardFlow + backwardFlow;
+    if (totalForward > 0.0) {
+        tvc.regurgitantFraction = (backwardFlow / totalForward) * 100.0;
+    }
+
+    getLogger()->info("TVC: {} phases, SV={:.1f} mL, RV={:.1f} mL, "
+                      "RF={:.1f}%",
+                      phases.size(), tvc.strokeVolume,
+                      tvc.regurgitantVolume, tvc.regurgitantFraction);
+
+    return tvc;
+}
+
+// =============================================================================
+// Pressure gradient estimation
+// =============================================================================
+
+double FlowQuantifier::estimatePressureGradient(double maxVelocityCmPerS) {
+    // Simplified Bernoulli: ΔP = 4 × V² (mmHg, V in m/s)
+    // V_m_per_s = V_cm_per_s / 100
+    // ΔP = 4 × (V/100)² = 4 × V² / 10000 = 0.0004 × V²
+    double vMetersPerS = maxVelocityCmPerS / 100.0;
+    return 4.0 * vMetersPerS * vMetersPerS;
+}
+
+// =============================================================================
+// CSV export
+// =============================================================================
+
+std::expected<void, FlowError>
+FlowQuantifier::exportToCSV(const TimeVelocityCurve& curve,
+                            const std::string& filePath) {
+    if (filePath.empty()) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InvalidInput,
+            "Empty file path"});
+    }
+
+    std::ofstream ofs(filePath);
+    if (!ofs.is_open()) {
+        return std::unexpected(FlowError{
+            FlowError::Code::InternalError,
+            "Cannot open file: " + filePath});
+    }
+
+    // Header
+    ofs << "Time_ms,MeanVelocity_cm_s,MaxVelocity_cm_s,FlowRate_mL_s\n";
+
+    // Data rows
+    for (size_t i = 0; i < curve.timePoints.size(); ++i) {
+        ofs << curve.timePoints[i] << ","
+            << curve.meanVelocities[i] << ","
+            << curve.maxVelocities[i] << ","
+            << curve.flowRates[i] << "\n";
+    }
+
+    // Summary
+    ofs << "\n# Summary\n";
+    ofs << "# Stroke Volume (mL)," << curve.strokeVolume << "\n";
+    ofs << "# Regurgitant Volume (mL)," << curve.regurgitantVolume << "\n";
+    ofs << "# Regurgitant Fraction (%)," << curve.regurgitantFraction << "\n";
+
+    return {};
+}
+
+// =============================================================================
+// Vector math utilities
+// =============================================================================
+
+double FlowQuantifier::dotProduct(
+    const std::array<double, 3>& a,
+    const std::array<double, 3>& b) {
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+std::array<double, 3> FlowQuantifier::normalize(
+    const std::array<double, 3>& v) {
+    double len = std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+    if (len < 1e-12) {
+        return {0, 0, 0};
+    }
+    return {v[0] / len, v[1] / len, v[2] / len};
+}
+
+std::array<double, 3> FlowQuantifier::crossProduct(
+    const std::array<double, 3>& a,
+    const std::array<double, 3>& b) {
+    return {
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0]
+    };
+}
+
+}  // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -850,3 +850,20 @@ target_include_directories(flow_visualizer_test PRIVATE
 )
 
 gtest_discover_tests(flow_visualizer_test DISCOVERY_TIMEOUT 60)
+
+# Flow quantifier tests
+add_executable(flow_quantifier_test
+    unit/flow_quantifier_test.cpp
+)
+
+target_link_libraries(flow_quantifier_test PRIVATE
+    flow_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(flow_quantifier_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(flow_quantifier_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/flow_quantifier_test.cpp
+++ b/tests/unit/flow_quantifier_test.cpp
@@ -1,0 +1,485 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+#include <itkVectorImage.h>
+
+#include "services/flow/flow_quantifier.hpp"
+
+using namespace dicom_viewer::services;
+
+namespace {
+
+/// Create a synthetic velocity field with uniform flow along Z axis
+VelocityPhase createUniformZFlow(int dim, float velocityZ, int phaseIndex = 0) {
+    auto image = VectorImage3D::New();
+    VectorImage3D::SizeType size;
+    size[0] = dim; size[1] = dim; size[2] = dim;
+    VectorImage3D::IndexType start;
+    start[0] = 0; start[1] = 0; start[2] = 0;
+    image->SetRegions(VectorImage3D::RegionType(start, size));
+    image->SetNumberOfComponentsPerPixel(3);
+
+    VectorImage3D::SpacingType spacing;
+    spacing[0] = 1.0; spacing[1] = 1.0; spacing[2] = 1.0;
+    image->SetSpacing(spacing);
+
+    VectorImage3D::PointType origin;
+    origin[0] = 0.0; origin[1] = 0.0; origin[2] = 0.0;
+    image->SetOrigin(origin);
+
+    image->Allocate();
+
+    auto* buffer = image->GetBufferPointer();
+    int numPixels = dim * dim * dim;
+    for (int i = 0; i < numPixels; ++i) {
+        buffer[i * 3]     = 0.0f;   // Vx
+        buffer[i * 3 + 1] = 0.0f;   // Vy
+        buffer[i * 3 + 2] = velocityZ;  // Vz
+    }
+
+    VelocityPhase phase;
+    phase.velocityField = image;
+    phase.phaseIndex = phaseIndex;
+    phase.triggerTime = phaseIndex * 40.0;
+    return phase;
+}
+
+/// Create a parabolic pipe flow along Z axis (Poiseuille profile)
+/// v(r) = vMax × (1 - r²/R²) for r < R, 0 otherwise
+VelocityPhase createPoiseuillePipeFlow(int dim, float vMax,
+                                       double pipeRadius,
+                                       int phaseIndex = 0) {
+    auto image = VectorImage3D::New();
+    VectorImage3D::SizeType size;
+    size[0] = dim; size[1] = dim; size[2] = dim;
+    VectorImage3D::IndexType start;
+    start[0] = 0; start[1] = 0; start[2] = 0;
+    image->SetRegions(VectorImage3D::RegionType(start, size));
+    image->SetNumberOfComponentsPerPixel(3);
+
+    VectorImage3D::SpacingType spacing;
+    spacing[0] = 1.0; spacing[1] = 1.0; spacing[2] = 1.0;
+    image->SetSpacing(spacing);
+
+    VectorImage3D::PointType origin;
+    origin[0] = 0.0; origin[1] = 0.0; origin[2] = 0.0;
+    image->SetOrigin(origin);
+
+    image->Allocate();
+
+    auto* buffer = image->GetBufferPointer();
+    double centerX = (dim - 1) / 2.0;
+    double centerY = (dim - 1) / 2.0;
+
+    for (int z = 0; z < dim; ++z) {
+        for (int y = 0; y < dim; ++y) {
+            for (int x = 0; x < dim; ++x) {
+                int idx = x + dim * (y + dim * z);
+                double dx = x - centerX;
+                double dy = y - centerY;
+                double r = std::sqrt(dx * dx + dy * dy);
+
+                float vz = 0.0f;
+                if (r < pipeRadius) {
+                    vz = static_cast<float>(
+                        vMax * (1.0 - (r * r) / (pipeRadius * pipeRadius)));
+                }
+                buffer[idx * 3]     = 0.0f;
+                buffer[idx * 3 + 1] = 0.0f;
+                buffer[idx * 3 + 2] = vz;
+            }
+        }
+    }
+
+    VelocityPhase phase;
+    phase.velocityField = image;
+    phase.phaseIndex = phaseIndex;
+    phase.triggerTime = phaseIndex * 40.0;
+    return phase;
+}
+
+const std::string kTestCSVPath = "/tmp/claude/flow_quantifier_test.csv";
+
+}  // anonymous namespace
+
+// =============================================================================
+// Struct default tests
+// =============================================================================
+
+TEST(FlowMeasurementTest, Defaults) {
+    FlowMeasurement m;
+    EXPECT_EQ(m.phaseIndex, 0);
+    EXPECT_DOUBLE_EQ(m.flowRate, 0.0);
+    EXPECT_DOUBLE_EQ(m.meanVelocity, 0.0);
+    EXPECT_DOUBLE_EQ(m.maxVelocity, 0.0);
+    EXPECT_DOUBLE_EQ(m.crossSectionArea, 0.0);
+    EXPECT_EQ(m.sampleCount, 0);
+}
+
+TEST(MeasurementPlaneTest, Defaults) {
+    MeasurementPlane p;
+    EXPECT_DOUBLE_EQ(p.center[0], 0.0);
+    EXPECT_DOUBLE_EQ(p.normal[2], 1.0);
+    EXPECT_DOUBLE_EQ(p.radius, 50.0);
+    EXPECT_DOUBLE_EQ(p.sampleSpacing, 1.0);
+}
+
+TEST(TimeVelocityCurveTest, Defaults) {
+    TimeVelocityCurve tvc;
+    EXPECT_TRUE(tvc.timePoints.empty());
+    EXPECT_DOUBLE_EQ(tvc.strokeVolume, 0.0);
+    EXPECT_DOUBLE_EQ(tvc.regurgitantVolume, 0.0);
+    EXPECT_DOUBLE_EQ(tvc.regurgitantFraction, 0.0);
+}
+
+// =============================================================================
+// FlowQuantifier construction tests
+// =============================================================================
+
+TEST(FlowQuantifierTest, DefaultConstruction) {
+    FlowQuantifier q;
+    auto plane = q.measurementPlane();
+    EXPECT_DOUBLE_EQ(plane.normal[2], 1.0);
+}
+
+TEST(FlowQuantifierTest, MoveConstruction) {
+    FlowQuantifier q;
+    FlowQuantifier moved(std::move(q));
+}
+
+TEST(FlowQuantifierTest, MoveAssignment) {
+    FlowQuantifier q;
+    FlowQuantifier other;
+    other = std::move(q);
+}
+
+// =============================================================================
+// Vector math utility tests
+// =============================================================================
+
+TEST(FlowQuantifierTest, DotProduct) {
+    EXPECT_DOUBLE_EQ(FlowQuantifier::dotProduct({1, 0, 0}, {1, 0, 0}), 1.0);
+    EXPECT_DOUBLE_EQ(FlowQuantifier::dotProduct({1, 0, 0}, {0, 1, 0}), 0.0);
+    EXPECT_DOUBLE_EQ(FlowQuantifier::dotProduct({1, 2, 3}, {4, 5, 6}), 32.0);
+    EXPECT_DOUBLE_EQ(FlowQuantifier::dotProduct({3, -2, 7}, {0, 4, -1}), -15.0);
+}
+
+TEST(FlowQuantifierTest, CrossProduct) {
+    auto c = FlowQuantifier::crossProduct({1, 0, 0}, {0, 1, 0});
+    EXPECT_DOUBLE_EQ(c[0], 0.0);
+    EXPECT_DOUBLE_EQ(c[1], 0.0);
+    EXPECT_DOUBLE_EQ(c[2], 1.0);
+
+    c = FlowQuantifier::crossProduct({0, 1, 0}, {0, 0, 1});
+    EXPECT_DOUBLE_EQ(c[0], 1.0);
+    EXPECT_DOUBLE_EQ(c[1], 0.0);
+    EXPECT_DOUBLE_EQ(c[2], 0.0);
+}
+
+TEST(FlowQuantifierTest, Normalize) {
+    auto n = FlowQuantifier::normalize({3, 4, 0});
+    EXPECT_NEAR(n[0], 0.6, 1e-10);
+    EXPECT_NEAR(n[1], 0.8, 1e-10);
+    EXPECT_NEAR(n[2], 0.0, 1e-10);
+
+    // Zero vector
+    auto z = FlowQuantifier::normalize({0, 0, 0});
+    EXPECT_DOUBLE_EQ(z[0], 0.0);
+    EXPECT_DOUBLE_EQ(z[1], 0.0);
+    EXPECT_DOUBLE_EQ(z[2], 0.0);
+}
+
+// =============================================================================
+// Measurement plane tests
+// =============================================================================
+
+TEST(FlowQuantifierTest, SetMeasurementPlane) {
+    FlowQuantifier q;
+    MeasurementPlane plane;
+    plane.center = {10, 20, 30};
+    plane.normal = {0, 0, 2};  // Not unit — should be normalized
+    plane.radius = 25.0;
+    plane.sampleSpacing = 0.5;
+    q.setMeasurementPlane(plane);
+
+    auto retrieved = q.measurementPlane();
+    EXPECT_DOUBLE_EQ(retrieved.center[0], 10.0);
+    EXPECT_NEAR(retrieved.normal[2], 1.0, 1e-10);  // Normalized
+    EXPECT_DOUBLE_EQ(retrieved.radius, 25.0);
+    EXPECT_DOUBLE_EQ(retrieved.sampleSpacing, 0.5);
+}
+
+TEST(FlowQuantifierTest, SetMeasurementPlaneFrom3Points) {
+    FlowQuantifier q;
+    // XY plane at z=5
+    q.setMeasurementPlaneFrom3Points(
+        {0, 0, 5}, {10, 0, 5}, {0, 10, 5});
+
+    auto plane = q.measurementPlane();
+    // Center is centroid
+    EXPECT_NEAR(plane.center[0], 10.0 / 3.0, 1e-10);
+    EXPECT_NEAR(plane.center[1], 10.0 / 3.0, 1e-10);
+    EXPECT_NEAR(plane.center[2], 5.0, 1e-10);
+    // Normal should be along Z
+    EXPECT_NEAR(std::abs(plane.normal[2]), 1.0, 1e-10);
+}
+
+// =============================================================================
+// Flow measurement tests
+// =============================================================================
+
+TEST(FlowQuantifierTest, MeasureFlow_NullField) {
+    FlowQuantifier q;
+    VelocityPhase phase;
+    auto result = q.measureFlow(phase);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, FlowError::Code::InvalidInput);
+}
+
+TEST(FlowQuantifierTest, MeasureFlow_UniformZFlow) {
+    FlowQuantifier q;
+
+    // 20x20x20 grid, spacing 1mm, uniform flow Vz=10 cm/s
+    auto phase = createUniformZFlow(20, 10.0f);
+
+    // Measurement plane at center, normal along Z, radius 5mm
+    MeasurementPlane plane;
+    plane.center = {10, 10, 10};
+    plane.normal = {0, 0, 1};
+    plane.radius = 5.0;
+    plane.sampleSpacing = 1.0;
+    q.setMeasurementPlane(plane);
+
+    auto result = q.measureFlow(phase);
+    ASSERT_TRUE(result.has_value());
+
+    // All samples should have through-plane velocity = 10 cm/s
+    EXPECT_NEAR(result->meanVelocity, 10.0, 0.1);
+    EXPECT_NEAR(result->maxVelocity, 10.0, 0.1);
+    EXPECT_GT(result->sampleCount, 0);
+    EXPECT_GT(result->flowRate, 0.0);
+    EXPECT_GT(result->crossSectionArea, 0.0);
+}
+
+TEST(FlowQuantifierTest, MeasureFlow_PerpendicularFlow) {
+    FlowQuantifier q;
+
+    // Flow along Z, but measure plane has normal along X
+    auto phase = createUniformZFlow(20, 10.0f);
+
+    MeasurementPlane plane;
+    plane.center = {10, 10, 10};
+    plane.normal = {1, 0, 0};  // Normal perpendicular to flow
+    plane.radius = 5.0;
+    plane.sampleSpacing = 1.0;
+    q.setMeasurementPlane(plane);
+
+    auto result = q.measureFlow(phase);
+    ASSERT_TRUE(result.has_value());
+
+    // Through-plane velocity should be ~0 (flow is perpendicular to normal)
+    EXPECT_NEAR(result->meanVelocity, 0.0, 0.01);
+    EXPECT_NEAR(result->flowRate, 0.0, 0.01);
+}
+
+TEST(FlowQuantifierTest, MeasureFlow_PoiseuillePipeFlow) {
+    FlowQuantifier q;
+
+    // Poiseuille flow: v(r) = vMax × (1 - r²/R²)
+    // Mean velocity = vMax / 2
+    // Flow rate = π × R² × vMax / 2
+    int dim = 40;
+    float vMax = 100.0f;  // cm/s
+    double pipeRadius = 8.0;  // mm (in grid units since spacing=1mm)
+
+    auto phase = createPoiseuillePipeFlow(dim, vMax, pipeRadius);
+
+    // Measurement plane at pipe center
+    MeasurementPlane plane;
+    plane.center = {(dim - 1) / 2.0, (dim - 1) / 2.0, (dim - 1) / 2.0};
+    plane.normal = {0, 0, 1};
+    plane.radius = pipeRadius + 2.0;  // Slightly larger than pipe
+    plane.sampleSpacing = 1.0;
+    q.setMeasurementPlane(plane);
+
+    auto result = q.measureFlow(phase);
+    ASSERT_TRUE(result.has_value());
+
+    // Analytical: mean velocity over pipe cross-section = vMax / 2
+    // But we're sampling over a larger area than the pipe, so mean velocity
+    // over the full sample area will be lower. Max velocity should be vMax.
+    EXPECT_NEAR(result->maxVelocity, vMax, 1.0);
+
+    // Analytical flow rate = π × R² × vMax / 2
+    // R = 8mm = 0.8cm, vMax = 100 cm/s
+    // Q = π × 0.64 × 50 = 100.53 mL/s
+    // But discrete sampling introduces error, accept ±10%
+    double expectedFlowRate = M_PI * (pipeRadius / 10.0) * (pipeRadius / 10.0)
+                              * vMax / 2.0;
+    EXPECT_NEAR(result->flowRate, expectedFlowRate, expectedFlowRate * 0.10);
+}
+
+TEST(FlowQuantifierTest, MeasureFlow_ObliqueNormal) {
+    FlowQuantifier q;
+
+    // Flow along Z = 10 cm/s
+    auto phase = createUniformZFlow(20, 10.0f);
+
+    // Measurement plane with 45-degree tilted normal
+    MeasurementPlane plane;
+    plane.center = {10, 10, 10};
+    plane.normal = {0, 1, 1};  // Will be normalized to {0, 1/√2, 1/√2}
+    plane.radius = 5.0;
+    plane.sampleSpacing = 1.0;
+    q.setMeasurementPlane(plane);
+
+    auto result = q.measureFlow(phase);
+    ASSERT_TRUE(result.has_value());
+
+    // Through-plane = dot({0,0,10}, {0, 1/√2, 1/√2}) = 10/√2 ≈ 7.07
+    EXPECT_NEAR(result->meanVelocity, 10.0 / std::sqrt(2.0), 0.5);
+}
+
+// =============================================================================
+// Time-velocity curve tests
+// =============================================================================
+
+TEST(FlowQuantifierTest, ComputeTVC_EmptyPhases) {
+    FlowQuantifier q;
+    std::vector<VelocityPhase> empty;
+    auto result = q.computeTimeVelocityCurve(empty, 40.0);
+    ASSERT_FALSE(result.has_value());
+}
+
+TEST(FlowQuantifierTest, ComputeTVC_InvalidResolution) {
+    FlowQuantifier q;
+    std::vector<VelocityPhase> phases;
+    phases.push_back(createUniformZFlow(10, 10.0f, 0));
+    auto result = q.computeTimeVelocityCurve(phases, 0.0);
+    ASSERT_FALSE(result.has_value());
+}
+
+TEST(FlowQuantifierTest, ComputeTVC_UniformFlow) {
+    FlowQuantifier q;
+
+    MeasurementPlane plane;
+    plane.center = {5, 5, 5};
+    plane.normal = {0, 0, 1};
+    plane.radius = 3.0;
+    plane.sampleSpacing = 1.0;
+    q.setMeasurementPlane(plane);
+
+    // 5 phases with constant flow
+    std::vector<VelocityPhase> phases;
+    for (int i = 0; i < 5; ++i) {
+        phases.push_back(createUniformZFlow(10, 10.0f, i));
+    }
+
+    auto result = q.computeTimeVelocityCurve(phases, 40.0);
+    ASSERT_TRUE(result.has_value());
+
+    EXPECT_EQ(result->timePoints.size(), 5);
+    EXPECT_EQ(result->flowRates.size(), 5);
+
+    // All phases should have same flow rate
+    for (size_t i = 1; i < result->flowRates.size(); ++i) {
+        EXPECT_NEAR(result->flowRates[i], result->flowRates[0], 0.01);
+    }
+
+    // Stroke volume = sum of flowRates × dt (40ms = 0.04s)
+    // All forward flow, no regurgitation
+    EXPECT_GT(result->strokeVolume, 0.0);
+    EXPECT_DOUBLE_EQ(result->regurgitantVolume, 0.0);
+    EXPECT_DOUBLE_EQ(result->regurgitantFraction, 0.0);
+}
+
+TEST(FlowQuantifierTest, ComputeTVC_WithRegurgitation) {
+    FlowQuantifier q;
+
+    MeasurementPlane plane;
+    plane.center = {5, 5, 5};
+    plane.normal = {0, 0, 1};
+    plane.radius = 3.0;
+    plane.sampleSpacing = 1.0;
+    q.setMeasurementPlane(plane);
+
+    // 4 phases: 2 forward, 2 backward (regurgitant)
+    std::vector<VelocityPhase> phases;
+    phases.push_back(createUniformZFlow(10, 10.0f, 0));   // Forward
+    phases.push_back(createUniformZFlow(10, 10.0f, 1));   // Forward
+    phases.push_back(createUniformZFlow(10, -5.0f, 2));   // Backward
+    phases.push_back(createUniformZFlow(10, -5.0f, 3));   // Backward
+
+    auto result = q.computeTimeVelocityCurve(phases, 40.0);
+    ASSERT_TRUE(result.has_value());
+
+    EXPECT_GT(result->strokeVolume, 0.0);
+    EXPECT_GT(result->regurgitantVolume, 0.0);
+    EXPECT_GT(result->regurgitantFraction, 0.0);
+    EXPECT_LT(result->regurgitantFraction, 100.0);
+}
+
+// =============================================================================
+// Pressure gradient tests
+// =============================================================================
+
+TEST(FlowQuantifierTest, PressureGradient_Zero) {
+    EXPECT_DOUBLE_EQ(FlowQuantifier::estimatePressureGradient(0.0), 0.0);
+}
+
+TEST(FlowQuantifierTest, PressureGradient_Typical) {
+    // V = 100 cm/s = 1 m/s → ΔP = 4 × 1² = 4 mmHg
+    EXPECT_NEAR(FlowQuantifier::estimatePressureGradient(100.0), 4.0, 1e-10);
+
+    // V = 200 cm/s = 2 m/s → ΔP = 4 × 4 = 16 mmHg
+    EXPECT_NEAR(FlowQuantifier::estimatePressureGradient(200.0), 16.0, 1e-10);
+
+    // V = 300 cm/s = 3 m/s → ΔP = 4 × 9 = 36 mmHg
+    EXPECT_NEAR(FlowQuantifier::estimatePressureGradient(300.0), 36.0, 1e-10);
+
+    // V = 50 cm/s = 0.5 m/s → ΔP = 4 × 0.25 = 1 mmHg
+    EXPECT_NEAR(FlowQuantifier::estimatePressureGradient(50.0), 1.0, 1e-10);
+}
+
+// =============================================================================
+// CSV export tests
+// =============================================================================
+
+TEST(FlowQuantifierTest, ExportToCSV_EmptyPath) {
+    TimeVelocityCurve tvc;
+    auto result = FlowQuantifier::exportToCSV(tvc, "");
+    ASSERT_FALSE(result.has_value());
+}
+
+TEST(FlowQuantifierTest, ExportToCSV_ValidData) {
+    TimeVelocityCurve tvc;
+    tvc.timePoints = {0, 40, 80};
+    tvc.meanVelocities = {10.0, 20.0, 15.0};
+    tvc.maxVelocities = {15.0, 30.0, 22.0};
+    tvc.flowRates = {5.0, 10.0, 7.5};
+    tvc.strokeVolume = 50.0;
+    tvc.regurgitantVolume = 5.0;
+    tvc.regurgitantFraction = 9.09;
+
+    auto result = FlowQuantifier::exportToCSV(tvc, kTestCSVPath);
+    ASSERT_TRUE(result.has_value());
+
+    // Verify file exists and has content
+    std::ifstream ifs(kTestCSVPath);
+    ASSERT_TRUE(ifs.is_open());
+
+    std::string line;
+    std::getline(ifs, line);
+    EXPECT_EQ(line, "Time_ms,MeanVelocity_cm_s,MaxVelocity_cm_s,FlowRate_mL_s");
+
+    // Check data rows
+    std::getline(ifs, line);
+    EXPECT_FALSE(line.empty());
+
+    // Clean up
+    std::filesystem::remove(kTestCSVPath);
+}


### PR DESCRIPTION
## Summary
- Implement `FlowQuantifier` for quantitative hemodynamic measurements from 4D Flow velocity data
- Flow rate computation at user-defined measurement planes via through-plane velocity integration (dot product with plane normal)
- Time-velocity curve (TVC) computation across all cardiac phases with stroke volume, regurgitant volume, and regurgitant fraction
- Simplified Bernoulli pressure gradient estimation: ΔP = 4V² (mmHg, V in m/s)
- CSV export for time-velocity curve data with summary statistics
- Measurement plane definition from center+normal or from 3 points
- Vector math utilities: dotProduct, crossProduct, normalize

## Key Design Decisions
- **No VTK dependency**: Pure ITK/C++ service layer. Velocity field sampling uses ITK's `TransformPhysicalPointToIndex` for nearest-neighbor lookup
- **Circular plane sampling**: Grid points on the measurement plane within a configurable radius, ensuring consistent area estimation
- **Unit conventions**: Velocity in cm/s (from VENC scaling), spacing in mm (ITK standard), flow rate in mL/s (= cm³/s), pressure in mmHg
- **Pixel area conversion**: Sample spacing (mm) → cm: `pixelArea_cm² = (spacing_mm / 10)²`

## Test Plan
- [x] 24 unit tests covering all components
- [x] Struct defaults (FlowMeasurement, MeasurementPlane, TimeVelocityCurve)
- [x] Construction, move semantics
- [x] Vector math: dotProduct, crossProduct, normalize (including zero vector)
- [x] Measurement plane: set from normal, set from 3 points (verifies centroid and normal)
- [x] Flow measurement: null field, uniform Z-flow, perpendicular flow (zero throughput), Poiseuille pipe flow (±10% of analytical solution), oblique normal (cos θ projection)
- [x] Time-velocity curve: empty phases, invalid resolution, uniform flow (no regurgitation), mixed forward/backward flow (33.3% regurgitant fraction)
- [x] Pressure gradient: zero velocity, typical values (4 mmHg at 100 cm/s, 16 mmHg at 200 cm/s)
- [x] CSV export: empty path error, valid data with file content verification
- [x] All 153 existing flow tests still pass (38+23+27+35+30)

Closes #157