### PR TITLE
feat(segmentation): add ISegmentationCommand interface and command stack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,6 +409,8 @@ add_library(segmentation_service STATIC
     src/services/segmentation/morphological_processor.cpp
     src/services/segmentation/label_map_overlay.cpp
     src/services/segmentation/mpr_segmentation_renderer.cpp
+    src/services/segmentation/segmentation_command.cpp
+    src/services/segmentation/brush_stroke_command.cpp
 )
 
 target_link_libraries(segmentation_service PUBLIC

--- a/include/services/segmentation/brush_stroke_command.hpp
+++ b/include/services/segmentation/brush_stroke_command.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "services/segmentation/segmentation_command.hpp"
+
+#include <cstdint>
+#include <vector>
+
+#include <itkImage.h>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Record of a single voxel change for diff-based undo
+ */
+struct VoxelChange {
+    size_t linearIndex;   ///< Flat index into label map buffer
+    uint8_t oldLabel;     ///< Label value before the operation
+    uint8_t newLabel;     ///< Label value after the operation
+};
+
+/**
+ * @brief Diff-based undoable command for brush stroke operations
+ *
+ * Stores only the voxels that were changed by the brush stroke,
+ * making it memory-efficient for localized edits. Can be used
+ * for Brush, Eraser, and Fill operations.
+ *
+ * Usage:
+ * 1. Create command with label map reference
+ * 2. Call recordChange() for each voxel modified during the stroke
+ * 3. Pass to SegmentationCommandStack::execute()
+ *    (execute() is a no-op since changes are recorded during drawing)
+ *
+ * @trace SRS-FR-023
+ */
+class BrushStrokeCommand : public ISegmentationCommand {
+public:
+    using LabelMapType = itk::Image<uint8_t, 3>;
+
+    /**
+     * @brief Construct with label map and operation description
+     * @param labelMap Label map to modify on undo/redo
+     * @param operationDescription Description (e.g., "Brush stroke")
+     */
+    BrushStrokeCommand(LabelMapType::Pointer labelMap,
+                       std::string operationDescription);
+
+    ~BrushStrokeCommand() override = default;
+
+    /**
+     * @brief Record a voxel change during the stroke
+     *
+     * Call this for each voxel modified during the drawing operation.
+     * Only records if the old and new labels differ.
+     *
+     * @param linearIndex Flat index into label map buffer
+     * @param oldLabel Previous label value
+     * @param newLabel New label value
+     */
+    void recordChange(size_t linearIndex, uint8_t oldLabel, uint8_t newLabel);
+
+    /**
+     * @brief Get the number of recorded voxel changes
+     */
+    [[nodiscard]] size_t changeCount() const noexcept;
+
+    /**
+     * @brief Check if the command has any recorded changes
+     */
+    [[nodiscard]] bool hasChanges() const noexcept;
+
+    // ISegmentationCommand interface
+    void execute() override;
+    void undo() override;
+    [[nodiscard]] std::string description() const override;
+    [[nodiscard]] size_t memoryUsage() const override;
+
+private:
+    LabelMapType::Pointer labelMap_;
+    std::vector<VoxelChange> changes_;
+    std::string description_;
+};
+
+} // namespace dicom_viewer::services

