### PR TITLE
feat(core): implement ProjectManager with ZIP-based .flo container

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,8 @@ find_library(FFTW3_LIBRARY fftw3 HINTS /opt/homebrew/lib)
 find_library(FFTW3_THREADS_LIBRARY fftw3_threads HINTS /opt/homebrew/lib)
 
 # Core library
+find_package(ZLIB REQUIRED)
+
 add_library(dicom_viewer_core STATIC
     src/core/logging/logging.cpp
     src/core/dicom/dicom_loader.cpp
@@ -328,6 +330,8 @@ add_library(dicom_viewer_core STATIC
     src/core/dicom/transfer_syntax_decoder.cpp
     src/core/image/image_converter.cpp
     src/core/image/hounsfield_converter.cpp
+    src/core/zip_archive.cpp
+    src/core/project_manager.cpp
 )
 
 target_include_directories(dicom_viewer_core PUBLIC
@@ -343,6 +347,8 @@ target_link_libraries(dicom_viewer_core PUBLIC
     ${VTK_LIBRARIES}
     ${FFTW3_LIBRARY}
     ${FFTW3_THREADS_LIBRARY}
+    ZLIB::ZLIB
+    nlohmann_json::nlohmann_json
     spdlog::spdlog
     fmt::fmt
 )

--- a/include/core/project_manager.hpp
+++ b/include/core/project_manager.hpp
@@ -1,0 +1,174 @@
+#pragma once
+
+#include <cstdint>
+#include <expected>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json_fwd.hpp>
+
+namespace dicom_viewer::core {
+
+/**
+ * @brief Error codes for project operations
+ */
+enum class ProjectError {
+    FileOpenFailed,
+    FileWriteFailed,
+    InvalidFormat,
+    ManifestMissing,
+    VersionIncompatible,
+    SerializationError,
+    InternalError
+};
+
+/**
+ * @brief Metadata about a recent project
+ */
+struct RecentProject {
+    std::filesystem::path path;
+    std::string name;
+    std::string timestamp;  ///< ISO 8601 format
+};
+
+/**
+ * @brief Patient information stored in the project
+ */
+struct PatientInfo {
+    std::string patientId;
+    std::string patientName;
+    std::string studyDate;
+    std::string studyDescription;
+    std::string seriesDescription;
+    std::string modality;
+};
+
+/**
+ * @brief Display settings persisted in the project
+ */
+struct DisplaySettings {
+    double windowCenter = 0.0;
+    double windowWidth = 0.0;
+    bool overlayVisible = true;
+    double overlayOpacity = 0.5;
+};
+
+/**
+ * @brief View state persisted in the project
+ */
+struct ViewState {
+    int sliceIndex = 0;
+    int phaseIndex = 0;
+    std::string activeView = "axial";  ///< axial, sagittal, coronal
+};
+
+/**
+ * @brief DICOM source references
+ */
+struct DicomReferences {
+    std::vector<std::filesystem::path> filePaths;
+    std::string seriesInstanceUid;
+    std::string studyInstanceUid;
+};
+
+/**
+ * @brief Manages .flo project file operations
+ *
+ * Provides save, load, and new project functionality using a ZIP-based
+ * container format. The .flo file contains JSON metadata, settings,
+ * and (in future) compressed data fields.
+ *
+ * @trace SRS-FR-050
+ */
+class ProjectManager {
+public:
+    /// Callback when project state changes
+    using StateChangeCallback = std::function<void()>;
+
+    static constexpr const char* kFileExtension = ".flo";
+    static constexpr int kFormatVersion = 1;
+    static constexpr int kMaxRecentProjects = 10;
+
+    ProjectManager();
+    ~ProjectManager();
+
+    // Non-copyable but movable
+    ProjectManager(const ProjectManager&) = delete;
+    ProjectManager& operator=(const ProjectManager&) = delete;
+    ProjectManager(ProjectManager&&) noexcept;
+    ProjectManager& operator=(ProjectManager&&) noexcept;
+
+    /**
+     * @brief Create a new empty project
+     *
+     * Clears all current project state and resets modified flag.
+     */
+    void newProject();
+
+    /**
+     * @brief Save the project to a file
+     *
+     * @param path Output file path (should end with .flo)
+     * @return Success or ProjectError
+     */
+    [[nodiscard]] std::expected<void, ProjectError>
+    saveProject(const std::filesystem::path& path);
+
+    /**
+     * @brief Load a project from a file
+     *
+     * @param path Input file path
+     * @return Success or ProjectError
+     */
+    [[nodiscard]] std::expected<void, ProjectError>
+    loadProject(const std::filesystem::path& path);
+
+    /**
+     * @brief Check if the project has been modified since last save
+     */
+    [[nodiscard]] bool isModified() const noexcept;
+
+    /**
+     * @brief Mark the project as modified
+     */
+    void markModified();
+
+    /**
+     * @brief Get the current project file path
+     * @return Path, or empty if unsaved
+     */
+    [[nodiscard]] std::filesystem::path currentPath() const;
+
+    /**
+     * @brief Get the project name (derived from filename)
+     */
+    [[nodiscard]] std::string projectName() const;
+
+    // -- Data accessors --
+
+    void setPatientInfo(const PatientInfo& info);
+    [[nodiscard]] const PatientInfo& patientInfo() const noexcept;
+
+    void setDicomReferences(const DicomReferences& refs);
+    [[nodiscard]] const DicomReferences& dicomReferences() const noexcept;
+
+    void setDisplaySettings(const DisplaySettings& settings);
+    [[nodiscard]] const DisplaySettings& displaySettings() const noexcept;
+
+    void setViewState(const ViewState& state);
+    [[nodiscard]] const ViewState& viewState() const noexcept;
+
+    // -- State change notification --
+
+    void setStateChangeCallback(StateChangeCallback callback);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::core

--- a/include/core/zip_archive.hpp
+++ b/include/core/zip_archive.hpp
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <cstdint>
+#include <expected>
+#include <filesystem>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace dicom_viewer::core {
+
+/**
+ * @brief Error codes for ZIP operations
+ */
+enum class ZipError {
+    FileOpenFailed,
+    FileWriteFailed,
+    FileReadFailed,
+    CompressionFailed,
+    DecompressionFailed,
+    InvalidArchive,
+    EntryNotFound,
+    InternalError
+};
+
+/**
+ * @brief Lightweight ZIP archive reader/writer using system zlib
+ *
+ * Supports creating ZIP files with multiple text/binary entries and
+ * reading entries from existing ZIP files. Uses DEFLATE compression.
+ *
+ * Usage (write):
+ * @code
+ * ZipArchive zip;
+ * zip.addEntry("manifest.json", manifestJson);
+ * zip.addEntry("data/file.bin", binaryData);
+ * auto result = zip.writeTo("/path/to/output.zip");
+ * @endcode
+ *
+ * Usage (read):
+ * @code
+ * auto result = ZipArchive::readFrom("/path/to/archive.zip");
+ * if (result) {
+ *     auto manifest = result->readEntry("manifest.json");
+ * }
+ * @endcode
+ */
+class ZipArchive {
+public:
+    ZipArchive() = default;
+
+    /**
+     * @brief Add an entry to the archive (for writing)
+     * @param name Entry name (path within the archive)
+     * @param data Entry content
+     */
+    void addEntry(const std::string& name, const std::vector<uint8_t>& data);
+
+    /**
+     * @brief Add a string entry to the archive (for writing)
+     * @param name Entry name
+     * @param content String content (converted to UTF-8 bytes)
+     */
+    void addEntry(const std::string& name, const std::string& content);
+
+    /**
+     * @brief Write the archive to a file
+     * @param path Output file path
+     * @return Success or ZipError
+     */
+    [[nodiscard]] std::expected<void, ZipError>
+    writeTo(const std::filesystem::path& path) const;
+
+    /**
+     * @brief Read an archive from a file
+     * @param path Input file path
+     * @return ZipArchive or ZipError
+     */
+    [[nodiscard]] static std::expected<ZipArchive, ZipError>
+    readFrom(const std::filesystem::path& path);
+
+    /**
+     * @brief Read a specific entry from the archive
+     * @param name Entry name
+     * @return Entry data or ZipError
+     */
+    [[nodiscard]] std::expected<std::vector<uint8_t>, ZipError>
+    readEntry(const std::string& name) const;
+
+    /**
+     * @brief Read a specific entry as a string
+     * @param name Entry name
+     * @return Entry content as string or ZipError
+     */
+    [[nodiscard]] std::expected<std::string, ZipError>
+    readEntryAsString(const std::string& name) const;
+
+    /**
+     * @brief Check if an entry exists
+     */
+    [[nodiscard]] bool hasEntry(const std::string& name) const;
+
+    /**
+     * @brief Get list of entry names
+     */
+    [[nodiscard]] std::vector<std::string> entryNames() const;
+
+private:
+    std::map<std::string, std::vector<uint8_t>> entries_;
+};
+
+} // namespace dicom_viewer::core

--- a/src/core/project_manager.cpp
+++ b/src/core/project_manager.cpp
@@ -1,0 +1,350 @@
+#include "core/project_manager.hpp"
+#include "core/zip_archive.hpp"
+
+#include <chrono>
+
+#include <nlohmann/json.hpp>
+
+namespace dicom_viewer::core {
+
+// =============================================================================
+// JSON serialization helpers
+// =============================================================================
+
+namespace {
+
+nlohmann::json patientInfoToJson(const PatientInfo& info) {
+    return {
+        {"patient_id", info.patientId},
+        {"patient_name", info.patientName},
+        {"study_date", info.studyDate},
+        {"study_description", info.studyDescription},
+        {"series_description", info.seriesDescription},
+        {"modality", info.modality}
+    };
+}
+
+PatientInfo patientInfoFromJson(const nlohmann::json& j) {
+    PatientInfo info;
+    info.patientId = j.value("patient_id", "");
+    info.patientName = j.value("patient_name", "");
+    info.studyDate = j.value("study_date", "");
+    info.studyDescription = j.value("study_description", "");
+    info.seriesDescription = j.value("series_description", "");
+    info.modality = j.value("modality", "");
+    return info;
+}
+
+nlohmann::json dicomRefsToJson(const DicomReferences& refs) {
+    nlohmann::json paths = nlohmann::json::array();
+    for (const auto& p : refs.filePaths) {
+        paths.push_back(p.string());
+    }
+    return {
+        {"file_paths", paths},
+        {"series_instance_uid", refs.seriesInstanceUid},
+        {"study_instance_uid", refs.studyInstanceUid}
+    };
+}
+
+DicomReferences dicomRefsFromJson(const nlohmann::json& j) {
+    DicomReferences refs;
+    if (j.contains("file_paths")) {
+        for (const auto& p : j["file_paths"]) {
+            refs.filePaths.emplace_back(p.get<std::string>());
+        }
+    }
+    refs.seriesInstanceUid = j.value("series_instance_uid", "");
+    refs.studyInstanceUid = j.value("study_instance_uid", "");
+    return refs;
+}
+
+nlohmann::json displaySettingsToJson(const DisplaySettings& s) {
+    return {
+        {"window_center", s.windowCenter},
+        {"window_width", s.windowWidth},
+        {"overlay_visible", s.overlayVisible},
+        {"overlay_opacity", s.overlayOpacity}
+    };
+}
+
+DisplaySettings displaySettingsFromJson(const nlohmann::json& j) {
+    DisplaySettings s;
+    s.windowCenter = j.value("window_center", 0.0);
+    s.windowWidth = j.value("window_width", 0.0);
+    s.overlayVisible = j.value("overlay_visible", true);
+    s.overlayOpacity = j.value("overlay_opacity", 0.5);
+    return s;
+}
+
+nlohmann::json viewStateToJson(const ViewState& v) {
+    return {
+        {"slice_index", v.sliceIndex},
+        {"phase_index", v.phaseIndex},
+        {"active_view", v.activeView}
+    };
+}
+
+ViewState viewStateFromJson(const nlohmann::json& j) {
+    ViewState v;
+    v.sliceIndex = j.value("slice_index", 0);
+    v.phaseIndex = j.value("phase_index", 0);
+    v.activeView = j.value("active_view", "axial");
+    return v;
+}
+
+std::string currentTimestamp() {
+    auto now = std::chrono::system_clock::now();
+    auto time = std::chrono::system_clock::to_time_t(now);
+    std::tm tm{};
+    localtime_r(&time, &tm);
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%S", &tm);
+    return buf;
+}
+
+} // anonymous namespace
+
+// =============================================================================
+// Implementation
+// =============================================================================
+
+class ProjectManager::Impl {
+public:
+    std::filesystem::path currentPath_;
+    bool modified_ = false;
+
+    PatientInfo patientInfo_;
+    DicomReferences dicomRefs_;
+    DisplaySettings displaySettings_;
+    ViewState viewState_;
+
+    StateChangeCallback stateChangeCallback_;
+
+    void notifyStateChange() {
+        if (stateChangeCallback_) {
+            stateChangeCallback_();
+        }
+    }
+};
+
+ProjectManager::ProjectManager()
+    : impl_(std::make_unique<Impl>()) {}
+
+ProjectManager::~ProjectManager() = default;
+
+ProjectManager::ProjectManager(ProjectManager&&) noexcept = default;
+ProjectManager& ProjectManager::operator=(ProjectManager&&) noexcept = default;
+
+void ProjectManager::newProject() {
+    impl_->currentPath_.clear();
+    impl_->modified_ = false;
+    impl_->patientInfo_ = {};
+    impl_->dicomRefs_ = {};
+    impl_->displaySettings_ = {};
+    impl_->viewState_ = {};
+    impl_->notifyStateChange();
+}
+
+std::expected<void, ProjectError>
+ProjectManager::saveProject(const std::filesystem::path& path) {
+    // Build manifest
+    nlohmann::json manifest = {
+        {"format", "dicom_viewer_project"},
+        {"version", kFormatVersion},
+        {"created", currentTimestamp()},
+        {"components", nlohmann::json::array(
+            {"patient", "dicom_refs", "settings/display", "settings/view_state"}
+        )}
+    };
+
+    ZipArchive zip;
+    zip.addEntry("manifest.json", manifest.dump(2));
+    zip.addEntry("patient.json", patientInfoToJson(impl_->patientInfo_).dump(2));
+    zip.addEntry("dicom_refs.json", dicomRefsToJson(impl_->dicomRefs_).dump(2));
+    zip.addEntry("settings/display.json",
+                 displaySettingsToJson(impl_->displaySettings_).dump(2));
+    zip.addEntry("settings/view_state.json",
+                 viewStateToJson(impl_->viewState_).dump(2));
+
+    auto result = zip.writeTo(path);
+    if (!result) {
+        switch (result.error()) {
+            case ZipError::FileOpenFailed:
+                return std::unexpected(ProjectError::FileOpenFailed);
+            case ZipError::FileWriteFailed:
+                return std::unexpected(ProjectError::FileWriteFailed);
+            default:
+                return std::unexpected(ProjectError::InternalError);
+        }
+    }
+
+    impl_->currentPath_ = path;
+    impl_->modified_ = false;
+    impl_->notifyStateChange();
+    return {};
+}
+
+std::expected<void, ProjectError>
+ProjectManager::loadProject(const std::filesystem::path& path) {
+    auto zipResult = ZipArchive::readFrom(path);
+    if (!zipResult) {
+        switch (zipResult.error()) {
+            case ZipError::FileOpenFailed:
+                return std::unexpected(ProjectError::FileOpenFailed);
+            case ZipError::InvalidArchive:
+                return std::unexpected(ProjectError::InvalidFormat);
+            default:
+                return std::unexpected(ProjectError::InternalError);
+        }
+    }
+
+    auto& zip = *zipResult;
+
+    // Validate manifest
+    if (!zip.hasEntry("manifest.json")) {
+        return std::unexpected(ProjectError::ManifestMissing);
+    }
+
+    auto manifestStr = zip.readEntryAsString("manifest.json");
+    if (!manifestStr) {
+        return std::unexpected(ProjectError::InvalidFormat);
+    }
+
+    nlohmann::json manifest;
+    try {
+        manifest = nlohmann::json::parse(*manifestStr);
+    } catch (const nlohmann::json::parse_error&) {
+        return std::unexpected(ProjectError::InvalidFormat);
+    }
+
+    // Check format identifier
+    if (manifest.value("format", "") != "dicom_viewer_project") {
+        return std::unexpected(ProjectError::InvalidFormat);
+    }
+
+    // Check version compatibility
+    int version = manifest.value("version", 0);
+    if (version > kFormatVersion) {
+        return std::unexpected(ProjectError::VersionIncompatible);
+    }
+
+    // Load patient info
+    if (zip.hasEntry("patient.json")) {
+        auto patientStr = zip.readEntryAsString("patient.json");
+        if (patientStr) {
+            try {
+                impl_->patientInfo_ = patientInfoFromJson(
+                    nlohmann::json::parse(*patientStr));
+            } catch (...) {
+                impl_->patientInfo_ = {};
+            }
+        }
+    }
+
+    // Load DICOM references
+    if (zip.hasEntry("dicom_refs.json")) {
+        auto refsStr = zip.readEntryAsString("dicom_refs.json");
+        if (refsStr) {
+            try {
+                impl_->dicomRefs_ = dicomRefsFromJson(
+                    nlohmann::json::parse(*refsStr));
+            } catch (...) {
+                impl_->dicomRefs_ = {};
+            }
+        }
+    }
+
+    // Load display settings
+    if (zip.hasEntry("settings/display.json")) {
+        auto displayStr = zip.readEntryAsString("settings/display.json");
+        if (displayStr) {
+            try {
+                impl_->displaySettings_ = displaySettingsFromJson(
+                    nlohmann::json::parse(*displayStr));
+            } catch (...) {
+                impl_->displaySettings_ = {};
+            }
+        }
+    }
+
+    // Load view state
+    if (zip.hasEntry("settings/view_state.json")) {
+        auto viewStr = zip.readEntryAsString("settings/view_state.json");
+        if (viewStr) {
+            try {
+                impl_->viewState_ = viewStateFromJson(
+                    nlohmann::json::parse(*viewStr));
+            } catch (...) {
+                impl_->viewState_ = {};
+            }
+        }
+    }
+
+    impl_->currentPath_ = path;
+    impl_->modified_ = false;
+    impl_->notifyStateChange();
+    return {};
+}
+
+bool ProjectManager::isModified() const noexcept {
+    return impl_->modified_;
+}
+
+void ProjectManager::markModified() {
+    impl_->modified_ = true;
+    impl_->notifyStateChange();
+}
+
+std::filesystem::path ProjectManager::currentPath() const {
+    return impl_->currentPath_;
+}
+
+std::string ProjectManager::projectName() const {
+    if (impl_->currentPath_.empty()) {
+        return "Untitled";
+    }
+    return impl_->currentPath_.stem().string();
+}
+
+void ProjectManager::setPatientInfo(const PatientInfo& info) {
+    impl_->patientInfo_ = info;
+    impl_->modified_ = true;
+}
+
+const PatientInfo& ProjectManager::patientInfo() const noexcept {
+    return impl_->patientInfo_;
+}
+
+void ProjectManager::setDicomReferences(const DicomReferences& refs) {
+    impl_->dicomRefs_ = refs;
+    impl_->modified_ = true;
+}
+
+const DicomReferences& ProjectManager::dicomReferences() const noexcept {
+    return impl_->dicomRefs_;
+}
+
+void ProjectManager::setDisplaySettings(const DisplaySettings& settings) {
+    impl_->displaySettings_ = settings;
+    impl_->modified_ = true;
+}
+
+const DisplaySettings& ProjectManager::displaySettings() const noexcept {
+    return impl_->displaySettings_;
+}
+
+void ProjectManager::setViewState(const ViewState& state) {
+    impl_->viewState_ = state;
+    impl_->modified_ = true;
+}
+
+const ViewState& ProjectManager::viewState() const noexcept {
+    return impl_->viewState_;
+}
+
+void ProjectManager::setStateChangeCallback(StateChangeCallback callback) {
+    impl_->stateChangeCallback_ = std::move(callback);
+}
+
+} // namespace dicom_viewer::core

--- a/src/core/zip_archive.cpp
+++ b/src/core/zip_archive.cpp
@@ -1,0 +1,366 @@
+#include "core/zip_archive.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <fstream>
+#include <zlib.h>
+
+namespace dicom_viewer::core {
+
+// ZIP format constants
+namespace {
+
+constexpr uint32_t kLocalFileHeaderSignature = 0x04034b50;
+constexpr uint32_t kCentralDirHeaderSignature = 0x02014b50;
+constexpr uint32_t kEndOfCentralDirSignature = 0x06054b50;
+constexpr uint16_t kVersionNeeded = 20;        // 2.0
+constexpr uint16_t kVersionMadeBy = 0x031E;    // Unix, version 3.0
+constexpr uint16_t kCompressionDeflate = 8;
+constexpr uint16_t kCompressionStore = 0;
+
+// Write a little-endian integer to a buffer
+template <typename T>
+void writeLE(std::vector<uint8_t>& buf, T value) {
+    for (size_t i = 0; i < sizeof(T); ++i) {
+        buf.push_back(static_cast<uint8_t>(value & 0xFF));
+        value >>= 8;
+    }
+}
+
+// Read a little-endian integer from a buffer at offset
+template <typename T>
+T readLE(const uint8_t* data, size_t offset) {
+    T result = 0;
+    for (size_t i = 0; i < sizeof(T); ++i) {
+        result |= static_cast<T>(data[offset + i]) << (i * 8);
+    }
+    return result;
+}
+
+// Compress data using zlib deflate
+std::expected<std::vector<uint8_t>, ZipError>
+deflateData(const std::vector<uint8_t>& input) {
+    if (input.empty()) {
+        return std::vector<uint8_t>{};
+    }
+
+    uLong compBound = compressBound(static_cast<uLong>(input.size()));
+    std::vector<uint8_t> output(compBound);
+
+    z_stream stream{};
+    stream.next_in = const_cast<Bytef*>(input.data());
+    stream.avail_in = static_cast<uInt>(input.size());
+    stream.next_out = output.data();
+    stream.avail_out = static_cast<uInt>(output.size());
+
+    // Use raw deflate (-MAX_WBITS) for ZIP compatibility
+    int ret = deflateInit2(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED,
+                           -MAX_WBITS, 8, Z_DEFAULT_STRATEGY);
+    if (ret != Z_OK) {
+        return std::unexpected(ZipError::CompressionFailed);
+    }
+
+    ret = deflate(&stream, Z_FINISH);
+    deflateEnd(&stream);
+
+    if (ret != Z_STREAM_END) {
+        return std::unexpected(ZipError::CompressionFailed);
+    }
+
+    output.resize(stream.total_out);
+    return output;
+}
+
+// Decompress data using zlib inflate
+std::expected<std::vector<uint8_t>, ZipError>
+inflateData(const std::vector<uint8_t>& input, size_t originalSize) {
+    if (input.empty()) {
+        return std::vector<uint8_t>(originalSize, 0);
+    }
+
+    std::vector<uint8_t> output(originalSize);
+
+    z_stream stream{};
+    stream.next_in = const_cast<Bytef*>(input.data());
+    stream.avail_in = static_cast<uInt>(input.size());
+    stream.next_out = output.data();
+    stream.avail_out = static_cast<uInt>(output.size());
+
+    // Use raw inflate (-MAX_WBITS) for ZIP compatibility
+    int ret = inflateInit2(&stream, -MAX_WBITS);
+    if (ret != Z_OK) {
+        return std::unexpected(ZipError::DecompressionFailed);
+    }
+
+    ret = inflate(&stream, Z_FINISH);
+    inflateEnd(&stream);
+
+    if (ret != Z_STREAM_END) {
+        return std::unexpected(ZipError::DecompressionFailed);
+    }
+
+    output.resize(stream.total_out);
+    return output;
+}
+
+} // anonymous namespace
+
+void ZipArchive::addEntry(const std::string& name, const std::vector<uint8_t>& data) {
+    entries_[name] = data;
+}
+
+void ZipArchive::addEntry(const std::string& name, const std::string& content) {
+    entries_[name] = std::vector<uint8_t>(content.begin(), content.end());
+}
+
+std::expected<void, ZipError>
+ZipArchive::writeTo(const std::filesystem::path& path) const {
+    std::ofstream file(path, std::ios::binary);
+    if (!file) {
+        return std::unexpected(ZipError::FileOpenFailed);
+    }
+
+    struct CentralDirEntry {
+        std::string name;
+        uint32_t crc32;
+        uint32_t compressedSize;
+        uint32_t uncompressedSize;
+        uint32_t localHeaderOffset;
+        uint16_t compressionMethod;
+    };
+
+    std::vector<CentralDirEntry> centralDir;
+    std::vector<uint8_t> buffer;
+
+    // Write local file headers and data
+    for (const auto& [name, data] : entries_) {
+        CentralDirEntry entry;
+        entry.name = name;
+        entry.uncompressedSize = static_cast<uint32_t>(data.size());
+        entry.crc32 = static_cast<uint32_t>(
+            ::crc32(0L, data.data(), static_cast<uInt>(data.size())));
+        entry.localHeaderOffset = static_cast<uint32_t>(buffer.size());
+
+        // Compress the data
+        std::vector<uint8_t> compressedData;
+        uint16_t method;
+
+        if (data.size() > 64) {
+            auto compressed = deflateData(data);
+            if (!compressed) {
+                return std::unexpected(compressed.error());
+            }
+            compressedData = std::move(*compressed);
+            method = kCompressionDeflate;
+        } else {
+            // Store small entries uncompressed
+            compressedData = data;
+            method = kCompressionStore;
+        }
+
+        entry.compressedSize = static_cast<uint32_t>(compressedData.size());
+        entry.compressionMethod = method;
+
+        // Local file header
+        writeLE<uint32_t>(buffer, kLocalFileHeaderSignature);
+        writeLE<uint16_t>(buffer, kVersionNeeded);
+        writeLE<uint16_t>(buffer, 0);  // general purpose bit flag
+        writeLE<uint16_t>(buffer, method);
+        writeLE<uint16_t>(buffer, 0);  // last mod time
+        writeLE<uint16_t>(buffer, 0);  // last mod date
+        writeLE<uint32_t>(buffer, entry.crc32);
+        writeLE<uint32_t>(buffer, entry.compressedSize);
+        writeLE<uint32_t>(buffer, entry.uncompressedSize);
+        writeLE<uint16_t>(buffer, static_cast<uint16_t>(name.size()));
+        writeLE<uint16_t>(buffer, 0);  // extra field length
+        buffer.insert(buffer.end(), name.begin(), name.end());
+        buffer.insert(buffer.end(), compressedData.begin(), compressedData.end());
+
+        centralDir.push_back(std::move(entry));
+    }
+
+    // Central directory
+    uint32_t centralDirOffset = static_cast<uint32_t>(buffer.size());
+
+    for (const auto& entry : centralDir) {
+        writeLE<uint32_t>(buffer, kCentralDirHeaderSignature);
+        writeLE<uint16_t>(buffer, kVersionMadeBy);
+        writeLE<uint16_t>(buffer, kVersionNeeded);
+        writeLE<uint16_t>(buffer, 0);  // general purpose bit flag
+        writeLE<uint16_t>(buffer, entry.compressionMethod);
+        writeLE<uint16_t>(buffer, 0);  // last mod time
+        writeLE<uint16_t>(buffer, 0);  // last mod date
+        writeLE<uint32_t>(buffer, entry.crc32);
+        writeLE<uint32_t>(buffer, entry.compressedSize);
+        writeLE<uint32_t>(buffer, entry.uncompressedSize);
+        writeLE<uint16_t>(buffer, static_cast<uint16_t>(entry.name.size()));
+        writeLE<uint16_t>(buffer, 0);  // extra field length
+        writeLE<uint16_t>(buffer, 0);  // file comment length
+        writeLE<uint16_t>(buffer, 0);  // disk number start
+        writeLE<uint16_t>(buffer, 0);  // internal file attributes
+        writeLE<uint32_t>(buffer, 0);  // external file attributes
+        writeLE<uint32_t>(buffer, entry.localHeaderOffset);
+        buffer.insert(buffer.end(), entry.name.begin(), entry.name.end());
+    }
+
+    uint32_t centralDirSize = static_cast<uint32_t>(buffer.size()) - centralDirOffset;
+
+    // End of central directory
+    writeLE<uint32_t>(buffer, kEndOfCentralDirSignature);
+    writeLE<uint16_t>(buffer, 0);  // disk number
+    writeLE<uint16_t>(buffer, 0);  // disk number with central dir
+    writeLE<uint16_t>(buffer, static_cast<uint16_t>(centralDir.size()));
+    writeLE<uint16_t>(buffer, static_cast<uint16_t>(centralDir.size()));
+    writeLE<uint32_t>(buffer, centralDirSize);
+    writeLE<uint32_t>(buffer, centralDirOffset);
+    writeLE<uint16_t>(buffer, 0);  // comment length
+
+    file.write(reinterpret_cast<const char*>(buffer.data()),
+               static_cast<std::streamsize>(buffer.size()));
+
+    if (!file) {
+        return std::unexpected(ZipError::FileWriteFailed);
+    }
+
+    return {};
+}
+
+std::expected<ZipArchive, ZipError>
+ZipArchive::readFrom(const std::filesystem::path& path) {
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    if (!file) {
+        return std::unexpected(ZipError::FileOpenFailed);
+    }
+
+    auto fileSize = file.tellg();
+    file.seekg(0);
+
+    std::vector<uint8_t> data(static_cast<size_t>(fileSize));
+    file.read(reinterpret_cast<char*>(data.data()),
+              static_cast<std::streamsize>(fileSize));
+
+    if (!file) {
+        return std::unexpected(ZipError::FileReadFailed);
+    }
+
+    // Minimum ZIP file size: end of central directory = 22 bytes
+    if (data.size() < 22) {
+        return std::unexpected(ZipError::InvalidArchive);
+    }
+
+    // Find end of central directory record (search backwards)
+    size_t eocdOffset = 0;
+    bool found = false;
+    for (size_t i = data.size() - 22; i > 0; --i) {
+        if (readLE<uint32_t>(data.data(), i) == kEndOfCentralDirSignature) {
+            eocdOffset = i;
+            found = true;
+            break;
+        }
+    }
+
+    if (!found) {
+        return std::unexpected(ZipError::InvalidArchive);
+    }
+
+    uint16_t entryCount = readLE<uint16_t>(data.data(), eocdOffset + 10);
+    uint32_t centralDirOffset = readLE<uint32_t>(data.data(), eocdOffset + 16);
+
+    ZipArchive archive;
+    size_t offset = centralDirOffset;
+
+    for (uint16_t i = 0; i < entryCount; ++i) {
+        if (offset + 46 > data.size()) {
+            return std::unexpected(ZipError::InvalidArchive);
+        }
+
+        if (readLE<uint32_t>(data.data(), offset) != kCentralDirHeaderSignature) {
+            return std::unexpected(ZipError::InvalidArchive);
+        }
+
+        uint16_t method = readLE<uint16_t>(data.data(), offset + 10);
+        uint32_t crc = readLE<uint32_t>(data.data(), offset + 16);
+        uint32_t compSize = readLE<uint32_t>(data.data(), offset + 20);
+        uint32_t uncompSize = readLE<uint32_t>(data.data(), offset + 24);
+        uint16_t nameLen = readLE<uint16_t>(data.data(), offset + 28);
+        uint16_t extraLen = readLE<uint16_t>(data.data(), offset + 30);
+        uint16_t commentLen = readLE<uint16_t>(data.data(), offset + 32);
+        uint32_t localOffset = readLE<uint32_t>(data.data(), offset + 42);
+
+        std::string name(data.begin() + static_cast<ptrdiff_t>(offset + 46),
+                         data.begin() + static_cast<ptrdiff_t>(offset + 46 + nameLen));
+
+        // Read compressed data from local file header
+        size_t localDataStart = localOffset + 30;
+        uint16_t localNameLen = readLE<uint16_t>(data.data(), localOffset + 26);
+        uint16_t localExtraLen = readLE<uint16_t>(data.data(), localOffset + 28);
+        localDataStart += localNameLen + localExtraLen;
+
+        if (localDataStart + compSize > data.size()) {
+            return std::unexpected(ZipError::InvalidArchive);
+        }
+
+        std::vector<uint8_t> compressedData(
+            data.begin() + static_cast<ptrdiff_t>(localDataStart),
+            data.begin() + static_cast<ptrdiff_t>(localDataStart + compSize));
+
+        // Decompress
+        if (method == kCompressionStore) {
+            archive.entries_[name] = std::move(compressedData);
+        } else if (method == kCompressionDeflate) {
+            auto decompressed = inflateData(compressedData, uncompSize);
+            if (!decompressed) {
+                return std::unexpected(decompressed.error());
+            }
+
+            // Verify CRC32
+            uint32_t actualCrc = static_cast<uint32_t>(
+                ::crc32(0L, decompressed->data(),
+                        static_cast<uInt>(decompressed->size())));
+            if (actualCrc != crc) {
+                return std::unexpected(ZipError::InvalidArchive);
+            }
+
+            archive.entries_[name] = std::move(*decompressed);
+        } else {
+            return std::unexpected(ZipError::InvalidArchive);
+        }
+
+        offset += 46 + nameLen + extraLen + commentLen;
+    }
+
+    return archive;
+}
+
+std::expected<std::vector<uint8_t>, ZipError>
+ZipArchive::readEntry(const std::string& name) const {
+    auto it = entries_.find(name);
+    if (it == entries_.end()) {
+        return std::unexpected(ZipError::EntryNotFound);
+    }
+    return it->second;
+}
+
+std::expected<std::string, ZipError>
+ZipArchive::readEntryAsString(const std::string& name) const {
+    auto result = readEntry(name);
+    if (!result) {
+        return std::unexpected(result.error());
+    }
+    return std::string(result->begin(), result->end());
+}
+
+bool ZipArchive::hasEntry(const std::string& name) const {
+    return entries_.contains(name);
+}
+
+std::vector<std::string> ZipArchive::entryNames() const {
+    std::vector<std::string> names;
+    names.reserve(entries_.size());
+    for (const auto& [name, _] : entries_) {
+        names.push_back(name);
+    }
+    return names;
+}
+
+} // namespace dicom_viewer::core

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1367,3 +1367,20 @@ target_include_directories(controller_undo_redo_test PRIVATE
 )
 
 gtest_discover_tests(controller_undo_redo_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for ProjectManager and ZipArchive
+add_executable(project_manager_test
+    unit/project_manager_test.cpp
+)
+
+target_link_libraries(project_manager_test PRIVATE
+    dicom_viewer_core
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(project_manager_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(project_manager_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/project_manager_test.cpp
+++ b/tests/unit/project_manager_test.cpp
@@ -1,0 +1,368 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+
+#include "core/project_manager.hpp"
+#include "core/zip_archive.hpp"
+
+using namespace dicom_viewer::core;
+namespace fs = std::filesystem;
+
+namespace {
+
+/// Helper to create a temp file path that is cleaned up after test
+class TempFile {
+public:
+    TempFile(const std::string& name)
+        : path_(fs::temp_directory_path() / ("dicom_viewer_test_" + name)) {}
+    ~TempFile() { fs::remove(path_); }
+    const fs::path& path() const { return path_; }
+private:
+    fs::path path_;
+};
+
+} // anonymous namespace
+
+// =============================================================================
+// ZipArchive — Write and Read roundtrip
+// =============================================================================
+
+TEST(ZipArchiveTest, WriteAndReadRoundtrip) {
+    TempFile tmp("test.zip");
+
+    // Write
+    ZipArchive writer;
+    writer.addEntry("hello.txt", "Hello, World!");
+    writer.addEntry("data/nested.json", R"({"key": "value"})");
+    auto writeResult = writer.writeTo(tmp.path());
+    ASSERT_TRUE(writeResult.has_value()) << "Write failed";
+
+    // Read
+    auto readResult = ZipArchive::readFrom(tmp.path());
+    ASSERT_TRUE(readResult.has_value()) << "Read failed";
+
+    auto& reader = *readResult;
+    EXPECT_TRUE(reader.hasEntry("hello.txt"));
+    EXPECT_TRUE(reader.hasEntry("data/nested.json"));
+    EXPECT_FALSE(reader.hasEntry("nonexistent.txt"));
+
+    auto hello = reader.readEntryAsString("hello.txt");
+    ASSERT_TRUE(hello.has_value());
+    EXPECT_EQ(*hello, "Hello, World!");
+
+    auto nested = reader.readEntryAsString("data/nested.json");
+    ASSERT_TRUE(nested.has_value());
+    EXPECT_EQ(*nested, R"({"key": "value"})");
+}
+
+TEST(ZipArchiveTest, EntryNames) {
+    ZipArchive zip;
+    zip.addEntry("a.txt", "A");
+    zip.addEntry("b.txt", "B");
+    zip.addEntry("c/d.txt", "D");
+
+    auto names = zip.entryNames();
+    EXPECT_EQ(names.size(), 3);
+}
+
+TEST(ZipArchiveTest, ReadFromNonexistentFile) {
+    auto result = ZipArchive::readFrom("/nonexistent/path/file.zip");
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ZipError::FileOpenFailed);
+}
+
+TEST(ZipArchiveTest, ReadEntryNotFound) {
+    ZipArchive zip;
+    zip.addEntry("exists.txt", "data");
+    auto result = zip.readEntry("missing.txt");
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ZipError::EntryNotFound);
+}
+
+TEST(ZipArchiveTest, LargeDataCompression) {
+    TempFile tmp("large.zip");
+
+    // Create large repetitive data that compresses well
+    std::string largeData(100000, 'A');
+    for (size_t i = 0; i < largeData.size(); i += 100) {
+        largeData[i] = static_cast<char>('A' + (i % 26));
+    }
+
+    ZipArchive writer;
+    writer.addEntry("large.bin", largeData);
+    auto writeResult = writer.writeTo(tmp.path());
+    ASSERT_TRUE(writeResult.has_value());
+
+    // Verify file is smaller than original data
+    auto fileSize = fs::file_size(tmp.path());
+    EXPECT_LT(fileSize, largeData.size());
+
+    // Verify roundtrip
+    auto readResult = ZipArchive::readFrom(tmp.path());
+    ASSERT_TRUE(readResult.has_value());
+
+    auto content = readResult->readEntryAsString("large.bin");
+    ASSERT_TRUE(content.has_value());
+    EXPECT_EQ(*content, largeData);
+}
+
+TEST(ZipArchiveTest, InvalidZipFile) {
+    TempFile tmp("invalid.zip");
+
+    // Write garbage data
+    std::ofstream out(tmp.path(), std::ios::binary);
+    out << "This is not a ZIP file";
+    out.close();
+
+    auto result = ZipArchive::readFrom(tmp.path());
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ZipError::InvalidArchive);
+}
+
+// =============================================================================
+// ProjectManager — Construction
+// =============================================================================
+
+TEST(ProjectManagerTest, DefaultState) {
+    ProjectManager pm;
+    EXPECT_FALSE(pm.isModified());
+    EXPECT_TRUE(pm.currentPath().empty());
+    EXPECT_EQ(pm.projectName(), "Untitled");
+}
+
+// =============================================================================
+// ProjectManager — New project
+// =============================================================================
+
+TEST(ProjectManagerTest, NewProjectResetsState) {
+    ProjectManager pm;
+    pm.setPatientInfo(PatientInfo{"ID1", "Patient", "", "", "", "MR"});
+    pm.markModified();
+
+    pm.newProject();
+
+    EXPECT_FALSE(pm.isModified());
+    EXPECT_TRUE(pm.currentPath().empty());
+    EXPECT_EQ(pm.projectName(), "Untitled");
+    EXPECT_TRUE(pm.patientInfo().patientId.empty());
+}
+
+// =============================================================================
+// ProjectManager — Save and Load roundtrip
+// =============================================================================
+
+TEST(ProjectManagerTest, SaveLoadRoundtrip) {
+    TempFile tmp("project.flo");
+
+    // Set up project state
+    ProjectManager saver;
+    saver.setPatientInfo(PatientInfo{
+        "PAT001", "John Doe", "20240101",
+        "4D Flow MRI Study", "Phase Contrast", "MR"
+    });
+    saver.setDicomReferences(DicomReferences{
+        {"/path/to/dicom/001.dcm", "/path/to/dicom/002.dcm"},
+        "1.2.3.4.5.6.7.8.9",
+        "1.2.3.4.5.6.7.8"
+    });
+    saver.setDisplaySettings(DisplaySettings{400.0, 1500.0, true, 0.7});
+    saver.setViewState(ViewState{42, 3, "coronal"});
+
+    // Save
+    auto saveResult = saver.saveProject(tmp.path());
+    ASSERT_TRUE(saveResult.has_value()) << "Save failed";
+    EXPECT_FALSE(saver.isModified());
+    EXPECT_EQ(saver.currentPath(), tmp.path());
+
+    // Load into new ProjectManager
+    ProjectManager loader;
+    auto loadResult = loader.loadProject(tmp.path());
+    ASSERT_TRUE(loadResult.has_value()) << "Load failed";
+
+    // Verify patient info
+    EXPECT_EQ(loader.patientInfo().patientId, "PAT001");
+    EXPECT_EQ(loader.patientInfo().patientName, "John Doe");
+    EXPECT_EQ(loader.patientInfo().studyDate, "20240101");
+    EXPECT_EQ(loader.patientInfo().modality, "MR");
+
+    // Verify DICOM references
+    EXPECT_EQ(loader.dicomReferences().filePaths.size(), 2);
+    EXPECT_EQ(loader.dicomReferences().seriesInstanceUid, "1.2.3.4.5.6.7.8.9");
+
+    // Verify display settings
+    EXPECT_DOUBLE_EQ(loader.displaySettings().windowCenter, 400.0);
+    EXPECT_DOUBLE_EQ(loader.displaySettings().windowWidth, 1500.0);
+    EXPECT_TRUE(loader.displaySettings().overlayVisible);
+    EXPECT_DOUBLE_EQ(loader.displaySettings().overlayOpacity, 0.7);
+
+    // Verify view state
+    EXPECT_EQ(loader.viewState().sliceIndex, 42);
+    EXPECT_EQ(loader.viewState().phaseIndex, 3);
+    EXPECT_EQ(loader.viewState().activeView, "coronal");
+
+    // Verify state after load
+    EXPECT_FALSE(loader.isModified());
+    EXPECT_EQ(loader.currentPath(), tmp.path());
+}
+
+// =============================================================================
+// ProjectManager — Project name
+// =============================================================================
+
+TEST(ProjectManagerTest, ProjectNameFromPath) {
+    TempFile tmp("my_study.flo");
+
+    ProjectManager pm;
+    pm.setPatientInfo(PatientInfo{"ID1", "Test", "", "", "", "CT"});
+    auto result = pm.saveProject(tmp.path());
+    ASSERT_TRUE(result.has_value());
+
+    EXPECT_EQ(pm.projectName(), "dicom_viewer_test_my_study");
+}
+
+// =============================================================================
+// ProjectManager — Modified tracking
+// =============================================================================
+
+TEST(ProjectManagerTest, ModifiedTracking) {
+    ProjectManager pm;
+    EXPECT_FALSE(pm.isModified());
+
+    pm.setPatientInfo(PatientInfo{"ID1", "Test", "", "", "", "CT"});
+    EXPECT_TRUE(pm.isModified());
+
+    pm.newProject();
+    EXPECT_FALSE(pm.isModified());
+
+    pm.setDisplaySettings(DisplaySettings{100.0, 200.0, false, 0.5});
+    EXPECT_TRUE(pm.isModified());
+
+    pm.markModified();
+    EXPECT_TRUE(pm.isModified());
+}
+
+TEST(ProjectManagerTest, SaveClearsModifiedFlag) {
+    TempFile tmp("modified_test.flo");
+
+    ProjectManager pm;
+    pm.setPatientInfo(PatientInfo{"ID1", "Test", "", "", "", "CT"});
+    EXPECT_TRUE(pm.isModified());
+
+    auto result = pm.saveProject(tmp.path());
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FALSE(pm.isModified());
+}
+
+// =============================================================================
+// ProjectManager — Error handling
+// =============================================================================
+
+TEST(ProjectManagerTest, LoadNonexistentFile) {
+    ProjectManager pm;
+    auto result = pm.loadProject("/nonexistent/path/project.flo");
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ProjectError::FileOpenFailed);
+}
+
+TEST(ProjectManagerTest, LoadInvalidFile) {
+    TempFile tmp("invalid.flo");
+
+    // Write garbage
+    std::ofstream out(tmp.path(), std::ios::binary);
+    out << "Not a ZIP file at all";
+    out.close();
+
+    ProjectManager pm;
+    auto result = pm.loadProject(tmp.path());
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ProjectError::InvalidFormat);
+}
+
+TEST(ProjectManagerTest, LoadMissingManifest) {
+    TempFile tmp("no_manifest.flo");
+
+    // Write valid ZIP but without manifest.json
+    ZipArchive zip;
+    zip.addEntry("patient.json", "{}");
+    zip.writeTo(tmp.path());
+
+    ProjectManager pm;
+    auto result = pm.loadProject(tmp.path());
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ProjectError::ManifestMissing);
+}
+
+TEST(ProjectManagerTest, LoadInvalidManifestFormat) {
+    TempFile tmp("bad_manifest.flo");
+
+    // Write valid ZIP with wrong format identifier
+    ZipArchive zip;
+    zip.addEntry("manifest.json", R"({"format": "wrong_format", "version": 1})");
+    zip.writeTo(tmp.path());
+
+    ProjectManager pm;
+    auto result = pm.loadProject(tmp.path());
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ProjectError::InvalidFormat);
+}
+
+TEST(ProjectManagerTest, LoadIncompatibleVersion) {
+    TempFile tmp("future_version.flo");
+
+    // Write valid ZIP with future version
+    ZipArchive zip;
+    zip.addEntry("manifest.json",
+        R"({"format": "dicom_viewer_project", "version": 999})");
+    zip.writeTo(tmp.path());
+
+    ProjectManager pm;
+    auto result = pm.loadProject(tmp.path());
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ProjectError::VersionIncompatible);
+}
+
+// =============================================================================
+// ProjectManager — State change callback
+// =============================================================================
+
+TEST(ProjectManagerTest, StateChangeCallbackNotified) {
+    ProjectManager pm;
+    int callCount = 0;
+    pm.setStateChangeCallback([&]() { ++callCount; });
+
+    pm.newProject();
+    EXPECT_EQ(callCount, 1);
+
+    pm.markModified();
+    EXPECT_EQ(callCount, 2);
+}
+
+// =============================================================================
+// ProjectManager — Flo file is valid ZIP
+// =============================================================================
+
+TEST(ProjectManagerTest, FloFileIsValidZip) {
+    TempFile tmp("valid_zip.flo");
+
+    ProjectManager pm;
+    pm.setPatientInfo(PatientInfo{"PAT", "Test", "", "", "", "MR"});
+    auto result = pm.saveProject(tmp.path());
+    ASSERT_TRUE(result.has_value());
+
+    // Verify the file can be read as a raw ZIP archive
+    auto zipResult = ZipArchive::readFrom(tmp.path());
+    ASSERT_TRUE(zipResult.has_value());
+
+    auto& zip = *zipResult;
+    EXPECT_TRUE(zip.hasEntry("manifest.json"));
+    EXPECT_TRUE(zip.hasEntry("patient.json"));
+    EXPECT_TRUE(zip.hasEntry("dicom_refs.json"));
+    EXPECT_TRUE(zip.hasEntry("settings/display.json"));
+    EXPECT_TRUE(zip.hasEntry("settings/view_state.json"));
+
+    // Verify manifest JSON is valid
+    auto manifestStr = zip.readEntryAsString("manifest.json");
+    ASSERT_TRUE(manifestStr.has_value());
+    EXPECT_NE(manifestStr->find("dicom_viewer_project"), std::string::npos);
+}


### PR DESCRIPTION
## Summary
- Add `ZipArchive` utility class for ZIP read/write using system zlib (DEFLATE compression)
- Add `ProjectManager` class with `newProject()`, `saveProject()`, `loadProject()` API
- Implement `.flo` container format: ZIP archive containing JSON entries for manifest, patient info, DICOM references, display settings, and view state
- Manifest schema with version field for forward compatibility
- `isModified()` state tracking with `StateChangeCallback` notification
- Add `ZLIB::ZLIB` and `nlohmann_json` dependencies to `dicom_viewer_core`

Closes #272

## Test Plan
- [x] 6 ZipArchive tests: write/read roundtrip, entry listing, error handling, large data compression, invalid file detection
- [x] 13 ProjectManager tests: default state, new project reset, save/load roundtrip (patient info, DICOM refs, display settings, view state), project naming, modified tracking, error handling (nonexistent file, invalid file, missing manifest, wrong format, future version), state change callback, .flo file ZIP validity
- [x] 16 existing `series_assembly_test` pass (no regression)