### PR TITLE
feat(rendering): implement HemodynamicOverlayRenderer core with velocity overlay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,6 +369,7 @@ add_library(render_service STATIC
     src/services/render/mpr_renderer.cpp
     src/services/render/transfer_function.cpp
     src/services/render/oblique_reslice_renderer.cpp
+    src/services/render/hemodynamic_overlay_renderer.cpp
 )
 
 target_link_libraries(render_service PUBLIC

--- a/include/services/render/hemodynamic_overlay_renderer.hpp
+++ b/include/services/render/hemodynamic_overlay_renderer.hpp
@@ -1,0 +1,223 @@
+#pragma once
+
+#include <array>
+#include <expected>
+#include <functional>
+#include <memory>
+#include <string>
+
+#include <vtkSmartPointer.h>
+
+class vtkImageData;
+class vtkRenderer;
+class vtkLookupTable;
+
+namespace dicom_viewer::services {
+
+enum class MPRPlane;
+
+/**
+ * @brief Error codes for hemodynamic overlay operations
+ */
+enum class OverlayError {
+    NoScalarField,
+    InvalidSliceIndex,
+    InvalidPlane,
+    ResliceFailed,
+    InternalError
+};
+
+/**
+ * @brief Type of hemodynamic overlay to render
+ */
+enum class OverlayType {
+    VelocityMagnitude,  ///< Speed = sqrt(Vx^2 + Vy^2 + Vz^2) in cm/s
+    VelocityX,          ///< X component of velocity
+    VelocityY,          ///< Y component of velocity
+    VelocityZ           ///< Z component of velocity
+};
+
+/**
+ * @brief Built-in colormap presets for hemodynamic overlays
+ */
+enum class ColormapPreset {
+    Jet,           ///< Blue-cyan-green-yellow-red (default for magnitude)
+    HotMetal,      ///< Black-red-yellow-white
+    CoolWarm,      ///< Blue-white-red (diverging, for signed data)
+    Viridis        ///< Perceptually uniform sequential
+};
+
+/**
+ * @brief 2D hemodynamic overlay renderer for MPR views
+ *
+ * Extracts scalar fields (velocity magnitude, components) from 3D
+ * vtkImageData volumes and renders them as color-mapped, alpha-blended
+ * overlays on top of anatomical MPR slices.
+ *
+ * Pipeline:
+ * @code
+ *   3D vtkImageData (scalar field)
+ *     → vtkImageReslice (extract 2D slice matching MPR plane/position)
+ *     → vtkLookupTable (colormap: scalar → RGBA)
+ *     → vtkImageMapToColors
+ *     → vtkImageActor (alpha-blended overlay)
+ * @endcode
+ *
+ * @trace SRS-FR-046
+ */
+class HemodynamicOverlayRenderer {
+public:
+    HemodynamicOverlayRenderer();
+    ~HemodynamicOverlayRenderer();
+
+    // Non-copyable, movable
+    HemodynamicOverlayRenderer(const HemodynamicOverlayRenderer&) = delete;
+    HemodynamicOverlayRenderer& operator=(const HemodynamicOverlayRenderer&) = delete;
+    HemodynamicOverlayRenderer(HemodynamicOverlayRenderer&&) noexcept;
+    HemodynamicOverlayRenderer& operator=(HemodynamicOverlayRenderer&&) noexcept;
+
+    // ==================== Input Data ====================
+
+    /**
+     * @brief Set the 3D scalar field for overlay rendering
+     *
+     * The scalar field should contain the hemodynamic parameter to visualize
+     * (e.g., velocity magnitude computed from VectorImage3D).
+     *
+     * @param scalarField 3D vtkImageData with scalar values
+     */
+    void setScalarField(vtkSmartPointer<vtkImageData> scalarField);
+
+    /**
+     * @brief Check if a scalar field has been set
+     */
+    [[nodiscard]] bool hasScalarField() const noexcept;
+
+    // ==================== Overlay Settings ====================
+
+    /**
+     * @brief Set overlay type
+     * @param type Overlay type (determines how the field is interpreted)
+     */
+    void setOverlayType(OverlayType type);
+
+    /**
+     * @brief Get current overlay type
+     */
+    [[nodiscard]] OverlayType overlayType() const noexcept;
+
+    /**
+     * @brief Set overlay visibility
+     * @param visible True to show overlay
+     */
+    void setVisible(bool visible);
+
+    /**
+     * @brief Check if overlay is visible
+     */
+    [[nodiscard]] bool isVisible() const noexcept;
+
+    /**
+     * @brief Set overlay opacity for alpha blending
+     * @param opacity Opacity value (0.0 = transparent, 1.0 = opaque)
+     */
+    void setOpacity(double opacity);
+
+    /**
+     * @brief Get overlay opacity
+     */
+    [[nodiscard]] double opacity() const noexcept;
+
+    // ==================== Colormap ====================
+
+    /**
+     * @brief Apply a colormap preset
+     * @param preset Colormap preset to use
+     */
+    void setColormapPreset(ColormapPreset preset);
+
+    /**
+     * @brief Get current colormap preset
+     */
+    [[nodiscard]] ColormapPreset colormapPreset() const noexcept;
+
+    /**
+     * @brief Set scalar range for colormap mapping
+     * @param minVal Minimum scalar value (mapped to colormap start)
+     * @param maxVal Maximum scalar value (mapped to colormap end)
+     */
+    void setScalarRange(double minVal, double maxVal);
+
+    /**
+     * @brief Get current scalar range
+     * @return {min, max}
+     */
+    [[nodiscard]] std::pair<double, double> scalarRange() const noexcept;
+
+    /**
+     * @brief Get the VTK lookup table used for colormapping
+     * @return Configured lookup table
+     */
+    [[nodiscard]] vtkSmartPointer<vtkLookupTable> getLookupTable() const;
+
+    // ==================== Rendering ====================
+
+    /**
+     * @brief Set VTK renderers for the three MPR planes
+     * @param axial Renderer for axial plane
+     * @param coronal Renderer for coronal plane
+     * @param sagittal Renderer for sagittal plane
+     */
+    void setRenderers(vtkSmartPointer<vtkRenderer> axial,
+                      vtkSmartPointer<vtkRenderer> coronal,
+                      vtkSmartPointer<vtkRenderer> sagittal);
+
+    /**
+     * @brief Set slice position for a specific plane
+     * @param plane MPR plane
+     * @param worldPosition Slice position in world coordinates (mm)
+     * @return Success or OverlayError
+     */
+    [[nodiscard]] std::expected<void, OverlayError>
+    setSlicePosition(MPRPlane plane, double worldPosition);
+
+    /**
+     * @brief Update rendering for all planes
+     */
+    void update();
+
+    /**
+     * @brief Update rendering for a specific plane
+     * @param plane MPR plane to update
+     */
+    void updatePlane(MPRPlane plane);
+
+    // ==================== Utility ====================
+
+    /**
+     * @brief Compute velocity magnitude from a 3-component velocity field
+     *
+     * Creates a scalar vtkImageData where each voxel = sqrt(Vx^2 + Vy^2 + Vz^2).
+     *
+     * @param velocityField 3D vtkImageData with 3-component vectors
+     * @return Scalar magnitude image, or OverlayError
+     */
+    [[nodiscard]] static std::expected<vtkSmartPointer<vtkImageData>, OverlayError>
+    computeVelocityMagnitude(vtkSmartPointer<vtkImageData> velocityField);
+
+    /**
+     * @brief Extract a single component from a multi-component field
+     *
+     * @param velocityField 3D vtkImageData with 3-component vectors
+     * @param component Component index (0=X, 1=Y, 2=Z)
+     * @return Scalar component image, or OverlayError
+     */
+    [[nodiscard]] static std::expected<vtkSmartPointer<vtkImageData>, OverlayError>
+    extractComponent(vtkSmartPointer<vtkImageData> velocityField, int component);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::services

--- a/src/services/render/hemodynamic_overlay_renderer.cpp
+++ b/src/services/render/hemodynamic_overlay_renderer.cpp
@@ -1,0 +1,478 @@
+#include "services/render/hemodynamic_overlay_renderer.hpp"
+#include "services/mpr_renderer.hpp"
+
+#include <vtkImageData.h>
+#include <vtkImageReslice.h>
+#include <vtkImageActor.h>
+#include <vtkImageMapper3D.h>
+#include <vtkImageMapToColors.h>
+#include <vtkLookupTable.h>
+#include <vtkRenderer.h>
+#include <vtkMatrix4x4.h>
+#include <vtkPointData.h>
+#include <vtkFloatArray.h>
+#include <vtkMath.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace dicom_viewer::services {
+
+// =============================================================================
+// Colormap builders
+// =============================================================================
+
+namespace {
+
+void buildJetColormap(vtkLookupTable* lut) {
+    lut->SetNumberOfTableValues(256);
+    lut->SetHueRange(0.667, 0.0);  // Blue to Red
+    lut->SetSaturationRange(1.0, 1.0);
+    lut->SetValueRange(1.0, 1.0);
+    lut->Build();
+}
+
+void buildHotMetalColormap(vtkLookupTable* lut) {
+    lut->SetNumberOfTableValues(256);
+    for (int i = 0; i < 256; ++i) {
+        double t = static_cast<double>(i) / 255.0;
+        double r = std::clamp(t * 3.0, 0.0, 1.0);
+        double g = std::clamp((t - 0.333) * 3.0, 0.0, 1.0);
+        double b = std::clamp((t - 0.667) * 3.0, 0.0, 1.0);
+        lut->SetTableValue(i, r, g, b, 1.0);
+    }
+    lut->Build();
+}
+
+void buildCoolWarmColormap(vtkLookupTable* lut) {
+    lut->SetNumberOfTableValues(256);
+    for (int i = 0; i < 256; ++i) {
+        double t = static_cast<double>(i) / 255.0;
+        // Cool (blue) to warm (red) through white at midpoint
+        double r, g, b;
+        if (t < 0.5) {
+            double s = t * 2.0;
+            r = s;
+            g = s;
+            b = 1.0;
+        } else {
+            double s = (t - 0.5) * 2.0;
+            r = 1.0;
+            g = 1.0 - s;
+            b = 1.0 - s;
+        }
+        lut->SetTableValue(i, r, g, b, 1.0);
+    }
+    lut->Build();
+}
+
+void buildViridisColormap(vtkLookupTable* lut) {
+    // Simplified Viridis: dark purple → blue → green → yellow
+    lut->SetNumberOfTableValues(256);
+    for (int i = 0; i < 256; ++i) {
+        double t = static_cast<double>(i) / 255.0;
+        double r = std::clamp(t * 1.5 - 0.25, 0.0, 1.0) * 0.9 + 0.1 * t;
+        double g = std::clamp(t * 1.2 - 0.1, 0.0, 1.0) * 0.8;
+        double b = std::clamp(0.6 - t * 0.8, 0.0, 0.7);
+        // Approximate viridis character
+        r = 0.267 + t * (0.993 - 0.267);
+        g = 0.004 + t * (0.906 - 0.004);
+        b = 0.329 + (t < 0.5 ? t * 0.6 : (1.0 - t) * 0.6);
+        lut->SetTableValue(i, r, g, b, 1.0);
+    }
+    lut->Build();
+}
+
+vtkSmartPointer<vtkMatrix4x4> createResliceMatrix(MPRPlane plane, double position) {
+    auto matrix = vtkSmartPointer<vtkMatrix4x4>::New();
+    matrix->Identity();
+
+    switch (plane) {
+        case MPRPlane::Axial:
+            // XY plane, slice along Z
+            matrix->SetElement(2, 3, position);
+            break;
+        case MPRPlane::Coronal:
+            // XZ plane, slice along Y
+            matrix->SetElement(1, 1, 0);
+            matrix->SetElement(1, 2, 1);
+            matrix->SetElement(2, 1, -1);
+            matrix->SetElement(2, 2, 0);
+            matrix->SetElement(1, 3, position);
+            break;
+        case MPRPlane::Sagittal:
+            // YZ plane, slice along X
+            matrix->SetElement(0, 0, 0);
+            matrix->SetElement(0, 2, -1);
+            matrix->SetElement(2, 0, 1);
+            matrix->SetElement(2, 2, 0);
+            matrix->SetElement(0, 3, position);
+            break;
+    }
+
+    return matrix;
+}
+
+} // anonymous namespace
+
+// =============================================================================
+// Implementation
+// =============================================================================
+
+class HemodynamicOverlayRenderer::Impl {
+public:
+    // Input data
+    vtkSmartPointer<vtkImageData> scalarField;
+
+    // Overlay settings
+    OverlayType overlayType = OverlayType::VelocityMagnitude;
+    bool visible = true;
+    double overlayOpacity = 0.5;
+
+    // Colormap settings
+    ColormapPreset colormapPreset = ColormapPreset::Jet;
+    double scalarMin = 0.0;
+    double scalarMax = 100.0;
+
+    // VTK pipeline per plane (Axial=0, Coronal=1, Sagittal=2)
+    std::array<vtkSmartPointer<vtkRenderer>, 3> renderers;
+    std::array<vtkSmartPointer<vtkImageReslice>, 3> reslicers;
+    std::array<vtkSmartPointer<vtkImageMapToColors>, 3> colorMappers;
+    std::array<vtkSmartPointer<vtkImageActor>, 3> imageActors;
+    std::array<double, 3> slicePositions = {0.0, 0.0, 0.0};
+
+    // Shared lookup table
+    vtkSmartPointer<vtkLookupTable> lookupTable;
+
+    Impl() {
+        lookupTable = vtkSmartPointer<vtkLookupTable>::New();
+        rebuildColormap();
+
+        for (int i = 0; i < 3; ++i) {
+            reslicers[i] = vtkSmartPointer<vtkImageReslice>::New();
+            reslicers[i]->SetOutputDimensionality(2);
+            reslicers[i]->SetInterpolationModeToLinear();
+
+            colorMappers[i] = vtkSmartPointer<vtkImageMapToColors>::New();
+            colorMappers[i]->SetLookupTable(lookupTable);
+            colorMappers[i]->SetInputConnection(reslicers[i]->GetOutputPort());
+
+            imageActors[i] = vtkSmartPointer<vtkImageActor>::New();
+            imageActors[i]->GetMapper()->SetInputConnection(
+                colorMappers[i]->GetOutputPort());
+            imageActors[i]->SetOpacity(overlayOpacity);
+            imageActors[i]->SetVisibility(false);
+        }
+
+        setupResliceMatrices();
+    }
+
+    void setupResliceMatrices() {
+        // Axial
+        auto axialMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+        axialMatrix->Identity();
+        reslicers[0]->SetResliceAxes(axialMatrix);
+
+        // Coronal
+        auto coronalMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+        coronalMatrix->Identity();
+        coronalMatrix->SetElement(1, 1, 0);
+        coronalMatrix->SetElement(1, 2, 1);
+        coronalMatrix->SetElement(2, 1, -1);
+        coronalMatrix->SetElement(2, 2, 0);
+        reslicers[1]->SetResliceAxes(coronalMatrix);
+
+        // Sagittal
+        auto sagittalMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+        sagittalMatrix->Identity();
+        sagittalMatrix->SetElement(0, 0, 0);
+        sagittalMatrix->SetElement(0, 2, -1);
+        sagittalMatrix->SetElement(2, 0, 1);
+        sagittalMatrix->SetElement(2, 2, 0);
+        reslicers[2]->SetResliceAxes(sagittalMatrix);
+    }
+
+    void rebuildColormap() {
+        lookupTable->SetTableRange(scalarMin, scalarMax);
+
+        switch (colormapPreset) {
+            case ColormapPreset::Jet:
+                buildJetColormap(lookupTable);
+                break;
+            case ColormapPreset::HotMetal:
+                buildHotMetalColormap(lookupTable);
+                break;
+            case ColormapPreset::CoolWarm:
+                buildCoolWarmColormap(lookupTable);
+                break;
+            case ColormapPreset::Viridis:
+                buildViridisColormap(lookupTable);
+                break;
+        }
+
+        lookupTable->SetTableRange(scalarMin, scalarMax);
+    }
+
+    void updateSlicePosition(int planeIndex) {
+        if (!scalarField) {
+            return;
+        }
+
+        auto matrix = reslicers[planeIndex]->GetResliceAxes();
+        double position = slicePositions[planeIndex];
+
+        switch (planeIndex) {
+            case 0:  // Axial - translate along Z
+                matrix->SetElement(2, 3, position);
+                break;
+            case 1:  // Coronal - translate along Y
+                matrix->SetElement(1, 3, position);
+                break;
+            case 2:  // Sagittal - translate along X
+                matrix->SetElement(0, 3, position);
+                break;
+        }
+
+        reslicers[planeIndex]->Modified();
+    }
+
+    void applyVisibility() {
+        for (int i = 0; i < 3; ++i) {
+            imageActors[i]->SetVisibility(visible && scalarField != nullptr);
+        }
+    }
+
+    void attachToRenderers() {
+        for (int i = 0; i < 3; ++i) {
+            if (renderers[i]) {
+                renderers[i]->AddViewProp(imageActors[i]);
+            }
+        }
+    }
+
+    void detachFromRenderers() {
+        for (int i = 0; i < 3; ++i) {
+            if (renderers[i]) {
+                renderers[i]->RemoveViewProp(imageActors[i]);
+            }
+        }
+    }
+};
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+HemodynamicOverlayRenderer::HemodynamicOverlayRenderer()
+    : impl_(std::make_unique<Impl>()) {}
+
+HemodynamicOverlayRenderer::~HemodynamicOverlayRenderer() {
+    if (impl_) {
+        impl_->detachFromRenderers();
+    }
+}
+
+HemodynamicOverlayRenderer::HemodynamicOverlayRenderer(HemodynamicOverlayRenderer&&) noexcept = default;
+HemodynamicOverlayRenderer& HemodynamicOverlayRenderer::operator=(HemodynamicOverlayRenderer&&) noexcept = default;
+
+void HemodynamicOverlayRenderer::setScalarField(vtkSmartPointer<vtkImageData> scalarField) {
+    impl_->scalarField = scalarField;
+
+    if (scalarField) {
+        for (int i = 0; i < 3; ++i) {
+            impl_->reslicers[i]->SetInputData(scalarField);
+        }
+    }
+
+    impl_->applyVisibility();
+}
+
+bool HemodynamicOverlayRenderer::hasScalarField() const noexcept {
+    return impl_->scalarField != nullptr;
+}
+
+void HemodynamicOverlayRenderer::setOverlayType(OverlayType type) {
+    impl_->overlayType = type;
+}
+
+OverlayType HemodynamicOverlayRenderer::overlayType() const noexcept {
+    return impl_->overlayType;
+}
+
+void HemodynamicOverlayRenderer::setVisible(bool visible) {
+    impl_->visible = visible;
+    impl_->applyVisibility();
+}
+
+bool HemodynamicOverlayRenderer::isVisible() const noexcept {
+    return impl_->visible;
+}
+
+void HemodynamicOverlayRenderer::setOpacity(double opacity) {
+    impl_->overlayOpacity = std::clamp(opacity, 0.0, 1.0);
+    for (int i = 0; i < 3; ++i) {
+        impl_->imageActors[i]->SetOpacity(impl_->overlayOpacity);
+    }
+}
+
+double HemodynamicOverlayRenderer::opacity() const noexcept {
+    return impl_->overlayOpacity;
+}
+
+void HemodynamicOverlayRenderer::setColormapPreset(ColormapPreset preset) {
+    impl_->colormapPreset = preset;
+    impl_->rebuildColormap();
+
+    for (int i = 0; i < 3; ++i) {
+        impl_->colorMappers[i]->Modified();
+    }
+}
+
+ColormapPreset HemodynamicOverlayRenderer::colormapPreset() const noexcept {
+    return impl_->colormapPreset;
+}
+
+void HemodynamicOverlayRenderer::setScalarRange(double minVal, double maxVal) {
+    impl_->scalarMin = minVal;
+    impl_->scalarMax = maxVal;
+    impl_->rebuildColormap();
+
+    for (int i = 0; i < 3; ++i) {
+        impl_->colorMappers[i]->Modified();
+    }
+}
+
+std::pair<double, double> HemodynamicOverlayRenderer::scalarRange() const noexcept {
+    return {impl_->scalarMin, impl_->scalarMax};
+}
+
+vtkSmartPointer<vtkLookupTable> HemodynamicOverlayRenderer::getLookupTable() const {
+    return impl_->lookupTable;
+}
+
+void HemodynamicOverlayRenderer::setRenderers(
+    vtkSmartPointer<vtkRenderer> axial,
+    vtkSmartPointer<vtkRenderer> coronal,
+    vtkSmartPointer<vtkRenderer> sagittal) {
+
+    impl_->detachFromRenderers();
+
+    impl_->renderers[0] = axial;
+    impl_->renderers[1] = coronal;
+    impl_->renderers[2] = sagittal;
+
+    impl_->attachToRenderers();
+    impl_->applyVisibility();
+}
+
+std::expected<void, OverlayError>
+HemodynamicOverlayRenderer::setSlicePosition(MPRPlane plane, double worldPosition) {
+    if (!impl_->scalarField) {
+        return std::unexpected(OverlayError::NoScalarField);
+    }
+
+    int planeIndex = static_cast<int>(plane);
+    if (planeIndex < 0 || planeIndex > 2) {
+        return std::unexpected(OverlayError::InvalidPlane);
+    }
+
+    impl_->slicePositions[planeIndex] = worldPosition;
+    impl_->updateSlicePosition(planeIndex);
+    return {};
+}
+
+void HemodynamicOverlayRenderer::update() {
+    for (int i = 0; i < 3; ++i) {
+        if (impl_->scalarField) {
+            impl_->reslicers[i]->Update();
+            impl_->colorMappers[i]->Update();
+        }
+    }
+}
+
+void HemodynamicOverlayRenderer::updatePlane(MPRPlane plane) {
+    int idx = static_cast<int>(plane);
+    if (idx >= 0 && idx <= 2 && impl_->scalarField) {
+        impl_->reslicers[idx]->Update();
+        impl_->colorMappers[idx]->Update();
+    }
+}
+
+// =============================================================================
+// Static utility methods
+// =============================================================================
+
+std::expected<vtkSmartPointer<vtkImageData>, OverlayError>
+HemodynamicOverlayRenderer::computeVelocityMagnitude(
+    vtkSmartPointer<vtkImageData> velocityField) {
+
+    if (!velocityField) {
+        return std::unexpected(OverlayError::NoScalarField);
+    }
+
+    int numComponents = velocityField->GetNumberOfScalarComponents();
+    if (numComponents < 3) {
+        return std::unexpected(OverlayError::NoScalarField);
+    }
+
+    int* dims = velocityField->GetDimensions();
+    double* spacing = velocityField->GetSpacing();
+    double* origin = velocityField->GetOrigin();
+
+    auto magnitude = vtkSmartPointer<vtkImageData>::New();
+    magnitude->SetDimensions(dims);
+    magnitude->SetSpacing(spacing);
+    magnitude->SetOrigin(origin);
+    magnitude->AllocateScalars(VTK_FLOAT, 1);
+
+    vtkIdType numVoxels = static_cast<vtkIdType>(dims[0]) * dims[1] * dims[2];
+
+    auto* inData = velocityField->GetPointData()->GetScalars();
+    auto* outPtr = static_cast<float*>(magnitude->GetScalarPointer());
+
+    for (vtkIdType i = 0; i < numVoxels; ++i) {
+        double vx = inData->GetComponent(i, 0);
+        double vy = inData->GetComponent(i, 1);
+        double vz = inData->GetComponent(i, 2);
+        outPtr[i] = static_cast<float>(std::sqrt(vx * vx + vy * vy + vz * vz));
+    }
+
+    return magnitude;
+}
+
+std::expected<vtkSmartPointer<vtkImageData>, OverlayError>
+HemodynamicOverlayRenderer::extractComponent(
+    vtkSmartPointer<vtkImageData> velocityField, int component) {
+
+    if (!velocityField) {
+        return std::unexpected(OverlayError::NoScalarField);
+    }
+
+    int numComponents = velocityField->GetNumberOfScalarComponents();
+    if (component < 0 || component >= numComponents) {
+        return std::unexpected(OverlayError::NoScalarField);
+    }
+
+    int* dims = velocityField->GetDimensions();
+    double* spacing = velocityField->GetSpacing();
+    double* origin = velocityField->GetOrigin();
+
+    auto result = vtkSmartPointer<vtkImageData>::New();
+    result->SetDimensions(dims);
+    result->SetSpacing(spacing);
+    result->SetOrigin(origin);
+    result->AllocateScalars(VTK_FLOAT, 1);
+
+    vtkIdType numVoxels = static_cast<vtkIdType>(dims[0]) * dims[1] * dims[2];
+
+    auto* inData = velocityField->GetPointData()->GetScalars();
+    auto* outPtr = static_cast<float*>(result->GetScalarPointer());
+
+    for (vtkIdType i = 0; i < numVoxels; ++i) {
+        outPtr[i] = static_cast<float>(inData->GetComponent(i, component));
+    }
+
+    return result;
+}
+
+} // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1384,3 +1384,30 @@ target_include_directories(project_manager_test PRIVATE
 )
 
 gtest_discover_tests(project_manager_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for Hemodynamic Overlay Renderer
+add_executable(hemodynamic_overlay_renderer_test
+    unit/hemodynamic_overlay_renderer_test.cpp
+)
+
+target_link_directories(hemodynamic_overlay_renderer_test PRIVATE
+    /opt/homebrew/lib
+)
+
+target_link_libraries(hemodynamic_overlay_renderer_test PRIVATE
+    render_service
+    ${VTK_LIBRARIES}
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(hemodynamic_overlay_renderer_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+vtk_module_autoinit(
+    TARGETS hemodynamic_overlay_renderer_test
+    MODULES ${VTK_LIBRARIES}
+)
+
+gtest_discover_tests(hemodynamic_overlay_renderer_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/hemodynamic_overlay_renderer_test.cpp
+++ b/tests/unit/hemodynamic_overlay_renderer_test.cpp
@@ -1,0 +1,501 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include <vtkFloatArray.h>
+#include <vtkImageData.h>
+#include <vtkLookupTable.h>
+#include <vtkPointData.h>
+#include <vtkRenderer.h>
+#include <vtkSmartPointer.h>
+
+#include "services/render/hemodynamic_overlay_renderer.hpp"
+#include "services/mpr_renderer.hpp"
+
+using namespace dicom_viewer::services;
+
+namespace {
+
+/// Create a 3D scalar field (e.g., velocity magnitude) for testing
+vtkSmartPointer<vtkImageData> createScalarField(
+    int dimX, int dimY, int dimZ,
+    double spacing = 1.0) {
+    auto image = vtkSmartPointer<vtkImageData>::New();
+    image->SetDimensions(dimX, dimY, dimZ);
+    image->SetSpacing(spacing, spacing, spacing);
+    image->SetOrigin(0.0, 0.0, 0.0);
+    image->AllocateScalars(VTK_FLOAT, 1);
+
+    auto* ptr = static_cast<float*>(image->GetScalarPointer());
+    int total = dimX * dimY * dimZ;
+    for (int i = 0; i < total; ++i) {
+        // Gradient pattern: value increases with voxel index
+        ptr[i] = static_cast<float>(i) / static_cast<float>(total) * 100.0f;
+    }
+    return image;
+}
+
+/// Create a 3D vector field (Vx, Vy, Vz) for testing computeVelocityMagnitude
+vtkSmartPointer<vtkImageData> createVectorField(
+    int dimX, int dimY, int dimZ,
+    double vx, double vy, double vz) {
+    auto image = vtkSmartPointer<vtkImageData>::New();
+    image->SetDimensions(dimX, dimY, dimZ);
+    image->SetSpacing(1.0, 1.0, 1.0);
+    image->SetOrigin(0.0, 0.0, 0.0);
+    image->AllocateScalars(VTK_FLOAT, 3);
+
+    auto* ptr = static_cast<float*>(image->GetScalarPointer());
+    int total = dimX * dimY * dimZ;
+    for (int i = 0; i < total; ++i) {
+        ptr[i * 3 + 0] = static_cast<float>(vx);
+        ptr[i * 3 + 1] = static_cast<float>(vy);
+        ptr[i * 3 + 2] = static_cast<float>(vz);
+    }
+    return image;
+}
+
+/// Create a non-uniform vector field with varying magnitudes
+vtkSmartPointer<vtkImageData> createGradientVectorField(
+    int dimX, int dimY, int dimZ) {
+    auto image = vtkSmartPointer<vtkImageData>::New();
+    image->SetDimensions(dimX, dimY, dimZ);
+    image->SetSpacing(1.0, 1.0, 1.0);
+    image->SetOrigin(0.0, 0.0, 0.0);
+    image->AllocateScalars(VTK_FLOAT, 3);
+
+    auto* ptr = static_cast<float*>(image->GetScalarPointer());
+    int idx = 0;
+    for (int z = 0; z < dimZ; ++z) {
+        for (int y = 0; y < dimY; ++y) {
+            for (int x = 0; x < dimX; ++x) {
+                ptr[idx * 3 + 0] = static_cast<float>(x);  // Vx
+                ptr[idx * 3 + 1] = static_cast<float>(y);  // Vy
+                ptr[idx * 3 + 2] = static_cast<float>(z);  // Vz
+                ++idx;
+            }
+        }
+    }
+    return image;
+}
+
+} // anonymous namespace
+
+// =============================================================================
+// Construction and Default State
+// =============================================================================
+
+TEST(HemodynamicOverlayRendererTest, DefaultState) {
+    HemodynamicOverlayRenderer renderer;
+    EXPECT_FALSE(renderer.hasScalarField());
+    EXPECT_TRUE(renderer.isVisible());
+    EXPECT_DOUBLE_EQ(renderer.opacity(), 0.5);
+    EXPECT_EQ(renderer.overlayType(), OverlayType::VelocityMagnitude);
+    EXPECT_EQ(renderer.colormapPreset(), ColormapPreset::Jet);
+
+    auto [minVal, maxVal] = renderer.scalarRange();
+    EXPECT_DOUBLE_EQ(minVal, 0.0);
+    EXPECT_DOUBLE_EQ(maxVal, 100.0);
+}
+
+TEST(HemodynamicOverlayRendererTest, MoveConstructor) {
+    HemodynamicOverlayRenderer r1;
+    r1.setOpacity(0.8);
+    r1.setOverlayType(OverlayType::VelocityX);
+
+    HemodynamicOverlayRenderer r2(std::move(r1));
+    EXPECT_DOUBLE_EQ(r2.opacity(), 0.8);
+    EXPECT_EQ(r2.overlayType(), OverlayType::VelocityX);
+}
+
+// =============================================================================
+// Scalar Field Input
+// =============================================================================
+
+TEST(HemodynamicOverlayRendererTest, SetScalarField) {
+    HemodynamicOverlayRenderer renderer;
+    auto field = createScalarField(16, 16, 16);
+
+    renderer.setScalarField(field);
+    EXPECT_TRUE(renderer.hasScalarField());
+
+    renderer.setScalarField(nullptr);
+    EXPECT_FALSE(renderer.hasScalarField());
+}
+
+// =============================================================================
+// Visibility and Opacity
+// =============================================================================
+
+TEST(HemodynamicOverlayRendererTest, VisibilityToggle) {
+    HemodynamicOverlayRenderer renderer;
+    EXPECT_TRUE(renderer.isVisible());
+
+    renderer.setVisible(false);
+    EXPECT_FALSE(renderer.isVisible());
+
+    renderer.setVisible(true);
+    EXPECT_TRUE(renderer.isVisible());
+}
+
+TEST(HemodynamicOverlayRendererTest, OpacityClamping) {
+    HemodynamicOverlayRenderer renderer;
+
+    renderer.setOpacity(0.75);
+    EXPECT_DOUBLE_EQ(renderer.opacity(), 0.75);
+
+    renderer.setOpacity(-0.5);
+    EXPECT_DOUBLE_EQ(renderer.opacity(), 0.0);
+
+    renderer.setOpacity(1.5);
+    EXPECT_DOUBLE_EQ(renderer.opacity(), 1.0);
+}
+
+// =============================================================================
+// Overlay Type
+// =============================================================================
+
+TEST(HemodynamicOverlayRendererTest, OverlayTypeSettings) {
+    HemodynamicOverlayRenderer renderer;
+
+    renderer.setOverlayType(OverlayType::VelocityX);
+    EXPECT_EQ(renderer.overlayType(), OverlayType::VelocityX);
+
+    renderer.setOverlayType(OverlayType::VelocityZ);
+    EXPECT_EQ(renderer.overlayType(), OverlayType::VelocityZ);
+}
+
+// =============================================================================
+// Colormap
+// =============================================================================
+
+TEST(HemodynamicOverlayRendererTest, ColormapPresetSwitch) {
+    HemodynamicOverlayRenderer renderer;
+
+    renderer.setColormapPreset(ColormapPreset::HotMetal);
+    EXPECT_EQ(renderer.colormapPreset(), ColormapPreset::HotMetal);
+
+    renderer.setColormapPreset(ColormapPreset::CoolWarm);
+    EXPECT_EQ(renderer.colormapPreset(), ColormapPreset::CoolWarm);
+
+    renderer.setColormapPreset(ColormapPreset::Viridis);
+    EXPECT_EQ(renderer.colormapPreset(), ColormapPreset::Viridis);
+}
+
+TEST(HemodynamicOverlayRendererTest, ScalarRangeControl) {
+    HemodynamicOverlayRenderer renderer;
+
+    renderer.setScalarRange(10.0, 200.0);
+    auto [minVal, maxVal] = renderer.scalarRange();
+    EXPECT_DOUBLE_EQ(minVal, 10.0);
+    EXPECT_DOUBLE_EQ(maxVal, 200.0);
+}
+
+TEST(HemodynamicOverlayRendererTest, LookupTableCreated) {
+    HemodynamicOverlayRenderer renderer;
+    renderer.setScalarRange(0.0, 50.0);
+
+    auto lut = renderer.getLookupTable();
+    ASSERT_NE(lut, nullptr);
+    EXPECT_EQ(lut->GetNumberOfTableValues(), 256);
+
+    double range[2];
+    lut->GetTableRange(range);
+    EXPECT_DOUBLE_EQ(range[0], 0.0);
+    EXPECT_DOUBLE_EQ(range[1], 50.0);
+}
+
+// =============================================================================
+// Renderer Attachment
+// =============================================================================
+
+TEST(HemodynamicOverlayRendererTest, SetRenderers) {
+    HemodynamicOverlayRenderer renderer;
+
+    auto axial = vtkSmartPointer<vtkRenderer>::New();
+    auto coronal = vtkSmartPointer<vtkRenderer>::New();
+    auto sagittal = vtkSmartPointer<vtkRenderer>::New();
+
+    renderer.setRenderers(axial, coronal, sagittal);
+
+    // After setRenderers, actors should be added to renderers
+    EXPECT_GT(axial->GetViewProps()->GetNumberOfItems(), 0);
+    EXPECT_GT(coronal->GetViewProps()->GetNumberOfItems(), 0);
+    EXPECT_GT(sagittal->GetViewProps()->GetNumberOfItems(), 0);
+}
+
+TEST(HemodynamicOverlayRendererTest, RendererReattachment) {
+    HemodynamicOverlayRenderer renderer;
+
+    auto r1 = vtkSmartPointer<vtkRenderer>::New();
+    auto r2 = vtkSmartPointer<vtkRenderer>::New();
+    auto r3 = vtkSmartPointer<vtkRenderer>::New();
+
+    renderer.setRenderers(r1, r2, r3);
+    int countBefore = r1->GetViewProps()->GetNumberOfItems();
+
+    // Re-attach to new renderers
+    auto r4 = vtkSmartPointer<vtkRenderer>::New();
+    renderer.setRenderers(r4, r2, r3);
+
+    // Old renderer should have actors removed
+    EXPECT_EQ(r1->GetViewProps()->GetNumberOfItems(), countBefore - 1);
+    // New renderer should have actors added
+    EXPECT_GT(r4->GetViewProps()->GetNumberOfItems(), 0);
+}
+
+// =============================================================================
+// Slice Position
+// =============================================================================
+
+TEST(HemodynamicOverlayRendererTest, SetSlicePositionWithoutField) {
+    HemodynamicOverlayRenderer renderer;
+    auto result = renderer.setSlicePosition(MPRPlane::Axial, 50.0);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), OverlayError::NoScalarField);
+}
+
+TEST(HemodynamicOverlayRendererTest, SetSlicePositionSuccess) {
+    HemodynamicOverlayRenderer renderer;
+    renderer.setScalarField(createScalarField(32, 32, 32));
+
+    auto result = renderer.setSlicePosition(MPRPlane::Axial, 15.0);
+    EXPECT_TRUE(result.has_value());
+
+    result = renderer.setSlicePosition(MPRPlane::Coronal, 10.0);
+    EXPECT_TRUE(result.has_value());
+
+    result = renderer.setSlicePosition(MPRPlane::Sagittal, 5.0);
+    EXPECT_TRUE(result.has_value());
+}
+
+// =============================================================================
+// Update Pipeline
+// =============================================================================
+
+TEST(HemodynamicOverlayRendererTest, UpdateWithScalarField) {
+    HemodynamicOverlayRenderer renderer;
+    auto field = createScalarField(16, 16, 16);
+    renderer.setScalarField(field);
+
+    // Should not crash
+    renderer.update();
+    renderer.updatePlane(MPRPlane::Axial);
+    renderer.updatePlane(MPRPlane::Coronal);
+    renderer.updatePlane(MPRPlane::Sagittal);
+}
+
+TEST(HemodynamicOverlayRendererTest, UpdateWithoutScalarField) {
+    HemodynamicOverlayRenderer renderer;
+    // Should not crash when no data is set
+    renderer.update();
+    renderer.updatePlane(MPRPlane::Axial);
+}
+
+// =============================================================================
+// Velocity Magnitude Computation
+// =============================================================================
+
+TEST(HemodynamicOverlayRendererTest, ComputeVelocityMagnitudeUniform) {
+    // V = (3, 4, 0) → |V| = 5.0
+    auto vecField = createVectorField(8, 8, 8, 3.0, 4.0, 0.0);
+    auto result = HemodynamicOverlayRenderer::computeVelocityMagnitude(vecField);
+    ASSERT_TRUE(result.has_value());
+
+    auto& mag = *result;
+    EXPECT_EQ(mag->GetNumberOfScalarComponents(), 1);
+
+    int* dims = mag->GetDimensions();
+    EXPECT_EQ(dims[0], 8);
+    EXPECT_EQ(dims[1], 8);
+    EXPECT_EQ(dims[2], 8);
+
+    // Check all voxels have magnitude 5.0
+    auto* ptr = static_cast<float*>(mag->GetScalarPointer());
+    for (int i = 0; i < 8 * 8 * 8; ++i) {
+        EXPECT_NEAR(ptr[i], 5.0f, 1e-5f);
+    }
+}
+
+TEST(HemodynamicOverlayRendererTest, ComputeVelocityMagnitudeGradient) {
+    // Gradient field: V(x,y,z) = (x, y, z) at each voxel
+    auto vecField = createGradientVectorField(4, 4, 4);
+    auto result = HemodynamicOverlayRenderer::computeVelocityMagnitude(vecField);
+    ASSERT_TRUE(result.has_value());
+
+    auto& mag = *result;
+    auto* ptr = static_cast<float*>(mag->GetScalarPointer());
+
+    // Check voxel at (0,0,0): |V| = 0
+    EXPECT_NEAR(ptr[0], 0.0f, 1e-5f);
+
+    // Check voxel at (3,3,3): |V| = sqrt(9+9+9) = sqrt(27) ≈ 5.196
+    int idx = 3 * 4 * 4 + 3 * 4 + 3;
+    float expected = std::sqrt(9.0f + 9.0f + 9.0f);
+    EXPECT_NEAR(ptr[idx], expected, 1e-4f);
+}
+
+TEST(HemodynamicOverlayRendererTest, ComputeVelocityMagnitudeNullInput) {
+    auto result = HemodynamicOverlayRenderer::computeVelocityMagnitude(nullptr);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), OverlayError::NoScalarField);
+}
+
+TEST(HemodynamicOverlayRendererTest, ComputeVelocityMagnitudeInvalidComponents) {
+    // Scalar image with 1 component (not a vector field)
+    auto scalar = createScalarField(4, 4, 4);
+    auto result = HemodynamicOverlayRenderer::computeVelocityMagnitude(scalar);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), OverlayError::NoScalarField);
+}
+
+// =============================================================================
+// Component Extraction
+// =============================================================================
+
+TEST(HemodynamicOverlayRendererTest, ExtractComponentX) {
+    auto vecField = createVectorField(4, 4, 4, 10.0, 20.0, 30.0);
+    auto result = HemodynamicOverlayRenderer::extractComponent(vecField, 0);
+    ASSERT_TRUE(result.has_value());
+
+    auto& comp = *result;
+    auto* ptr = static_cast<float*>(comp->GetScalarPointer());
+    for (int i = 0; i < 4 * 4 * 4; ++i) {
+        EXPECT_NEAR(ptr[i], 10.0f, 1e-5f);
+    }
+}
+
+TEST(HemodynamicOverlayRendererTest, ExtractComponentY) {
+    auto vecField = createVectorField(4, 4, 4, 10.0, 20.0, 30.0);
+    auto result = HemodynamicOverlayRenderer::extractComponent(vecField, 1);
+    ASSERT_TRUE(result.has_value());
+
+    auto& comp = *result;
+    auto* ptr = static_cast<float*>(comp->GetScalarPointer());
+    for (int i = 0; i < 4 * 4 * 4; ++i) {
+        EXPECT_NEAR(ptr[i], 20.0f, 1e-5f);
+    }
+}
+
+TEST(HemodynamicOverlayRendererTest, ExtractComponentZ) {
+    auto vecField = createVectorField(4, 4, 4, 10.0, 20.0, 30.0);
+    auto result = HemodynamicOverlayRenderer::extractComponent(vecField, 2);
+    ASSERT_TRUE(result.has_value());
+
+    auto& comp = *result;
+    auto* ptr = static_cast<float*>(comp->GetScalarPointer());
+    for (int i = 0; i < 4 * 4 * 4; ++i) {
+        EXPECT_NEAR(ptr[i], 30.0f, 1e-5f);
+    }
+}
+
+TEST(HemodynamicOverlayRendererTest, ExtractComponentInvalidIndex) {
+    auto vecField = createVectorField(4, 4, 4, 1.0, 2.0, 3.0);
+    auto result = HemodynamicOverlayRenderer::extractComponent(vecField, 5);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), OverlayError::NoScalarField);
+}
+
+TEST(HemodynamicOverlayRendererTest, ExtractComponentNullInput) {
+    auto result = HemodynamicOverlayRenderer::extractComponent(nullptr, 0);
+    EXPECT_FALSE(result.has_value());
+}
+
+// =============================================================================
+// Full Pipeline Integration
+// =============================================================================
+
+TEST(HemodynamicOverlayRendererTest, FullPipelineEndToEnd) {
+    // Create a velocity vector field
+    auto vecField = createVectorField(16, 16, 16, 30.0, 40.0, 0.0);
+
+    // Compute magnitude
+    auto magResult = HemodynamicOverlayRenderer::computeVelocityMagnitude(vecField);
+    ASSERT_TRUE(magResult.has_value());
+
+    // Set up overlay renderer
+    HemodynamicOverlayRenderer renderer;
+    renderer.setScalarField(*magResult);
+    renderer.setScalarRange(0.0, 100.0);
+    renderer.setColormapPreset(ColormapPreset::Jet);
+    renderer.setOpacity(0.6);
+
+    auto axial = vtkSmartPointer<vtkRenderer>::New();
+    auto coronal = vtkSmartPointer<vtkRenderer>::New();
+    auto sagittal = vtkSmartPointer<vtkRenderer>::New();
+    renderer.setRenderers(axial, coronal, sagittal);
+
+    // Set slice positions
+    auto r1 = renderer.setSlicePosition(MPRPlane::Axial, 8.0);
+    EXPECT_TRUE(r1.has_value());
+
+    auto r2 = renderer.setSlicePosition(MPRPlane::Coronal, 8.0);
+    EXPECT_TRUE(r2.has_value());
+
+    auto r3 = renderer.setSlicePosition(MPRPlane::Sagittal, 8.0);
+    EXPECT_TRUE(r3.has_value());
+
+    // Update pipeline - should not crash
+    renderer.update();
+
+    // Verify overlay actors are in renderers
+    EXPECT_GT(axial->GetViewProps()->GetNumberOfItems(), 0);
+}
+
+// =============================================================================
+// Colormap Preset Validation
+// =============================================================================
+
+TEST(HemodynamicOverlayRendererTest, AllColormapsProduceValidLUT) {
+    HemodynamicOverlayRenderer renderer;
+
+    for (auto preset : {ColormapPreset::Jet, ColormapPreset::HotMetal,
+                        ColormapPreset::CoolWarm, ColormapPreset::Viridis}) {
+        renderer.setColormapPreset(preset);
+        auto lut = renderer.getLookupTable();
+        ASSERT_NE(lut, nullptr);
+        EXPECT_EQ(lut->GetNumberOfTableValues(), 256);
+
+        // Verify all table values are in [0, 1] range
+        for (int i = 0; i < 256; ++i) {
+            double rgba[4];
+            lut->GetTableValue(i, rgba);
+            EXPECT_GE(rgba[0], 0.0);
+            EXPECT_LE(rgba[0], 1.0);
+            EXPECT_GE(rgba[1], 0.0);
+            EXPECT_LE(rgba[1], 1.0);
+            EXPECT_GE(rgba[2], 0.0);
+            EXPECT_LE(rgba[2], 1.0);
+        }
+    }
+}
+
+// =============================================================================
+// Geometry Preservation
+// =============================================================================
+
+TEST(HemodynamicOverlayRendererTest, MagnitudePreservesGeometry) {
+    auto vecField = createVectorField(8, 12, 16, 1.0, 0.0, 0.0);
+    vecField->SetSpacing(0.5, 0.75, 1.25);
+    vecField->SetOrigin(10.0, 20.0, 30.0);
+
+    auto result = HemodynamicOverlayRenderer::computeVelocityMagnitude(vecField);
+    ASSERT_TRUE(result.has_value());
+
+    auto& mag = *result;
+    int* dims = mag->GetDimensions();
+    double* spacing = mag->GetSpacing();
+    double* origin = mag->GetOrigin();
+
+    EXPECT_EQ(dims[0], 8);
+    EXPECT_EQ(dims[1], 12);
+    EXPECT_EQ(dims[2], 16);
+
+    EXPECT_DOUBLE_EQ(spacing[0], 0.5);
+    EXPECT_DOUBLE_EQ(spacing[1], 0.75);
+    EXPECT_DOUBLE_EQ(spacing[2], 1.25);
+
+    EXPECT_DOUBLE_EQ(origin[0], 10.0);
+    EXPECT_DOUBLE_EQ(origin[1], 20.0);
+    EXPECT_DOUBLE_EQ(origin[2], 30.0);
+}


### PR DESCRIPTION
## Summary
- Implement `HemodynamicOverlayRenderer` class for 2D hemodynamic overlay rendering on MPR views
- Add velocity magnitude computation from 3-component velocity vector fields (`sqrt(Vx^2 + Vy^2 + Vz^2)`)
- Add individual velocity component extraction (Vx, Vy, Vz) for directional overlays
- Implement VTK rendering pipeline: `vtkImageReslice` → `vtkLookupTable` → `vtkImageMapToColors` → `vtkImageActor`
- Support 4 colormap presets (Jet, HotMetal, CoolWarm, Viridis) with configurable scalar range
- Alpha-blended compositing with configurable opacity (0.0-1.0)
- 27 unit tests covering default state, settings, colormap validation, velocity computation, component extraction, and full pipeline

## Test Plan
- [x] All 27 new HemodynamicOverlayRenderer tests pass
- [x] No regression in existing tests
- [x] Build succeeds with Release configuration

Closes #276