### PR TITLE
fix(flow): use multi-point velocity gradient for WSS calculation (#233)

### DIFF
--- a/include/services/flow/vessel_analyzer.hpp
+++ b/include/services/flow/vessel_analyzer.hpp
@@ -125,8 +125,11 @@ public:
      *
      * For each wall vertex:
      * 1. Get inward normal direction
-     * 2. Sample velocity at 1-2 voxels from wall along normal
-     * 3. WSS = mu * |V_near| / distance
+     * 2. Sample velocity at 3 distances along inward normal
+     * 3. Fit quadratic profile, extract gradient at wall (d=0)
+     * 4. WSS = mu * dV_tangential/dn
+     *
+     * Low WSS area is computed from actual mesh cell (triangle) areas.
      *
      * @param phase Velocity field
      * @param wallMesh Vessel wall surface mesh with vertex normals


### PR DESCRIPTION
Closes #233

## Summary
- Replace single-point fixed-distance WSS approximation (`WSS = mu * V/d`) with 3-point quadratic Lagrange interpolation to estimate velocity gradient at the vessel wall (d=0)
- Use actual mesh triangle cell areas for low WSS area computation instead of vertex counting
- Tighten Poiseuille flow WSS test tolerance from 0.1-5.0x to ±30% of analytical solution
- Add new test validating low WSS area is computed from triangle geometry in cm²

## Technical Details

### Multi-point gradient estimation
For each wall vertex, velocity is sampled at 3 distances (1x, 2x, 3x voxel spacing) along the inward normal. A quadratic Lagrange polynomial is fit through these points, and its derivative at d=0 gives the wall velocity gradient. This correctly captures parabolic velocity profiles (Poiseuille flow).

Graceful degradation: 2 valid samples → linear fit, 1 sample → V/d fallback.

### Low WSS area from cell areas
Instead of counting vertices with low WSS, the code now iterates over mesh triangles, computes each triangle's area via cross product, and accumulates area for triangles whose average vertex WSS is below threshold. Result is in cm².

## Test Plan
- [x] All 26 vessel_analyzer_test cases pass (including WSS, TAWSS, OSI, vorticity, TKE)
- [x] `PoiseuilleFlowProducesNonZeroWSS` — mean WSS within ±30% of analytical (0.533 Pa)
- [x] `LowWSSAreaUsesTriangleCellAreas` — low WSS area matches cylinder geometry in cm²
- [x] `ZeroVelocityFieldProducesZeroWSS` — no regression
- [x] TAWSS and OSI tests pass without regression