### PR TITLE
feat(ui): add S/P mode toggle for scroll wheel phase navigation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -567,6 +567,7 @@ add_library(dicom_viewer_ui STATIC
     src/ui/widgets/mpr_view_widget.cpp
     src/ui/widgets/dr_viewer.cpp
     src/ui/widgets/phase_slider_widget.cpp
+    src/ui/widgets/sp_mode_toggle.cpp
     src/ui/panels/patient_browser.cpp
     src/ui/panels/tools_panel.cpp
     src/ui/panels/statistics_panel.cpp
@@ -579,6 +580,7 @@ add_library(dicom_viewer_ui STATIC
     include/ui/mpr_view_widget.hpp
     include/ui/dr_viewer.hpp
     include/ui/widgets/phase_slider_widget.hpp
+    include/ui/widgets/sp_mode_toggle.hpp
     include/ui/panels/patient_browser.hpp
     include/ui/panels/tools_panel.hpp
     include/ui/panels/statistics_panel.hpp

--- a/include/ui/mpr_view_widget.hpp
+++ b/include/ui/mpr_view_widget.hpp
@@ -13,6 +13,8 @@
 
 namespace dicom_viewer::ui {
 
+enum class ScrollMode;
+
 /**
  * @brief Composite widget displaying synchronized MPR views with segmentation support
  *
@@ -240,7 +242,12 @@ signals:
     /// Emitted when slab mode changes
     void slabModeChanged(services::SlabMode mode, double thickness);
 
+    /// Emitted when scroll wheel is used in Phase mode
+    void phaseScrollRequested(int delta);
+
 public slots:
+    /// Set the scroll mode (Slice or Phase)
+    void setScrollMode(ScrollMode mode);
     /// Set crosshair position from external source
     void setCrosshairPosition(double x, double y, double z);
 

--- a/include/ui/widgets/phase_slider_widget.hpp
+++ b/include/ui/widgets/phase_slider_widget.hpp
@@ -5,6 +5,8 @@
 
 namespace dicom_viewer::ui {
 
+enum class ScrollMode;
+
 /**
  * @brief Widget for cardiac phase navigation with cine playback
  *
@@ -37,6 +39,11 @@ public:
      * @brief Check if cine playback is active
      */
     [[nodiscard]] bool isPlaying() const;
+
+    /**
+     * @brief Get current scroll mode (Slice or Phase)
+     */
+    [[nodiscard]] ScrollMode scrollMode() const;
 
 public slots:
     /**
@@ -84,6 +91,12 @@ signals:
      * @brief User clicked Stop button
      */
     void stopRequested();
+
+    /**
+     * @brief S/P mode changed by user
+     * @param mode New scroll mode
+     */
+    void scrollModeChanged(ScrollMode mode);
 
 private:
     void setupUI();

--- a/include/ui/widgets/sp_mode_toggle.hpp
+++ b/include/ui/widgets/sp_mode_toggle.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <memory>
+#include <QWidget>
+
+namespace dicom_viewer::ui {
+
+/**
+ * @brief Scroll mode for viewer panels
+ *
+ * Controls whether mouse wheel scrolls through slices (S) or phases (P).
+ */
+enum class ScrollMode {
+    Slice,   ///< Scroll wheel navigates slices (default)
+    Phase    ///< Scroll wheel navigates cardiac phases
+};
+
+/**
+ * @brief Toggle widget for S/P (Slice/Phase) scroll mode
+ *
+ * Provides two mutually exclusive buttons [S] [P] that switch
+ * the scroll wheel behavior between slice navigation and phase
+ * navigation in 4D Flow MRI viewers.
+ *
+ * @trace SRS-FR-048
+ */
+class SPModeToggle : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit SPModeToggle(QWidget* parent = nullptr);
+    ~SPModeToggle() override;
+
+    // Non-copyable
+    SPModeToggle(const SPModeToggle&) = delete;
+    SPModeToggle& operator=(const SPModeToggle&) = delete;
+
+    /**
+     * @brief Get current scroll mode
+     */
+    [[nodiscard]] ScrollMode mode() const;
+
+public slots:
+    /**
+     * @brief Set the scroll mode
+     * @param mode Slice or Phase mode
+     */
+    void setMode(ScrollMode mode);
+
+signals:
+    /**
+     * @brief Emitted when the user changes the scroll mode
+     * @param mode New scroll mode
+     */
+    void modeChanged(ScrollMode mode);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::ui

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -1,6 +1,7 @@
 #include "ui/main_window.hpp"
 #include "ui/viewport_widget.hpp"
 #include "ui/widgets/phase_slider_widget.hpp"
+#include "ui/widgets/sp_mode_toggle.hpp"
 #include "ui/panels/patient_browser.hpp"
 #include "ui/panels/tools_panel.hpp"
 #include "ui/panels/statistics_panel.hpp"
@@ -497,6 +498,16 @@ void MainWindow::setupPhaseControl()
             impl_->cineTimer->stop();
             impl_->phaseSlider->setPlaying(false);
             impl_->temporalNavigator.pause();
+        }
+    });
+
+    // S/P mode toggle → propagate to status bar
+    connect(impl_->phaseSlider, &PhaseSliderWidget::scrollModeChanged,
+            this, [this](ScrollMode mode) {
+        if (mode == ScrollMode::Phase) {
+            impl_->statusLabel->setText(tr("Phase scroll mode"));
+        } else {
+            impl_->statusLabel->setText(tr("Slice scroll mode"));
         }
     });
 }

