### PR TITLE
docs(sds): add SDS-MOD-008 and SDS-MOD-009 design for Enhanced DICOM and Cardiac CT

### DIFF
--- a/docs/SDS.md
+++ b/docs/SDS.md
@@ -3168,7 +3168,7 @@ sequenceDiagram
 | FR-014.9~11 | SRS-FR-048 | SDS-MOD-007, SDS-DATA-006 | Flow (TemporalNavigator) | ⬜ Planned |
 | FR-014.12~18 | SRS-FR-047 | SDS-MOD-007, SDS-SEQ-007 | Flow (FlowQuantifier) | ⬜ Planned |
 | FR-014.19~21 | SRS-FR-047 | SDS-MOD-007, SDS-SEQ-007 | Flow (VesselAnalyzer, Export) | ⬜ Planned |
-| FR-015.1~6 | SRS-FR-049 | SDS-MOD-008 | Enhanced DICOM (EnhancedDicomParser, FrameExtractor, FunctionalGroupParser) | ⬜ Planned |
+| FR-015.1~6 | SRS-FR-049 | SDS-MOD-008 | Enhanced DICOM (EnhancedDicomParser, FrameExtractor, FunctionalGroupParser, DimensionIndexSorter) | ⬜ Planned |
 | FR-016.1~4 | SRS-FR-050 | SDS-MOD-009 | Cardiac CT (CardiacPhaseDetector) | ⬜ Planned |
 | FR-016.5~8 | SRS-FR-051 | SDS-MOD-009 | Cardiac CT (CoronaryCenterlineExtractor, CurvedPlanarReformatter) | ⬜ Planned |
 | FR-016.9~12 | SRS-FR-052 | SDS-MOD-009 | Cardiac CT (CalciumScorer) | ⬜ Planned |


### PR DESCRIPTION
Closes #174

## Summary
- Add SDS-MOD-008 (Enhanced DICOM Module) with 4 components:
  - EnhancedDicomParser: Detect and parse Enhanced CT/MR IODs
  - FrameExtractor: Extract individual frames from multi-frame pixel data
  - FunctionalGroupParser: Parse Shared/PerFrame FunctionalGroupsSequence
  - DimensionIndexSorter: Sort frames by DimensionIndexSequence
- Add SDS-MOD-009 (Cardiac CT Analysis Module) with 5 components:
  - CardiacPhaseDetector: ECG-gated cardiac phase separation
  - CoronaryCenterlineExtractor: Frangi vesselness + minimal path centerline
  - CurvedPlanarReformatter: Straightened, cross-sectional, and stretched CPR
  - CalciumScorer: Agatston, volume, and mass calcium scores
  - CineOrganizer: Cine MRI series organization (reuses TemporalNavigator)
- Include class diagrams, key data structures, and design decisions for both modules
- Update traceability matrix 7.1 (PRD→SRS summary) with FR-015~017
- Update traceability matrix 7.2 (SRS→SDS) with SRS-FR-049~053 mappings
- Update traceability matrix 7.3 (Complete end-to-end) with 6 new rows
- Add file structure entries for enhanced_dicom/ and cardiac/ directories
- Bump SDS version to 0.6.0 based on SRS v0.6.0

## Traceability
Part of #171 (Epic: Enhanced DICOM IOD, Cardiac CT, Cine MRI)
Depends on: #173 / #183 (SRS update)

| SDS Module | SRS Source | Components |
|------------|-----------|------------|
| SDS-MOD-008 | SRS-FR-049 | EnhancedDicomParser, FrameExtractor, FunctionalGroupParser, DimensionIndexSorter |
| SDS-MOD-009 | SRS-FR-050~053 | CardiacPhaseDetector, CoronaryCenterlineExtractor, CurvedPlanarReformatter, CalciumScorer, CineOrganizer |

## Test Plan
- [x] Verify SDS version updated to 0.6.0, references SRS v0.6.0
- [x] Verify SDS-MOD-008 includes class diagram, data structures (2 structs), and design decisions (4 decisions)
- [x] Verify SDS-MOD-009 includes class diagram, data structures (4 structs), and design decisions (5 decisions)
- [x] Verify traceability matrix 7.1 includes FR-015~017 entries (3 rows)
- [x] Verify traceability matrix 7.2 maps SRS-FR-049~053 to SDS components (5 rows)
- [x] Verify traceability matrix 7.3 has 6 new rows marked as Planned (fixed: added DimensionIndexSorter to FR-015 row)
- [x] Verify file structure includes enhanced_dicom/ and cardiac/ directories
- [x] Verify no broken markdown or ASCII art formatting (code fence count: 88, even)

## Fixes Applied During Verification
- Added missing `DimensionIndexSorter` to FR-015.1~6 row in traceability matrix 7.3
- Corrected row count from "7 new rows" to "6 new rows" (FR-015 is one consolidated row)