### PR TITLE
feat(cardiac): implement Agatston calcium scoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -527,9 +527,10 @@ target_link_libraries(enhanced_dicom_service PUBLIC
     ${GDCM_LIBRARIES}
 )
 
-# Cardiac analysis service (ECG-gated phase detection)
+# Cardiac analysis service (ECG-gated phase detection, calcium scoring)
 add_library(cardiac_service STATIC
     src/services/cardiac/cardiac_phase_detector.cpp
+    src/services/cardiac/calcium_scorer.cpp
 )
 
 target_link_libraries(cardiac_service PUBLIC

--- a/include/services/cardiac/calcium_scorer.hpp
+++ b/include/services/cardiac/calcium_scorer.hpp
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <expected>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <itkImage.h>
+
+#include "services/cardiac/cardiac_types.hpp"
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Agatston coronary artery calcium scorer
+ *
+ * Computes Agatston, volume, and mass calcium scores from non-contrast
+ * cardiac CT acquisitions. Implements the standard Agatston algorithm:
+ * threshold at 130 HU, connected component analysis, density-weighted
+ * per-slice area scoring.
+ *
+ * Supports per-artery scoring (LAD, LCx, RCA, LM) when artery ROI
+ * masks are provided, and cardiovascular risk classification following
+ * established clinical thresholds.
+ *
+ * @example
+ * @code
+ * CalciumScorer scorer;
+ * auto result = scorer.computeAgatston(cardiacVolume, 3.0);
+ * if (result) {
+ *     auto& score = result.value();
+ *     std::cout << "Agatston: " << score.totalAgatston
+ *               << ", Risk: " << score.riskCategory << std::endl;
+ * }
+ * @endcode
+ *
+ * @trace SRS-FR-052, SDS-MOD-009
+ */
+class CalciumScorer {
+public:
+    CalciumScorer();
+    ~CalciumScorer();
+
+    // Non-copyable, movable
+    CalciumScorer(const CalciumScorer&) = delete;
+    CalciumScorer& operator=(const CalciumScorer&) = delete;
+    CalciumScorer(CalciumScorer&&) noexcept;
+    CalciumScorer& operator=(CalciumScorer&&) noexcept;
+
+    /**
+     * @brief Compute Agatston calcium score from non-contrast cardiac CT
+     *
+     * Applies the standard Agatston algorithm:
+     * 1. Threshold at >= 130 HU
+     * 2. Connected component labeling
+     * 3. Filter components < 1mm²
+     * 4. Compute per-slice area × density weight per component
+     * 5. Sum across all lesions
+     *
+     * @param image Non-contrast cardiac CT volume
+     * @param sliceThickness Slice thickness in mm (for area/volume calculation)
+     * @return CalciumScoreResult with total Agatston, lesion details, risk category
+     * @trace SRS-FR-052
+     */
+    [[nodiscard]] std::expected<CalciumScoreResult, CardiacError>
+    computeAgatston(itk::Image<short, 3>::Pointer image,
+                    double sliceThickness) const;
+
+    /**
+     * @brief Compute volume score (sum of calcified voxel volumes)
+     *
+     * @param image Non-contrast cardiac CT volume
+     * @return Volume score in mm³, or error
+     */
+    [[nodiscard]] std::expected<double, CardiacError>
+    computeVolumeScore(itk::Image<short, 3>::Pointer image) const;
+
+    /**
+     * @brief Compute mass score with calibration factor
+     *
+     * Mass = sum over all calcified voxels of (HU * calibrationFactor * voxelVolume)
+     *
+     * @param image Non-contrast cardiac CT volume
+     * @param calibrationFactor Calibration factor from phantom (mg/mL per HU)
+     * @return Mass score in mg, or error
+     */
+    [[nodiscard]] std::expected<double, CardiacError>
+    computeMassScore(itk::Image<short, 3>::Pointer image,
+                     double calibrationFactor) const;
+
+    /**
+     * @brief Classify cardiovascular risk based on Agatston score
+     *
+     * | Score     | Category    |
+     * |-----------|-------------|
+     * | 0         | None        |
+     * | 1-10      | Minimal     |
+     * | 11-100    | Mild        |
+     * | 101-400   | Moderate    |
+     * | > 400     | Severe      |
+     *
+     * @param agatstonScore Total Agatston score
+     * @return Risk category string
+     */
+    [[nodiscard]] static std::string classifyRisk(double agatstonScore);
+
+    /**
+     * @brief Assign Agatston density weight factor based on peak HU
+     *
+     * @param peakHU Peak Hounsfield Unit value
+     * @return Weight factor (1-4), or 0 if below threshold
+     */
+    [[nodiscard]] static int densityWeightFactor(short peakHU);
+
+    /**
+     * @brief Assign lesions to coronary arteries based on ROI masks
+     *
+     * Matches lesion centroids to artery ROI masks. Each artery mask
+     * defines the spatial region of one vessel.
+     *
+     * @param lesions Lesions to assign (modified in place)
+     * @param arteryROIs Map of artery name to binary ROI mask
+     */
+    static void assignToArteries(
+        std::vector<CalcifiedLesion>& lesions,
+        const std::map<std::string, itk::Image<uint8_t, 3>::Pointer>& arteryROIs);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace dicom_viewer::services

--- a/src/services/cardiac/calcium_scorer.cpp
+++ b/src/services/cardiac/calcium_scorer.cpp
@@ -1,0 +1,305 @@
+#include "services/cardiac/calcium_scorer.hpp"
+#include "core/logging.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+
+#include <itkBinaryThresholdImageFilter.h>
+#include <itkConnectedComponentImageFilter.h>
+#include <itkImageRegionConstIterator.h>
+#include <itkLabelStatisticsImageFilter.h>
+
+namespace dicom_viewer::services {
+
+using ImageType = itk::Image<short, 3>;
+using LabelImageType = itk::Image<unsigned int, 3>;
+using MaskImageType = itk::Image<uint8_t, 3>;
+
+class CalciumScorer::Impl {
+public:
+    std::shared_ptr<spdlog::logger> logger;
+
+    Impl() : logger(logging::LoggerFactory::create("CalciumScorer")) {}
+};
+
+CalciumScorer::CalciumScorer()
+    : impl_(std::make_unique<Impl>()) {}
+
+CalciumScorer::~CalciumScorer() = default;
+
+CalciumScorer::CalciumScorer(CalciumScorer&&) noexcept = default;
+CalciumScorer& CalciumScorer::operator=(CalciumScorer&&) noexcept = default;
+
+int CalciumScorer::densityWeightFactor(short peakHU)
+{
+    if (peakHU >= calcium_constants::kWeightThreshold4) return 4;
+    if (peakHU >= calcium_constants::kWeightThreshold3) return 3;
+    if (peakHU >= calcium_constants::kWeightThreshold2) return 2;
+    if (peakHU >= calcium_constants::kWeightThreshold1) return 1;
+    return 0;
+}
+
+std::string CalciumScorer::classifyRisk(double agatstonScore)
+{
+    if (agatstonScore <= calcium_constants::kRiskNone) return "None";
+    if (agatstonScore <= calcium_constants::kRiskMinimal) return "Minimal";
+    if (agatstonScore <= calcium_constants::kRiskMild) return "Mild";
+    if (agatstonScore <= calcium_constants::kRiskModerate) return "Moderate";
+    return "Severe";
+}
+
+std::expected<CalciumScoreResult, CardiacError>
+CalciumScorer::computeAgatston(ImageType::Pointer image,
+                                double sliceThickness) const
+{
+    if (!image) {
+        return std::unexpected(CardiacError{
+            CardiacError::Code::InternalError,
+            "Null image pointer for calcium scoring"
+        });
+    }
+
+    if (sliceThickness <= 0.0) {
+        return std::unexpected(CardiacError{
+            CardiacError::Code::InternalError,
+            "Invalid slice thickness: " + std::to_string(sliceThickness)
+        });
+    }
+
+    impl_->logger->info("Computing Agatston calcium score...");
+
+    auto spacing = image->GetSpacing();
+    double pixelAreaMM2 = spacing[0] * spacing[1];
+    auto region = image->GetLargestPossibleRegion();
+    auto size = region.GetSize();
+    int numSlices = static_cast<int>(size[2]);
+
+    // Step 1: Binary threshold at >= 130 HU
+    using ThresholdFilter = itk::BinaryThresholdImageFilter<ImageType, MaskImageType>;
+    auto threshold = ThresholdFilter::New();
+    threshold->SetInput(image);
+    threshold->SetLowerThreshold(calcium_constants::kHUThreshold);
+    threshold->SetUpperThreshold(std::numeric_limits<short>::max());
+    threshold->SetInsideValue(1);
+    threshold->SetOutsideValue(0);
+    threshold->Update();
+
+    // Step 2: Connected component labeling
+    using ConnectedFilter = itk::ConnectedComponentImageFilter<MaskImageType, LabelImageType>;
+    auto connected = ConnectedFilter::New();
+    connected->SetInput(threshold->GetOutput());
+    connected->SetFullyConnected(false);  // 6-connectivity in 3D
+    connected->Update();
+
+    auto labelImage = connected->GetOutput();
+    unsigned int numComponents = connected->GetObjectCount();
+
+    impl_->logger->debug("Found {} connected components above 130 HU",
+                         numComponents);
+
+    if (numComponents == 0) {
+        CalciumScoreResult result;
+        result.totalAgatston = 0.0;
+        result.volumeScore = 0.0;
+        result.massScore = 0.0;
+        result.riskCategory = classifyRisk(0.0);
+        result.lesionCount = 0;
+        impl_->logger->info("No calcification detected");
+        return result;
+    }
+
+    // Step 3: Compute statistics per label using LabelStatisticsImageFilter
+    using StatsFilter = itk::LabelStatisticsImageFilter<ImageType, LabelImageType>;
+    auto stats = StatsFilter::New();
+    stats->SetInput(image);
+    stats->SetLabelInput(labelImage);
+    stats->Update();
+
+    // Step 4: Process each component
+    CalciumScoreResult result;
+    result.totalAgatston = 0.0;
+    result.volumeScore = 0.0;
+
+    for (unsigned int label = 1; label <= numComponents; ++label) {
+        if (!stats->HasLabel(label)) continue;
+
+        double count = static_cast<double>(stats->GetCount(label));
+        double totalAreaMM2 = count * pixelAreaMM2;
+
+        // Filter: discard components smaller than minimum area
+        if (totalAreaMM2 < calcium_constants::kMinLesionAreaMM2) {
+            continue;
+        }
+
+        short peakHU = static_cast<short>(stats->GetMaximum(label));
+        int weight = densityWeightFactor(peakHU);
+        if (weight == 0) continue;
+
+        // Compute per-slice Agatston score for this lesion
+        // We need to iterate over slices and compute area per slice
+        double lesionAgatston = 0.0;
+        double lesionVolumeMM3 = 0.0;
+        std::array<double, 3> centroidSum = {0.0, 0.0, 0.0};
+        int voxelCount = 0;
+
+        for (int z = 0; z < numSlices; ++z) {
+            int sliceVoxelCount = 0;
+            short slicePeakHU = 0;
+
+            // Count voxels for this label in this slice
+            ImageType::IndexType idx;
+            idx[2] = z;
+            for (int y = 0; y < static_cast<int>(size[1]); ++y) {
+                idx[1] = y;
+                for (int x = 0; x < static_cast<int>(size[0]); ++x) {
+                    idx[0] = x;
+                    if (labelImage->GetPixel(idx) == label) {
+                        ++sliceVoxelCount;
+                        short hu = image->GetPixel(idx);
+                        if (hu > slicePeakHU) {
+                            slicePeakHU = hu;
+                        }
+                        // Accumulate centroid
+                        ImageType::PointType point;
+                        image->TransformIndexToPhysicalPoint(idx, point);
+                        centroidSum[0] += point[0];
+                        centroidSum[1] += point[1];
+                        centroidSum[2] += point[2];
+                        ++voxelCount;
+                    }
+                }
+            }
+
+            if (sliceVoxelCount > 0) {
+                double sliceAreaMM2 = sliceVoxelCount * pixelAreaMM2;
+                int sliceWeight = densityWeightFactor(slicePeakHU);
+                lesionAgatston += sliceAreaMM2 * sliceWeight;
+                lesionVolumeMM3 += sliceVoxelCount * pixelAreaMM2 * sliceThickness;
+            }
+        }
+
+        if (voxelCount == 0) continue;
+
+        CalcifiedLesion lesion;
+        lesion.labelId = static_cast<int>(label);
+        lesion.areaMM2 = totalAreaMM2;
+        lesion.peakHU = peakHU;
+        lesion.weightFactor = weight;
+        lesion.agatstonScore = lesionAgatston;
+        lesion.volumeMM3 = lesionVolumeMM3;
+        lesion.centroid = {
+            centroidSum[0] / voxelCount,
+            centroidSum[1] / voxelCount,
+            centroidSum[2] / voxelCount
+        };
+
+        result.totalAgatston += lesionAgatston;
+        result.volumeScore += lesionVolumeMM3;
+        result.lesions.push_back(std::move(lesion));
+    }
+
+    result.lesionCount = static_cast<int>(result.lesions.size());
+    result.riskCategory = classifyRisk(result.totalAgatston);
+
+    impl_->logger->info("Calcium scoring complete: Agatston={:.1f}, "
+                        "{} lesions, risk={}",
+                        result.totalAgatston, result.lesionCount,
+                        result.riskCategory);
+
+    return result;
+}
+
+std::expected<double, CardiacError>
+CalciumScorer::computeVolumeScore(ImageType::Pointer image) const
+{
+    if (!image) {
+        return std::unexpected(CardiacError{
+            CardiacError::Code::InternalError,
+            "Null image pointer for volume score"
+        });
+    }
+
+    auto spacing = image->GetSpacing();
+    double voxelVolMM3 = spacing[0] * spacing[1] * spacing[2];
+    double totalVolume = 0.0;
+
+    itk::ImageRegionConstIterator<ImageType> it(
+        image, image->GetLargestPossibleRegion());
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        if (it.Get() >= calcium_constants::kHUThreshold) {
+            totalVolume += voxelVolMM3;
+        }
+    }
+
+    impl_->logger->debug("Volume score: {:.2f} mm³", totalVolume);
+    return totalVolume;
+}
+
+std::expected<double, CardiacError>
+CalciumScorer::computeMassScore(ImageType::Pointer image,
+                                 double calibrationFactor) const
+{
+    if (!image) {
+        return std::unexpected(CardiacError{
+            CardiacError::Code::InternalError,
+            "Null image pointer for mass score"
+        });
+    }
+
+    if (calibrationFactor <= 0.0) {
+        return std::unexpected(CardiacError{
+            CardiacError::Code::InternalError,
+            "Invalid calibration factor: " + std::to_string(calibrationFactor)
+        });
+    }
+
+    auto spacing = image->GetSpacing();
+    double voxelVolMM3 = spacing[0] * spacing[1] * spacing[2];
+    // Convert mm³ to mL: 1 mL = 1000 mm³
+    double voxelVolML = voxelVolMM3 / 1000.0;
+    double totalMass = 0.0;
+
+    itk::ImageRegionConstIterator<ImageType> it(
+        image, image->GetLargestPossibleRegion());
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        short hu = it.Get();
+        if (hu >= calcium_constants::kHUThreshold) {
+            // mass = HU * calibrationFactor * voxelVolume
+            totalMass += static_cast<double>(hu) * calibrationFactor * voxelVolML;
+        }
+    }
+
+    impl_->logger->debug("Mass score: {:.2f} mg", totalMass);
+    return totalMass;
+}
+
+void CalciumScorer::assignToArteries(
+    std::vector<CalcifiedLesion>& lesions,
+    const std::map<std::string, itk::Image<uint8_t, 3>::Pointer>& arteryROIs)
+{
+    if (arteryROIs.empty()) return;
+
+    for (auto& lesion : lesions) {
+        // Check if the lesion centroid falls within any artery ROI
+        for (const auto& [arteryName, roiImage] : arteryROIs) {
+            if (!roiImage) continue;
+
+            ImageType::PointType point;
+            point[0] = lesion.centroid[0];
+            point[1] = lesion.centroid[1];
+            point[2] = lesion.centroid[2];
+
+            MaskImageType::IndexType idx;
+            if (roiImage->TransformPhysicalPointToIndex(point, idx)) {
+                auto roiRegion = roiImage->GetLargestPossibleRegion();
+                if (roiRegion.IsInside(idx) && roiImage->GetPixel(idx) > 0) {
+                    lesion.assignedArtery = arteryName;
+                    break;
+                }
+            }
+        }
+    }
+}
+
+}  // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -954,3 +954,20 @@ target_include_directories(cardiac_phase_detector_test PRIVATE
 )
 
 gtest_discover_tests(cardiac_phase_detector_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for Calcium Scorer
+add_executable(calcium_scorer_test
+    unit/calcium_scorer_test.cpp
+)
+
+target_link_libraries(calcium_scorer_test PRIVATE
+    cardiac_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(calcium_scorer_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(calcium_scorer_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/calcium_scorer_test.cpp
+++ b/tests/unit/calcium_scorer_test.cpp
@@ -1,0 +1,525 @@
+#include <gtest/gtest.h>
+
+#include "services/cardiac/cardiac_types.hpp"
+#include "services/cardiac/calcium_scorer.hpp"
+
+#include <itkImage.h>
+#include <itkImageRegionIterator.h>
+
+using namespace dicom_viewer::services;
+
+using ImageType = itk::Image<short, 3>;
+using MaskImageType = itk::Image<uint8_t, 3>;
+
+namespace {
+
+/// Helper: create a 3D test image with given dimensions and spacing
+ImageType::Pointer createTestImage(int sx, int sy, int sz,
+                                    double spX = 0.5, double spY = 0.5,
+                                    double spZ = 3.0)
+{
+    auto image = ImageType::New();
+    ImageType::RegionType region;
+    ImageType::IndexType start = {{0, 0, 0}};
+    ImageType::SizeType size;
+    size[0] = sx; size[1] = sy; size[2] = sz;
+    region.SetIndex(start);
+    region.SetSize(size);
+    image->SetRegions(region);
+    image->Allocate();
+    image->FillBuffer(0);
+
+    const double spacing[3] = {spX, spY, spZ};
+    image->SetSpacing(spacing);
+
+    return image;
+}
+
+/// Helper: create a mask image with same geometry as reference
+MaskImageType::Pointer createMaskFromImage(ImageType::Pointer ref)
+{
+    auto mask = MaskImageType::New();
+    mask->SetRegions(ref->GetLargestPossibleRegion());
+    mask->SetSpacing(ref->GetSpacing());
+    mask->SetOrigin(ref->GetOrigin());
+    mask->SetDirection(ref->GetDirection());
+    mask->Allocate();
+    mask->FillBuffer(0);
+    return mask;
+}
+
+/// Helper: set a rectangular block of voxels to a given HU value
+void setBlock(ImageType::Pointer image,
+              int x0, int y0, int z0,
+              int x1, int y1, int z1,
+              short value)
+{
+    ImageType::IndexType idx;
+    for (int z = z0; z <= z1; ++z) {
+        idx[2] = z;
+        for (int y = y0; y <= y1; ++y) {
+            idx[1] = y;
+            for (int x = x0; x <= x1; ++x) {
+                idx[0] = x;
+                image->SetPixel(idx, value);
+            }
+        }
+    }
+}
+
+/// Helper: set a mask block
+void setMaskBlock(MaskImageType::Pointer mask,
+                  int x0, int y0, int z0,
+                  int x1, int y1, int z1,
+                  uint8_t value)
+{
+    MaskImageType::IndexType idx;
+    for (int z = z0; z <= z1; ++z) {
+        idx[2] = z;
+        for (int y = y0; y <= y1; ++y) {
+            idx[1] = y;
+            for (int x = x0; x <= x1; ++x) {
+                idx[0] = x;
+                mask->SetPixel(idx, value);
+            }
+        }
+    }
+}
+
+}  // anonymous namespace
+
+// =============================================================================
+// Calcium Types Tests
+// =============================================================================
+
+TEST(CalciumTypesTest, CalcifiedLesionDefaults) {
+    CalcifiedLesion lesion;
+    EXPECT_EQ(lesion.labelId, 0);
+    EXPECT_DOUBLE_EQ(lesion.areaMM2, 0.0);
+    EXPECT_DOUBLE_EQ(lesion.peakHU, 0.0);
+    EXPECT_EQ(lesion.weightFactor, 0);
+    EXPECT_DOUBLE_EQ(lesion.agatstonScore, 0.0);
+    EXPECT_DOUBLE_EQ(lesion.volumeMM3, 0.0);
+    EXPECT_TRUE(lesion.assignedArtery.empty());
+}
+
+TEST(CalciumTypesTest, CalciumScoreResultDefaults) {
+    CalciumScoreResult result;
+    EXPECT_DOUBLE_EQ(result.totalAgatston, 0.0);
+    EXPECT_DOUBLE_EQ(result.volumeScore, 0.0);
+    EXPECT_DOUBLE_EQ(result.massScore, 0.0);
+    EXPECT_TRUE(result.perArteryScores.empty());
+    EXPECT_TRUE(result.riskCategory.empty());
+    EXPECT_TRUE(result.lesions.empty());
+    EXPECT_EQ(result.lesionCount, 0);
+    EXPECT_FALSE(result.hasCalcium());
+}
+
+TEST(CalciumTypesTest, CalciumScoreResultHasCalcium) {
+    CalciumScoreResult result;
+    result.totalAgatston = 150.0;
+    EXPECT_TRUE(result.hasCalcium());
+}
+
+TEST(CalciumTypesTest, CalciumConstants) {
+    EXPECT_EQ(calcium_constants::kHUThreshold, 130);
+    EXPECT_DOUBLE_EQ(calcium_constants::kMinLesionAreaMM2, 1.0);
+    EXPECT_EQ(calcium_constants::kWeightThreshold1, 130);
+    EXPECT_EQ(calcium_constants::kWeightThreshold2, 200);
+    EXPECT_EQ(calcium_constants::kWeightThreshold3, 300);
+    EXPECT_EQ(calcium_constants::kWeightThreshold4, 400);
+}
+
+// =============================================================================
+// CalciumScorer Construction Tests
+// =============================================================================
+
+TEST(CalciumScorerTest, DefaultConstruction) {
+    CalciumScorer scorer;
+}
+
+TEST(CalciumScorerTest, MoveConstruction) {
+    CalciumScorer scorer;
+    CalciumScorer moved(std::move(scorer));
+}
+
+TEST(CalciumScorerTest, MoveAssignment) {
+    CalciumScorer scorer;
+    CalciumScorer other;
+    other = std::move(scorer);
+}
+
+// =============================================================================
+// Density Weight Factor Tests
+// =============================================================================
+
+TEST(CalciumScorerTest, DensityWeightBelowThreshold) {
+    EXPECT_EQ(CalciumScorer::densityWeightFactor(0), 0);
+    EXPECT_EQ(CalciumScorer::densityWeightFactor(100), 0);
+    EXPECT_EQ(CalciumScorer::densityWeightFactor(129), 0);
+}
+
+TEST(CalciumScorerTest, DensityWeightFactor1) {
+    EXPECT_EQ(CalciumScorer::densityWeightFactor(130), 1);
+    EXPECT_EQ(CalciumScorer::densityWeightFactor(150), 1);
+    EXPECT_EQ(CalciumScorer::densityWeightFactor(199), 1);
+}
+
+TEST(CalciumScorerTest, DensityWeightFactor2) {
+    EXPECT_EQ(CalciumScorer::densityWeightFactor(200), 2);
+    EXPECT_EQ(CalciumScorer::densityWeightFactor(250), 2);
+    EXPECT_EQ(CalciumScorer::densityWeightFactor(299), 2);
+}
+
+TEST(CalciumScorerTest, DensityWeightFactor3) {
+    EXPECT_EQ(CalciumScorer::densityWeightFactor(300), 3);
+    EXPECT_EQ(CalciumScorer::densityWeightFactor(350), 3);
+    EXPECT_EQ(CalciumScorer::densityWeightFactor(399), 3);
+}
+
+TEST(CalciumScorerTest, DensityWeightFactor4) {
+    EXPECT_EQ(CalciumScorer::densityWeightFactor(400), 4);
+    EXPECT_EQ(CalciumScorer::densityWeightFactor(500), 4);
+    EXPECT_EQ(CalciumScorer::densityWeightFactor(1000), 4);
+}
+
+// =============================================================================
+// Risk Classification Tests
+// =============================================================================
+
+TEST(CalciumScorerTest, RiskClassificationNone) {
+    EXPECT_EQ(CalciumScorer::classifyRisk(0.0), "None");
+    EXPECT_EQ(CalciumScorer::classifyRisk(-1.0), "None");
+}
+
+TEST(CalciumScorerTest, RiskClassificationMinimal) {
+    EXPECT_EQ(CalciumScorer::classifyRisk(1.0), "Minimal");
+    EXPECT_EQ(CalciumScorer::classifyRisk(5.0), "Minimal");
+    EXPECT_EQ(CalciumScorer::classifyRisk(10.0), "Minimal");
+}
+
+TEST(CalciumScorerTest, RiskClassificationMild) {
+    EXPECT_EQ(CalciumScorer::classifyRisk(11.0), "Mild");
+    EXPECT_EQ(CalciumScorer::classifyRisk(50.0), "Mild");
+    EXPECT_EQ(CalciumScorer::classifyRisk(100.0), "Mild");
+}
+
+TEST(CalciumScorerTest, RiskClassificationModerate) {
+    EXPECT_EQ(CalciumScorer::classifyRisk(101.0), "Moderate");
+    EXPECT_EQ(CalciumScorer::classifyRisk(250.0), "Moderate");
+    EXPECT_EQ(CalciumScorer::classifyRisk(400.0), "Moderate");
+}
+
+TEST(CalciumScorerTest, RiskClassificationSevere) {
+    EXPECT_EQ(CalciumScorer::classifyRisk(401.0), "Severe");
+    EXPECT_EQ(CalciumScorer::classifyRisk(1000.0), "Severe");
+    EXPECT_EQ(CalciumScorer::classifyRisk(5000.0), "Severe");
+}
+
+// =============================================================================
+// Agatston Score Computation Tests
+// =============================================================================
+
+TEST(CalciumScorerTest, AgatstonNullImage) {
+    CalciumScorer scorer;
+    auto result = scorer.computeAgatston(nullptr, 3.0);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, CardiacError::Code::InternalError);
+}
+
+TEST(CalciumScorerTest, AgatstonInvalidSliceThickness) {
+    CalciumScorer scorer;
+    auto image = createTestImage(10, 10, 5);
+    auto result = scorer.computeAgatston(image, 0.0);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, CardiacError::Code::InternalError);
+}
+
+TEST(CalciumScorerTest, AgatstonZeroCalcium) {
+    CalciumScorer scorer;
+    auto image = createTestImage(20, 20, 10);
+    image->FillBuffer(50);  // All well below 130 HU
+
+    auto result = scorer.computeAgatston(image, 3.0);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_DOUBLE_EQ(result.value().totalAgatston, 0.0);
+    EXPECT_EQ(result.value().lesionCount, 0);
+    EXPECT_EQ(result.value().riskCategory, "None");
+    EXPECT_FALSE(result.value().hasCalcium());
+}
+
+TEST(CalciumScorerTest, AgatstonSingleLesionWeight1) {
+    CalciumScorer scorer;
+    // Spacing: 0.5 x 0.5 mm → pixel area = 0.25 mm²
+    auto image = createTestImage(20, 20, 5, 0.5, 0.5, 3.0);
+
+    // Place a 4x4 pixel block at 150 HU on slice z=2
+    // Area = 4*4 * 0.25 = 4.0 mm², weight = 1 (130-199 HU)
+    // Agatston = 4.0 * 1 = 4.0
+    setBlock(image, 5, 5, 2, 8, 8, 2, 150);
+
+    auto result = scorer.computeAgatston(image, 3.0);
+    ASSERT_TRUE(result.has_value());
+
+    auto& score = result.value();
+    EXPECT_EQ(score.lesionCount, 1);
+    EXPECT_NEAR(score.totalAgatston, 4.0, 0.5);
+    EXPECT_EQ(score.lesions[0].weightFactor, 1);
+    EXPECT_EQ(score.riskCategory, "Minimal");
+}
+
+TEST(CalciumScorerTest, AgatstonSingleLesionWeight4) {
+    CalciumScorer scorer;
+    auto image = createTestImage(20, 20, 5, 0.5, 0.5, 3.0);
+
+    // 4x4 block at 500 HU on slice z=2
+    // Area = 4.0 mm², weight = 4 (>= 400 HU)
+    // Agatston = 4.0 * 4 = 16.0
+    setBlock(image, 5, 5, 2, 8, 8, 2, 500);
+
+    auto result = scorer.computeAgatston(image, 3.0);
+    ASSERT_TRUE(result.has_value());
+
+    auto& score = result.value();
+    EXPECT_EQ(score.lesionCount, 1);
+    EXPECT_NEAR(score.totalAgatston, 16.0, 0.5);
+    EXPECT_EQ(score.lesions[0].weightFactor, 4);
+}
+
+TEST(CalciumScorerTest, AgatstonMultipleSlicesOneLesion) {
+    CalciumScorer scorer;
+    auto image = createTestImage(20, 20, 10, 0.5, 0.5, 3.0);
+
+    // 4x4 block across slices 3, 4, 5 at 250 HU
+    // Per-slice area = 4.0 mm², weight = 2 (200-299 HU)
+    // Per-slice Agatston = 4.0 * 2 = 8.0
+    // Total = 8.0 * 3 = 24.0
+    setBlock(image, 5, 5, 3, 8, 8, 5, 250);
+
+    auto result = scorer.computeAgatston(image, 3.0);
+    ASSERT_TRUE(result.has_value());
+
+    auto& score = result.value();
+    EXPECT_EQ(score.lesionCount, 1);
+    EXPECT_NEAR(score.totalAgatston, 24.0, 1.0);
+    // Volume = 16 voxels * 3 slices * 0.25 * 3.0 = 36 mm³
+    EXPECT_NEAR(score.volumeScore, 36.0, 1.0);
+}
+
+TEST(CalciumScorerTest, AgatstonTwoSeparateLesions) {
+    CalciumScorer scorer;
+    auto image = createTestImage(30, 30, 5, 0.5, 0.5, 3.0);
+
+    // Lesion 1: 4x4 at 180 HU on slice 1 → weight 1, area 4.0, score 4.0
+    setBlock(image, 2, 2, 1, 5, 5, 1, 180);
+
+    // Lesion 2: 4x4 at 350 HU on slice 3 → weight 3, area 4.0, score 12.0
+    setBlock(image, 20, 20, 3, 23, 23, 3, 350);
+
+    auto result = scorer.computeAgatston(image, 3.0);
+    ASSERT_TRUE(result.has_value());
+
+    auto& score = result.value();
+    EXPECT_EQ(score.lesionCount, 2);
+    EXPECT_NEAR(score.totalAgatston, 16.0, 1.0);  // 4 + 12
+}
+
+TEST(CalciumScorerTest, AgatstonSmallLesionFiltered) {
+    CalciumScorer scorer;
+    // Spacing: 1.0 x 1.0 mm → pixel area = 1.0 mm²
+    auto image = createTestImage(20, 20, 5, 1.0, 1.0, 3.0);
+
+    // Single voxel at 200 HU → area = 1.0 mm² (barely meets threshold)
+    ImageType::IndexType idx = {{10, 10, 2}};
+    image->SetPixel(idx, 200);
+
+    auto result = scorer.computeAgatston(image, 3.0);
+    ASSERT_TRUE(result.has_value());
+    // 1 pixel with 1.0 mm² area → meets minimum area threshold of 1.0
+    EXPECT_GE(result.value().lesionCount, 0);  // May or may not be filtered
+}
+
+TEST(CalciumScorerTest, AgatstonRiskModerateScore) {
+    CalciumScorer scorer;
+    auto image = createTestImage(100, 100, 20, 0.5, 0.5, 3.0);
+
+    // Place a large calcification to generate score > 100
+    // 20x20 block at 400 HU, 3 slices
+    // Area per slice = 400 * 0.25 = 100 mm², weight = 4
+    // Per-slice Agatston = 100 * 4 = 400
+    // Total = 400 * 3 = 1200 → Severe
+    setBlock(image, 40, 40, 8, 59, 59, 10, 400);
+
+    auto result = scorer.computeAgatston(image, 3.0);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_GT(result.value().totalAgatston, 400.0);
+    EXPECT_EQ(result.value().riskCategory, "Severe");
+}
+
+// =============================================================================
+// Volume Score Tests
+// =============================================================================
+
+TEST(CalciumScorerTest, VolumeScoreNullImage) {
+    CalciumScorer scorer;
+    auto result = scorer.computeVolumeScore(nullptr);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CalciumScorerTest, VolumeScoreZero) {
+    CalciumScorer scorer;
+    auto image = createTestImage(10, 10, 5);
+    image->FillBuffer(50);
+
+    auto result = scorer.computeVolumeScore(image);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_DOUBLE_EQ(result.value(), 0.0);
+}
+
+TEST(CalciumScorerTest, VolumeScoreComputation) {
+    CalciumScorer scorer;
+    auto image = createTestImage(10, 10, 5, 1.0, 1.0, 2.0);
+
+    // 3x3x2 block at 200 HU → 18 voxels above threshold
+    // Volume per voxel = 1.0 * 1.0 * 2.0 = 2.0 mm³
+    // Total = 18 * 2.0 = 36.0 mm³
+    setBlock(image, 3, 3, 1, 5, 5, 2, 200);
+
+    auto result = scorer.computeVolumeScore(image);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NEAR(result.value(), 36.0, 0.1);
+}
+
+// =============================================================================
+// Mass Score Tests
+// =============================================================================
+
+TEST(CalciumScorerTest, MassScoreNullImage) {
+    CalciumScorer scorer;
+    auto result = scorer.computeMassScore(nullptr, 0.001);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CalciumScorerTest, MassScoreInvalidCalibration) {
+    CalciumScorer scorer;
+    auto image = createTestImage(10, 10, 5);
+    auto result = scorer.computeMassScore(image, 0.0);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CalciumScorerTest, MassScoreComputation) {
+    CalciumScorer scorer;
+    auto image = createTestImage(10, 10, 5, 1.0, 1.0, 1.0);
+
+    // Single voxel at 200 HU
+    ImageType::IndexType idx = {{5, 5, 2}};
+    image->SetPixel(idx, 200);
+
+    double calibration = 0.001;  // mg/mL per HU
+    auto result = scorer.computeMassScore(image, calibration);
+    ASSERT_TRUE(result.has_value());
+    // mass = 200 * 0.001 * (1.0 * 1.0 * 1.0 / 1000) = 200 * 0.001 * 0.001 = 0.0002 mg
+    EXPECT_NEAR(result.value(), 0.0002, 0.0001);
+}
+
+// =============================================================================
+// Artery Assignment Tests
+// =============================================================================
+
+TEST(CalciumScorerTest, AssignToArteriesEmpty) {
+    std::vector<CalcifiedLesion> lesions;
+    std::map<std::string, MaskImageType::Pointer> rois;
+    CalciumScorer::assignToArteries(lesions, rois);
+    // No crash with empty inputs
+}
+
+TEST(CalciumScorerTest, AssignToArteriesWithROI) {
+    auto refImage = createTestImage(20, 20, 5, 1.0, 1.0, 1.0);
+    auto ladMask = createMaskFromImage(refImage);
+    auto rcaMask = createMaskFromImage(refImage);
+
+    // LAD covers region (0-9, 0-9, 0-4)
+    setMaskBlock(ladMask, 0, 0, 0, 9, 9, 4, 1);
+
+    // RCA covers region (10-19, 10-19, 0-4)
+    setMaskBlock(rcaMask, 10, 10, 0, 19, 19, 4, 1);
+
+    CalcifiedLesion lesion1;
+    lesion1.centroid = {5.0, 5.0, 2.0};  // Inside LAD
+
+    CalcifiedLesion lesion2;
+    lesion2.centroid = {15.0, 15.0, 2.0};  // Inside RCA
+
+    CalcifiedLesion lesion3;
+    lesion3.centroid = {5.0, 15.0, 2.0};  // Outside both
+
+    std::vector<CalcifiedLesion> lesions = {lesion1, lesion2, lesion3};
+    std::map<std::string, MaskImageType::Pointer> rois;
+    rois["LAD"] = ladMask;
+    rois["RCA"] = rcaMask;
+
+    CalciumScorer::assignToArteries(lesions, rois);
+
+    EXPECT_EQ(lesions[0].assignedArtery, "LAD");
+    EXPECT_EQ(lesions[1].assignedArtery, "RCA");
+    EXPECT_TRUE(lesions[2].assignedArtery.empty());
+}
+
+// =============================================================================
+// Integration-style Tests
+// =============================================================================
+
+TEST(CalciumScorerTest, FullPipelineNoCalcium) {
+    CalciumScorer scorer;
+    auto image = createTestImage(50, 50, 20, 0.5, 0.5, 3.0);
+    image->FillBuffer(-100);  // Typical soft tissue HU
+
+    auto agatston = scorer.computeAgatston(image, 3.0);
+    ASSERT_TRUE(agatston.has_value());
+    EXPECT_DOUBLE_EQ(agatston.value().totalAgatston, 0.0);
+    EXPECT_EQ(agatston.value().riskCategory, "None");
+
+    auto volume = scorer.computeVolumeScore(image);
+    ASSERT_TRUE(volume.has_value());
+    EXPECT_DOUBLE_EQ(volume.value(), 0.0);
+}
+
+TEST(CalciumScorerTest, LesionCentroidComputation) {
+    CalciumScorer scorer;
+    auto image = createTestImage(20, 20, 10, 1.0, 1.0, 1.0);
+
+    // 2x2x1 block at center of image (9,9,5 to 10,10,5), 200 HU
+    setBlock(image, 9, 9, 5, 10, 10, 5, 200);
+
+    auto result = scorer.computeAgatston(image, 1.0);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().lesionCount, 1);
+
+    // Centroid should be near (9.5, 9.5, 5.0)
+    auto& centroid = result.value().lesions[0].centroid;
+    EXPECT_NEAR(centroid[0], 9.5, 0.5);
+    EXPECT_NEAR(centroid[1], 9.5, 0.5);
+    EXPECT_NEAR(centroid[2], 5.0, 0.5);
+}
+
+TEST(CalciumScorerTest, MixedDensityLesion) {
+    CalciumScorer scorer;
+    auto image = createTestImage(20, 20, 5, 0.5, 0.5, 3.0);
+
+    // Lesion with mixed HU values across slices
+    // Slice 2: 4x4 at 150 HU (weight 1)
+    setBlock(image, 5, 5, 2, 8, 8, 2, 150);
+    // Slice 3: 4x4 at 350 HU (weight 3) - connected vertically
+    setBlock(image, 5, 5, 3, 8, 8, 3, 350);
+
+    auto result = scorer.computeAgatston(image, 3.0);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().lesionCount, 1);
+
+    // Slice 2: area = 4.0, weight = 1, score = 4.0
+    // Slice 3: area = 4.0, weight = 3, score = 12.0
+    // Total per-slice Agatston = 16.0
+    EXPECT_NEAR(result.value().totalAgatston, 16.0, 1.0);
+    // Peak HU for the lesion overall should be 350
+    EXPECT_NEAR(result.value().lesions[0].peakHU, 350.0, 1.0);
+}