--- a/src/ui/widgets/mpr_view_widget.cpp
+++ b/src/ui/widgets/mpr_view_widget.cpp
@@ -1,4 +1,5 @@
 #include "ui/mpr_view_widget.hpp"
+#include "ui/widgets/sp_mode_toggle.hpp"
 
 #include <QGridLayout>
 #include <QMouseEvent>
@@ -68,6 +69,9 @@ public:
 
     // Active plane (last interacted)
     services::MPRPlane activePlane = services::MPRPlane::Axial;
+
+    // Scroll mode (Slice or Phase)
+    ScrollMode scrollMode = ScrollMode::Slice;
 
     Impl(MPRViewWidget* w) : widget(w) {
         mprRenderer = std::make_unique<services::MPRRenderer>();
@@ -220,6 +224,13 @@ public:
     }
 
     void handleMouseWheel(services::MPRPlane plane, int delta) {
+        if (scrollMode == ScrollMode::Phase) {
+            // In Phase mode, scroll wheel navigates cardiac phases
+            emit widget->phaseScrollRequested(delta);
+            return;
+        }
+
+        // Default Slice mode: scroll through slices
         mprRenderer->scrollSlice(plane, delta);
 
         // Update overlay for new slice position
@@ -517,6 +528,10 @@ void MPRViewWidget::setCrosshairPosition(double x, double y, double z) {
 
     impl_->updateAllViews();
     emit crosshairPositionChanged(x, y, z);
+}
+
+void MPRViewWidget::setScrollMode(ScrollMode mode) {
+    impl_->scrollMode = mode;
 }
 
 void MPRViewWidget::resizeEvent(QResizeEvent* event) {

--- a/src/ui/widgets/phase_slider_widget.cpp
+++ b/src/ui/widgets/phase_slider_widget.cpp
@@ -1,4 +1,5 @@
 #include "ui/widgets/phase_slider_widget.hpp"
+#include "ui/widgets/sp_mode_toggle.hpp"
 
 #include <QHBoxLayout>
 #include <QLabel>
@@ -15,6 +16,7 @@ public:
     QSpinBox* spinBox = nullptr;
     QPushButton* playStopButton = nullptr;
     QLabel* titleLabel = nullptr;
+    SPModeToggle* spToggle = nullptr;
 
     int phaseCount = 0;
     bool playing = false;
@@ -40,6 +42,11 @@ void PhaseSliderWidget::setupUI()
 
     impl_->titleLabel = new QLabel(tr("Phase:"), this);
     layout->addWidget(impl_->titleLabel);
+
+    // S/P mode toggle
+    impl_->spToggle = new SPModeToggle(this);
+    impl_->spToggle->setToolTip(tr("S = Slice scroll, P = Phase scroll"));
+    layout->addWidget(impl_->spToggle);
 
     impl_->playStopButton = new QPushButton(tr("Play"), this);
     impl_->playStopButton->setFixedWidth(50);
@@ -92,6 +99,10 @@ void PhaseSliderWidget::setupConnections()
             emit playRequested();
         }
     });
+
+    // S/P toggle → forward as scrollModeChanged signal
+    connect(impl_->spToggle, &SPModeToggle::modeChanged,
+            this, &PhaseSliderWidget::scrollModeChanged);
 }
 
 int PhaseSliderWidget::currentPhase() const
@@ -102,6 +113,11 @@ int PhaseSliderWidget::currentPhase() const
 bool PhaseSliderWidget::isPlaying() const
 {
     return impl_->playing;
+}
+
+ScrollMode PhaseSliderWidget::scrollMode() const
+{
+    return impl_->spToggle->mode();
 }
 
 void PhaseSliderWidget::setPhaseCount(int phaseCount)