--- a/include/services/segmentation/segmentation_command.hpp
+++ b/include/services/segmentation/segmentation_command.hpp
@@ -1,0 +1,162 @@
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Abstract interface for undoable segmentation operations
+ *
+ * All segmentation operations that support undo/redo must implement
+ * this interface. Commands are stored in a SegmentationCommandStack.
+ *
+ * @trace SRS-FR-023
+ */
+class ISegmentationCommand {
+public:
+    virtual ~ISegmentationCommand() = default;
+
+    /**
+     * @brief Execute or re-execute the command
+     */
+    virtual void execute() = 0;
+
+    /**
+     * @brief Reverse the effect of execute()
+     */
+    virtual void undo() = 0;
+
+    /**
+     * @brief Human-readable description of the operation
+     */
+    [[nodiscard]] virtual std::string description() const = 0;
+
+    /**
+     * @brief Estimated memory usage of stored undo data in bytes
+     */
+    [[nodiscard]] virtual size_t memoryUsage() const = 0;
+};
+
+/**
+ * @brief Manages undo/redo history for segmentation operations
+ *
+ * Implements a command stack with configurable history depth (default ≥20).
+ * When a new command is executed after an undo, the redo stack is cleared.
+ * When the undo stack exceeds the maximum size, the oldest command is discarded.
+ *
+ * @trace SRS-FR-023
+ */
+class SegmentationCommandStack {
+public:
+    /// Callback when undo/redo availability changes
+    using AvailabilityCallback = std::function<void(bool canUndo, bool canRedo)>;
+
+    /**
+     * @brief Construct with default max history of 20
+     */
+    SegmentationCommandStack();
+
+    /**
+     * @brief Construct with specified max history size
+     * @param maxHistory Maximum number of undo steps (minimum 1)
+     */
+    explicit SegmentationCommandStack(size_t maxHistory);
+
+    ~SegmentationCommandStack();
+
+    // Non-copyable, movable
+    SegmentationCommandStack(const SegmentationCommandStack&) = delete;
+    SegmentationCommandStack& operator=(const SegmentationCommandStack&) = delete;
+    SegmentationCommandStack(SegmentationCommandStack&&) noexcept;
+    SegmentationCommandStack& operator=(SegmentationCommandStack&&) noexcept;
+
+    /**
+     * @brief Execute a command and push it onto the undo stack
+     *
+     * Clears the redo stack. If the undo stack exceeds maxHistorySize,
+     * the oldest command is discarded.
+     *
+     * @param command Command to execute
+     */
+    void execute(std::unique_ptr<ISegmentationCommand> command);
+
+    /**
+     * @brief Undo the most recent command
+     * @return true if an undo was performed
+     */
+    bool undo();
+
+    /**
+     * @brief Redo the most recently undone command
+     * @return true if a redo was performed
+     */
+    bool redo();
+
+    /**
+     * @brief Check if undo is available
+     */
+    [[nodiscard]] bool canUndo() const noexcept;
+
+    /**
+     * @brief Check if redo is available
+     */
+    [[nodiscard]] bool canRedo() const noexcept;
+
+    /**
+     * @brief Get the number of undoable commands
+     */
+    [[nodiscard]] size_t undoCount() const noexcept;
+
+    /**
+     * @brief Get the number of redoable commands
+     */
+    [[nodiscard]] size_t redoCount() const noexcept;
+
+    /**
+     * @brief Clear all history (both undo and redo stacks)
+     */
+    void clear();
+
+    /**
+     * @brief Get the maximum history size
+     */
+    [[nodiscard]] size_t maxHistorySize() const noexcept;
+
+    /**
+     * @brief Set the maximum history size
+     * @param maxHistory New maximum (minimum 1)
+     */
+    void setMaxHistorySize(size_t maxHistory);
+
+    /**
+     * @brief Get the description of the next undo command
+     * @return Description string, or empty if no undo available
+     */
+    [[nodiscard]] std::string undoDescription() const;
+
+    /**
+     * @brief Get the description of the next redo command
+     * @return Description string, or empty if no redo available
+     */
+    [[nodiscard]] std::string redoDescription() const;
+
+    /**
+     * @brief Set callback for undo/redo availability changes
+     */
+    void setAvailabilityCallback(AvailabilityCallback callback);
+
+private:
+    void notifyAvailability();
+    void trimUndoStack();
+
+    std::deque<std::unique_ptr<ISegmentationCommand>> undoStack_;
+    std::deque<std::unique_ptr<ISegmentationCommand>> redoStack_;
+    size_t maxHistory_;
+    AvailabilityCallback availabilityCallback_;
+};
+
+} // namespace dicom_viewer::services