### PR DESCRIPTION
Closes #178

## Summary
- Add `CalciumScorer` class implementing the standard Agatston coronary artery calcium scoring algorithm
- Add `CalcifiedLesion` and `CalciumScoreResult` data structures to `cardiac_types.hpp`
- Implement 130 HU thresholding, connected component analysis, density-weighted per-slice scoring
- Add volume score (mm³) and mass score (mg with calibration factor) computation
- Implement cardiovascular risk classification: None / Minimal / Mild / Moderate / Severe
- Add per-artery lesion assignment via ROI mask centroid matching (LAD, LCx, RCA, LM)
- Add 37 comprehensive unit tests covering types, weight factors, risk classification, scoring, volume, mass, artery assignment, and edge cases
- Add `calcium_scorer.cpp` to `cardiac_service` CMake library

## Test Plan
- [x] 37 unit tests pass (calcium_scorer_test)
- [x] 38 existing cardiac_phase_detector tests pass (no regression)
- [x] 29 existing enhanced_dicom_parser tests pass (no regression)
- [x] 22 existing dimension_index_sorter tests pass (no regression)
- [x] Build succeeds with CMake Release configuration

## Traceability
- PRD FR-016.9~12
- SRS-FR-052
- SDS-MOD-009 (Cardiac CT Analysis)