--- a/src/ui/widgets/sp_mode_toggle.cpp
+++ b/src/ui/widgets/sp_mode_toggle.cpp
@@ -1,0 +1,114 @@
+#include "ui/widgets/sp_mode_toggle.hpp"
+
+#include <QHBoxLayout>
+#include <QPushButton>
+
+namespace dicom_viewer::ui {
+
+class SPModeToggle::Impl {
+public:
+    QPushButton* sliceButton = nullptr;
+    QPushButton* phaseButton = nullptr;
+    ScrollMode currentMode = ScrollMode::Slice;
+    bool updatingFromExternal = false;
+};
+
+SPModeToggle::SPModeToggle(QWidget* parent)
+    : QWidget(parent)
+    , impl_(std::make_unique<Impl>())
+{
+    auto* layout = new QHBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(0);
+
+    impl_->sliceButton = new QPushButton(tr("S"), this);
+    impl_->phaseButton = new QPushButton(tr("P"), this);
+
+    // Fixed size for compact toggle buttons
+    const int buttonSize = 28;
+    impl_->sliceButton->setFixedSize(buttonSize, buttonSize);
+    impl_->phaseButton->setFixedSize(buttonSize, buttonSize);
+
+    impl_->sliceButton->setCheckable(true);
+    impl_->phaseButton->setCheckable(true);
+    impl_->sliceButton->setChecked(true);
+
+    impl_->sliceButton->setToolTip(tr("Slice mode: scroll wheel navigates slices"));
+    impl_->phaseButton->setToolTip(tr("Phase mode: scroll wheel navigates cardiac phases"));
+
+    // Styling for toggle appearance
+    const QString checkedStyle =
+        "QPushButton { font-weight: bold; background-color: #2a82da; "
+        "color: white; border: 1px solid #1a72ca; border-radius: 3px; }"
+        "QPushButton:hover { background-color: #3a92ea; }";
+    const QString uncheckedStyle =
+        "QPushButton { background-color: #404040; color: #aaaaaa; "
+        "border: 1px solid #505050; border-radius: 3px; }"
+        "QPushButton:hover { background-color: #505050; color: white; }";
+
+    auto updateStyles = [this, checkedStyle, uncheckedStyle]() {
+        impl_->sliceButton->setStyleSheet(
+            impl_->currentMode == ScrollMode::Slice ? checkedStyle : uncheckedStyle);
+        impl_->phaseButton->setStyleSheet(
+            impl_->currentMode == ScrollMode::Phase ? checkedStyle : uncheckedStyle);
+    };
+
+    updateStyles();
+
+    connect(impl_->sliceButton, &QPushButton::clicked, this, [this, updateStyles]() {
+        if (impl_->updatingFromExternal) return;
+        impl_->currentMode = ScrollMode::Slice;
+        impl_->sliceButton->setChecked(true);
+        impl_->phaseButton->setChecked(false);
+        updateStyles();
+        emit modeChanged(ScrollMode::Slice);
+    });
+
+    connect(impl_->phaseButton, &QPushButton::clicked, this, [this, updateStyles]() {
+        if (impl_->updatingFromExternal) return;
+        impl_->currentMode = ScrollMode::Phase;
+        impl_->sliceButton->setChecked(false);
+        impl_->phaseButton->setChecked(true);
+        updateStyles();
+        emit modeChanged(ScrollMode::Phase);
+    });
+
+    layout->addWidget(impl_->sliceButton);
+    layout->addWidget(impl_->phaseButton);
+}
+
+SPModeToggle::~SPModeToggle() = default;
+
+ScrollMode SPModeToggle::mode() const
+{
+    return impl_->currentMode;
+}
+
+void SPModeToggle::setMode(ScrollMode mode)
+{
+    if (impl_->currentMode == mode) return;
+
+    impl_->updatingFromExternal = true;
+    impl_->currentMode = mode;
+    impl_->sliceButton->setChecked(mode == ScrollMode::Slice);
+    impl_->phaseButton->setChecked(mode == ScrollMode::Phase);
+
+    // Update styles
+    const QString checkedStyle =
+        "QPushButton { font-weight: bold; background-color: #2a82da; "
+        "color: white; border: 1px solid #1a72ca; border-radius: 3px; }"
+        "QPushButton:hover { background-color: #3a92ea; }";
+    const QString uncheckedStyle =
+        "QPushButton { background-color: #404040; color: #aaaaaa; "
+        "border: 1px solid #505050; border-radius: 3px; }"
+        "QPushButton:hover { background-color: #505050; color: white; }";
+
+    impl_->sliceButton->setStyleSheet(
+        mode == ScrollMode::Slice ? checkedStyle : uncheckedStyle);
+    impl_->phaseButton->setStyleSheet(
+        mode == ScrollMode::Phase ? checkedStyle : uncheckedStyle);
+
+    impl_->updatingFromExternal = false;
+}
+
+} // namespace dicom_viewer::ui

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1332,3 +1332,21 @@ target_include_directories(segmentation_command_test PRIVATE
 )
 
 gtest_discover_tests(segmentation_command_test DISCOVERY_TIMEOUT 60)