--- a/src/services/segmentation/brush_stroke_command.cpp
+++ b/src/services/segmentation/brush_stroke_command.cpp
@@ -1,0 +1,63 @@
+#include "services/segmentation/brush_stroke_command.hpp"
+
+#include <utility>
+
+namespace dicom_viewer::services {
+
+BrushStrokeCommand::BrushStrokeCommand(
+    LabelMapType::Pointer labelMap,
+    std::string operationDescription)
+    : labelMap_(std::move(labelMap))
+    , description_(std::move(operationDescription))
+{
+}
+
+void BrushStrokeCommand::recordChange(
+    size_t linearIndex, uint8_t oldLabel, uint8_t newLabel)
+{
+    if (oldLabel != newLabel) {
+        changes_.push_back({linearIndex, oldLabel, newLabel});
+    }
+}
+
+size_t BrushStrokeCommand::changeCount() const noexcept
+{
+    return changes_.size();
+}
+
+bool BrushStrokeCommand::hasChanges() const noexcept
+{
+    return !changes_.empty();
+}
+
+void BrushStrokeCommand::execute()
+{
+    if (!labelMap_) return;
+
+    auto* buffer = labelMap_->GetBufferPointer();
+    for (const auto& change : changes_) {
+        buffer[change.linearIndex] = change.newLabel;
+    }
+}
+
+void BrushStrokeCommand::undo()
+{
+    if (!labelMap_) return;
+
+    auto* buffer = labelMap_->GetBufferPointer();
+    for (const auto& change : changes_) {
+        buffer[change.linearIndex] = change.oldLabel;
+    }
+}
+
+std::string BrushStrokeCommand::description() const
+{
+    return description_;
+}
+
+size_t BrushStrokeCommand::memoryUsage() const
+{
+    return changes_.size() * sizeof(VoxelChange) + description_.size();
+}
+
+} // namespace dicom_viewer::services