+
+# S/P mode toggle and phase slider integration tests
+add_executable(sp_mode_toggle_test
+    unit/sp_mode_toggle_test.cpp
+)
+
+target_link_libraries(sp_mode_toggle_test PRIVATE
+    dicom_viewer_ui
+    Qt6::Test
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(sp_mode_toggle_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(sp_mode_toggle_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/sp_mode_toggle_test.cpp
+++ b/tests/unit/sp_mode_toggle_test.cpp
@@ -1,0 +1,95 @@
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QSignalSpy>
+
+#include "ui/widgets/sp_mode_toggle.hpp"
+#include "ui/widgets/phase_slider_widget.hpp"
+
+using namespace dicom_viewer::ui;
+
+namespace {
+
+// Ensure QApplication exists for widget tests
+class SPModeToggleTestFixture : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() {
+        if (!QApplication::instance()) {
+            static int argc = 1;
+            static char* argv[] = {const_cast<char*>("test")};
+            static QApplication app(argc, argv);
+        }
+    }
+};
+
+} // anonymous namespace
+
+// =============================================================================
+// SPModeToggle — Construction
+// =============================================================================
+
+TEST_F(SPModeToggleTestFixture, DefaultModeIsSlice) {
+    SPModeToggle toggle;
+    EXPECT_EQ(toggle.mode(), ScrollMode::Slice);
+}
+
+// =============================================================================
+// SPModeToggle — Mode switching
+// =============================================================================
+
+TEST_F(SPModeToggleTestFixture, SetModeToPhase) {
+    SPModeToggle toggle;
+    toggle.setMode(ScrollMode::Phase);
+    EXPECT_EQ(toggle.mode(), ScrollMode::Phase);
+}
+
+TEST_F(SPModeToggleTestFixture, SetModeToSlice) {
+    SPModeToggle toggle;
+    toggle.setMode(ScrollMode::Phase);
+    toggle.setMode(ScrollMode::Slice);
+    EXPECT_EQ(toggle.mode(), ScrollMode::Slice);
+}
+
+TEST_F(SPModeToggleTestFixture, SetSameModeNoOp) {
+    SPModeToggle toggle;
+    QSignalSpy spy(&toggle, &SPModeToggle::modeChanged);
+    toggle.setMode(ScrollMode::Slice);  // Already in Slice mode
+    EXPECT_EQ(spy.count(), 0);
+}
+
+// =============================================================================
+// SPModeToggle — Signal emission
+// =============================================================================
+
+TEST_F(SPModeToggleTestFixture, ModeChangedSignalNotEmittedOnExternalSet) {
+    SPModeToggle toggle;
+    QSignalSpy spy(&toggle, &SPModeToggle::modeChanged);
+
+    // setMode is external programmatic change, should NOT emit signal
+    toggle.setMode(ScrollMode::Phase);
+    EXPECT_EQ(spy.count(), 0);
+    EXPECT_EQ(toggle.mode(), ScrollMode::Phase);
+}
+
+// =============================================================================
+// PhaseSliderWidget — S/P mode integration
+// =============================================================================
+
+TEST_F(SPModeToggleTestFixture, PhaseSliderDefaultScrollModeIsSlice) {
+    PhaseSliderWidget slider;
+    EXPECT_EQ(slider.scrollMode(), ScrollMode::Slice);
+}
+
+TEST_F(SPModeToggleTestFixture, PhaseSliderExposesScrollMode) {
+    PhaseSliderWidget slider;
+    // scrollMode should return the current S/P state
+    EXPECT_EQ(slider.scrollMode(), ScrollMode::Slice);
+}
+
+// =============================================================================
+// ScrollMode — Enum values
+// =============================================================================
+
+TEST(ScrollModeEnumTest, DistinctValues) {
+    EXPECT_NE(static_cast<int>(ScrollMode::Slice),
+              static_cast<int>(ScrollMode::Phase));
+}


### PR DESCRIPTION
Closes #261

## Summary
- Add `SPModeToggle` widget with exclusive [S]/[P] buttons for switching scroll wheel behavior between slice navigation and cardiac phase navigation
- Integrate S/P toggle into `PhaseSliderWidget` layout alongside existing play/stop/slider controls
- Modify `MPRViewWidget::handleMouseWheel` to dispatch scroll events based on current S/P mode — emits `phaseScrollRequested(int delta)` signal in Phase mode
- Connect S/P mode change to MainWindow status bar for user feedback

## Test Plan
- [x] All 8 `sp_mode_toggle_test` tests pass
- [x] All 9 existing `phase_slider_widget_test` tests still pass (no regression)
- [x] SPModeToggle: default mode is Slice, mode switching works, external set doesn't emit signal
- [x] PhaseSliderWidget: exposes `scrollMode()` accessor correctly
- [x] ScrollMode enum has distinct Slice/Phase values