--- a/src/services/segmentation/segmentation_command.cpp
+++ b/src/services/segmentation/segmentation_command.cpp
@@ -1,0 +1,138 @@
+#include "services/segmentation/segmentation_command.hpp"
+
+#include <algorithm>
+
+namespace dicom_viewer::services {
+
+SegmentationCommandStack::SegmentationCommandStack()
+    : maxHistory_(20)
+{
+}
+
+SegmentationCommandStack::SegmentationCommandStack(size_t maxHistory)
+    : maxHistory_(std::max(size_t{1}, maxHistory))
+{
+}
+
+SegmentationCommandStack::~SegmentationCommandStack() = default;
+
+SegmentationCommandStack::SegmentationCommandStack(
+    SegmentationCommandStack&&) noexcept = default;
+SegmentationCommandStack& SegmentationCommandStack::operator=(
+    SegmentationCommandStack&&) noexcept = default;
+
+void SegmentationCommandStack::execute(
+    std::unique_ptr<ISegmentationCommand> command)
+{
+    if (!command) return;
+
+    command->execute();
+    undoStack_.push_back(std::move(command));
+
+    // New command invalidates redo history
+    redoStack_.clear();
+
+    trimUndoStack();
+    notifyAvailability();
+}
+
+bool SegmentationCommandStack::undo()
+{
+    if (undoStack_.empty()) return false;
+
+    auto command = std::move(undoStack_.back());
+    undoStack_.pop_back();
+
+    command->undo();
+    redoStack_.push_back(std::move(command));
+
+    notifyAvailability();
+    return true;
+}
+
+bool SegmentationCommandStack::redo()
+{
+    if (redoStack_.empty()) return false;
+
+    auto command = std::move(redoStack_.back());
+    redoStack_.pop_back();
+
+    command->execute();
+    undoStack_.push_back(std::move(command));
+
+    notifyAvailability();
+    return true;
+}
+
+bool SegmentationCommandStack::canUndo() const noexcept
+{
+    return !undoStack_.empty();
+}
+
+bool SegmentationCommandStack::canRedo() const noexcept
+{
+    return !redoStack_.empty();
+}
+
+size_t SegmentationCommandStack::undoCount() const noexcept
+{
+    return undoStack_.size();
+}
+
+size_t SegmentationCommandStack::redoCount() const noexcept
+{
+    return redoStack_.size();
+}
+
+void SegmentationCommandStack::clear()
+{
+    undoStack_.clear();
+    redoStack_.clear();
+    notifyAvailability();
+}
+
+size_t SegmentationCommandStack::maxHistorySize() const noexcept
+{
+    return maxHistory_;
+}
+
+void SegmentationCommandStack::setMaxHistorySize(size_t maxHistory)
+{
+    maxHistory_ = std::max(size_t{1}, maxHistory);
+    trimUndoStack();
+    notifyAvailability();
+}
+
+std::string SegmentationCommandStack::undoDescription() const
+{
+    if (undoStack_.empty()) return {};
+    return undoStack_.back()->description();
+}
+
+std::string SegmentationCommandStack::redoDescription() const
+{
+    if (redoStack_.empty()) return {};
+    return redoStack_.back()->description();
+}
+
+void SegmentationCommandStack::setAvailabilityCallback(
+    AvailabilityCallback callback)
+{
+    availabilityCallback_ = std::move(callback);
+}
+
+void SegmentationCommandStack::notifyAvailability()
+{
+    if (availabilityCallback_) {
+        availabilityCallback_(canUndo(), canRedo());
+    }
+}
+
+void SegmentationCommandStack::trimUndoStack()
+{
+    while (undoStack_.size() > maxHistory_) {
+        undoStack_.pop_front();
+    }
+}
+
+} // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1315,3 +1315,20 @@ target_include_directories(phase_slider_widget_test PRIVATE
 )
 
 gtest_discover_tests(phase_slider_widget_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for Segmentation Command Stack and BrushStrokeCommand
+add_executable(segmentation_command_test
+    unit/segmentation_command_test.cpp
+)
+
+target_link_libraries(segmentation_command_test PRIVATE
+    segmentation_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(segmentation_command_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(segmentation_command_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/segmentation_command_test.cpp
+++ b/tests/unit/segmentation_command_test.cpp
@@ -1,0 +1,372 @@
+#include <gtest/gtest.h>
+
+#include <itkImage.h>
+
+#include "services/segmentation/segmentation_command.hpp"
+#include "services/segmentation/brush_stroke_command.hpp"
+
+using namespace dicom_viewer::services;
+
+namespace {
+
+/// Simple concrete command for testing the stack
+class TestCommand : public ISegmentationCommand {
+public:
+    TestCommand(int& counter, int delta, std::string desc = "Test")
+        : counter_(counter), delta_(delta), desc_(std::move(desc)) {}
+
+    void execute() override { counter_ += delta_; }
+    void undo() override { counter_ -= delta_; }
+    std::string description() const override { return desc_; }
+    size_t memoryUsage() const override { return sizeof(*this); }
+
+private:
+    int& counter_;
+    int delta_;
+    std::string desc_;
+};
+
+/// Create a 10x10x1 label map for testing
+BrushStrokeCommand::LabelMapType::Pointer createTestLabelMap() {
+    auto image = BrushStrokeCommand::LabelMapType::New();
+    BrushStrokeCommand::LabelMapType::SizeType size;
+    size[0] = 10; size[1] = 10; size[2] = 1;
+    BrushStrokeCommand::LabelMapType::IndexType start;
+    start[0] = 0; start[1] = 0; start[2] = 0;
+    image->SetRegions(
+        BrushStrokeCommand::LabelMapType::RegionType(start, size));
+    image->Allocate(true);  // Initialize to zero
+    return image;
+}
+
+}  // anonymous namespace
+
+// =============================================================================
+// SegmentationCommandStack — Construction
+// =============================================================================
+
+TEST(SegmentationCommandStackTest, DefaultConstruction) {
+    SegmentationCommandStack stack;
+    EXPECT_FALSE(stack.canUndo());
+    EXPECT_FALSE(stack.canRedo());
+    EXPECT_EQ(stack.undoCount(), 0);
+    EXPECT_EQ(stack.redoCount(), 0);
+    EXPECT_EQ(stack.maxHistorySize(), 20);
+}
+
+TEST(SegmentationCommandStackTest, CustomHistorySize) {
+    SegmentationCommandStack stack(50);
+    EXPECT_EQ(stack.maxHistorySize(), 50);
+}
+
+TEST(SegmentationCommandStackTest, MinimumHistorySize) {
+    SegmentationCommandStack stack(0);
+    EXPECT_EQ(stack.maxHistorySize(), 1);
+}
+
+// =============================================================================
+// SegmentationCommandStack — Execute / Undo / Redo
+// =============================================================================
+
+TEST(SegmentationCommandStackTest, ExecuteAndUndo) {
+    int counter = 0;
+    SegmentationCommandStack stack;
+
+    stack.execute(std::make_unique<TestCommand>(counter, 5));
+    EXPECT_EQ(counter, 5);
+    EXPECT_TRUE(stack.canUndo());
+    EXPECT_FALSE(stack.canRedo());
+
+    stack.undo();
+    EXPECT_EQ(counter, 0);
+    EXPECT_FALSE(stack.canUndo());
+    EXPECT_TRUE(stack.canRedo());
+}
+
+TEST(SegmentationCommandStackTest, UndoAndRedo) {
+    int counter = 0;
+    SegmentationCommandStack stack;
+
+    stack.execute(std::make_unique<TestCommand>(counter, 10));
+    stack.execute(std::make_unique<TestCommand>(counter, 20));
+    EXPECT_EQ(counter, 30);
+
+    stack.undo();
+    EXPECT_EQ(counter, 10);
+
+    stack.redo();
+    EXPECT_EQ(counter, 30);
+}
+
+TEST(SegmentationCommandStackTest, RedoClearedOnNewCommand) {
+    int counter = 0;
+    SegmentationCommandStack stack;
+
+    stack.execute(std::make_unique<TestCommand>(counter, 10));
+    stack.execute(std::make_unique<TestCommand>(counter, 20));
+    EXPECT_EQ(counter, 30);
+
+    stack.undo();
+    EXPECT_EQ(counter, 10);
+    EXPECT_TRUE(stack.canRedo());
+
+    // New command should clear redo
+    stack.execute(std::make_unique<TestCommand>(counter, 5));
+    EXPECT_EQ(counter, 15);
+    EXPECT_FALSE(stack.canRedo());
+}
+
+TEST(SegmentationCommandStackTest, MultipleUndoRedo) {
+    int counter = 0;
+    SegmentationCommandStack stack;
+
+    stack.execute(std::make_unique<TestCommand>(counter, 1));
+    stack.execute(std::make_unique<TestCommand>(counter, 2));
+    stack.execute(std::make_unique<TestCommand>(counter, 3));
+    EXPECT_EQ(counter, 6);
+    EXPECT_EQ(stack.undoCount(), 3);
+
+    stack.undo();
+    stack.undo();
+    stack.undo();
+    EXPECT_EQ(counter, 0);
+    EXPECT_EQ(stack.redoCount(), 3);
+
+    stack.redo();
+    stack.redo();
+    EXPECT_EQ(counter, 3);
+    EXPECT_EQ(stack.undoCount(), 2);
+    EXPECT_EQ(stack.redoCount(), 1);
+}
+
+// =============================================================================
+// SegmentationCommandStack — History limit
+// =============================================================================
+
+TEST(SegmentationCommandStackTest, HistoryLimitRespected) {
+    int counter = 0;
+    SegmentationCommandStack stack(5);
+
+    for (int i = 0; i < 10; ++i) {
+        stack.execute(std::make_unique<TestCommand>(counter, 1));
+    }
+    EXPECT_EQ(counter, 10);
+    EXPECT_EQ(stack.undoCount(), 5);
+
+    // Can only undo 5 steps
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_TRUE(stack.undo());
+    }
+    EXPECT_EQ(counter, 5);
+    EXPECT_FALSE(stack.undo());
+}
+
+TEST(SegmentationCommandStackTest, DefaultHistoryAtLeast20) {
+    int counter = 0;
+    SegmentationCommandStack stack;
+
+    for (int i = 0; i < 25; ++i) {
+        stack.execute(std::make_unique<TestCommand>(counter, 1));
+    }
+    EXPECT_GE(stack.undoCount(), 20);
+}
+
+// =============================================================================
+// SegmentationCommandStack — Clear and descriptions
+// =============================================================================
+
+TEST(SegmentationCommandStackTest, Clear) {
+    int counter = 0;
+    SegmentationCommandStack stack;
+
+    stack.execute(std::make_unique<TestCommand>(counter, 1));
+    stack.execute(std::make_unique<TestCommand>(counter, 2));
+    stack.undo();
+
+    stack.clear();
+    EXPECT_FALSE(stack.canUndo());
+    EXPECT_FALSE(stack.canRedo());
+    EXPECT_EQ(stack.undoCount(), 0);
+    EXPECT_EQ(stack.redoCount(), 0);
+}
+
+TEST(SegmentationCommandStackTest, Descriptions) {
+    int counter = 0;
+    SegmentationCommandStack stack;
+
+    EXPECT_TRUE(stack.undoDescription().empty());
+    EXPECT_TRUE(stack.redoDescription().empty());
+
+    stack.execute(std::make_unique<TestCommand>(counter, 1, "Step 1"));
+    stack.execute(std::make_unique<TestCommand>(counter, 2, "Step 2"));
+
+    EXPECT_EQ(stack.undoDescription(), "Step 2");
+
+    stack.undo();
+    EXPECT_EQ(stack.undoDescription(), "Step 1");
+    EXPECT_EQ(stack.redoDescription(), "Step 2");
+}
+
+// =============================================================================
+// SegmentationCommandStack — Availability callback
+// =============================================================================
+
+TEST(SegmentationCommandStackTest, AvailabilityCallback) {
+    int counter = 0;
+    SegmentationCommandStack stack;
+
+    bool lastCanUndo = false;
+    bool lastCanRedo = false;
+    int callCount = 0;
+
+    stack.setAvailabilityCallback(
+        [&](bool canUndo, bool canRedo) {
+            lastCanUndo = canUndo;
+            lastCanRedo = canRedo;
+            ++callCount;
+        });
+
+    stack.execute(std::make_unique<TestCommand>(counter, 1));
+    EXPECT_TRUE(lastCanUndo);
+    EXPECT_FALSE(lastCanRedo);
+    EXPECT_EQ(callCount, 1);
+
+    stack.undo();
+    EXPECT_FALSE(lastCanUndo);
+    EXPECT_TRUE(lastCanRedo);
+    EXPECT_EQ(callCount, 2);
+}
+
+// =============================================================================
+// SegmentationCommandStack — Edge cases
+// =============================================================================
+
+TEST(SegmentationCommandStackTest, UndoOnEmptyReturnsFalse) {
+    SegmentationCommandStack stack;
+    EXPECT_FALSE(stack.undo());
+}
+
+TEST(SegmentationCommandStackTest, RedoOnEmptyReturnsFalse) {
+    SegmentationCommandStack stack;
+    EXPECT_FALSE(stack.redo());
+}
+
+TEST(SegmentationCommandStackTest, NullCommandIgnored) {
+    SegmentationCommandStack stack;
+    stack.execute(nullptr);
+    EXPECT_FALSE(stack.canUndo());
+}
+
+// =============================================================================
+// BrushStrokeCommand
+// =============================================================================
+
+TEST(BrushStrokeCommandTest, RecordAndUndo) {
+    auto labelMap = createTestLabelMap();
+    auto* buffer = labelMap->GetBufferPointer();
+
+    // Simulate a brush stroke: paint label 1 on voxels 0-4
+    auto cmd = std::make_unique<BrushStrokeCommand>(labelMap, "Brush stroke");
+    for (int i = 0; i < 5; ++i) {
+        cmd->recordChange(i, buffer[i], 1);
+        buffer[i] = 1;  // Apply during drawing
+    }
+    EXPECT_EQ(cmd->changeCount(), 5);
+    EXPECT_TRUE(cmd->hasChanges());
+
+    // Verify painted
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_EQ(buffer[i], 1);
+    }
+
+    // Undo should restore to 0
+    cmd->undo();
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_EQ(buffer[i], 0);
+    }
+
+    // Execute (redo) should re-apply
+    cmd->execute();
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_EQ(buffer[i], 1);
+    }
+}
+
+TEST(BrushStrokeCommandTest, SkipsDuplicateLabels) {
+    auto labelMap = createTestLabelMap();
+
+    auto cmd = std::make_unique<BrushStrokeCommand>(labelMap, "No-op");
+    // Recording same old/new label should be ignored
+    cmd->recordChange(0, 0, 0);
+    cmd->recordChange(1, 1, 1);
+    EXPECT_EQ(cmd->changeCount(), 0);
+    EXPECT_FALSE(cmd->hasChanges());
+}
+
+TEST(BrushStrokeCommandTest, MemoryUsage) {
+    auto labelMap = createTestLabelMap();
+
+    auto cmd = std::make_unique<BrushStrokeCommand>(labelMap, "Brush");
+    size_t baseMemory = cmd->memoryUsage();
+
+    cmd->recordChange(0, 0, 1);
+    cmd->recordChange(1, 0, 1);
+    EXPECT_GT(cmd->memoryUsage(), baseMemory);
+    EXPECT_EQ(cmd->memoryUsage(),
+              2 * sizeof(VoxelChange) + std::string("Brush").size());
+}
+
+TEST(BrushStrokeCommandTest, Description) {
+    auto labelMap = createTestLabelMap();
+    BrushStrokeCommand cmd(labelMap, "Circle brush size 10");
+    EXPECT_EQ(cmd.description(), "Circle brush size 10");
+}
+
+TEST(BrushStrokeCommandTest, IntegrationWithCommandStack) {
+    auto labelMap = createTestLabelMap();
+    auto* buffer = labelMap->GetBufferPointer();
+
+    SegmentationCommandStack stack;
+
+    // Stroke 1: paint label 1 on voxels 0-2
+    {
+        auto cmd = std::make_unique<BrushStrokeCommand>(labelMap, "Stroke 1");
+        for (int i = 0; i < 3; ++i) {
+            cmd->recordChange(i, buffer[i], 1);
+            buffer[i] = 1;
+        }
+        // execute() is a no-op since we already applied during drawing,
+        // but the stack calls it — re-applying same values is idempotent
+        stack.execute(std::move(cmd));
+    }
+
+    // Stroke 2: paint label 2 on voxels 3-5
+    {
+        auto cmd = std::make_unique<BrushStrokeCommand>(labelMap, "Stroke 2");
+        for (int i = 3; i < 6; ++i) {
+            cmd->recordChange(i, buffer[i], 2);
+            buffer[i] = 2;
+        }
+        stack.execute(std::move(cmd));
+    }
+
+    // Verify state: [1,1,1,2,2,2,0,0,0,0...]
+    EXPECT_EQ(buffer[0], 1);
+    EXPECT_EQ(buffer[3], 2);
+    EXPECT_EQ(buffer[6], 0);
+
+    // Undo stroke 2
+    stack.undo();
+    EXPECT_EQ(buffer[3], 0);
+    EXPECT_EQ(buffer[0], 1);
+
+    // Undo stroke 1
+    stack.undo();
+    EXPECT_EQ(buffer[0], 0);
+
+    // Redo both
+    stack.redo();
+    EXPECT_EQ(buffer[0], 1);
+    stack.redo();
+    EXPECT_EQ(buffer[3], 2);
+}


### PR DESCRIPTION
Closes #264

## Summary
- Implement `ISegmentationCommand` abstract interface with `execute()`, `undo()`, `description()`, and `memoryUsage()` pure virtual methods
- Implement `SegmentationCommandStack` with deque-based undo/redo, configurable max history (default 20, minimum 1), redo clearing on new command execution, and availability callback notification
- Implement `BrushStrokeCommand` as a diff-based concrete command that stores only changed voxels (`VoxelChange` records) for memory-efficient brush/eraser/fill undo support
- Add 20 unit tests covering stack construction, execute/undo/redo, history limits, edge cases (null command, empty stack), descriptions, availability callback, and BrushStrokeCommand integration with the stack

## Test Plan
- [x] All 20 `segmentation_command_test` tests pass
- [x] SegmentationCommandStack: default construction, custom/minimum history size
- [x] Execute → Undo → Redo cycle verification
- [x] Redo stack cleared on new command after undo
- [x] History limit enforcement (oldest commands trimmed)
- [x] Availability callback fires on state changes
- [x] Edge cases: undo/redo on empty stack, null command ignored
- [x] BrushStrokeCommand: record/undo/redo, skip duplicate labels, memory usage calculation
- [x] BrushStrokeCommand integration with SegmentationCommandStack (multi-stroke undo/redo)