### PR TITLE
fix(flow): correct helicity unit conversion and add directional decomposition

### DIFF
--- a/include/services/flow/vessel_analyzer.hpp
+++ b/include/services/flow/vessel_analyzer.hpp
@@ -41,6 +41,8 @@ struct VortexResult {
     FloatImage3D::Pointer vorticityMagnitude;   ///< |curl(V)| in 1/s
     VectorImage3D::Pointer vorticityField;      ///< curl(V) vector field
     FloatImage3D::Pointer helicityDensity;      ///< V dot curl(V) in m/s^2
+    FloatImage3D::Pointer rightHelicity;        ///< max(H, 0) in m/s^2
+    FloatImage3D::Pointer leftHelicity;         ///< min(H, 0) in m/s^2
 };
 
 /**


### PR DESCRIPTION
Closes #234

## Summary
- Convert velocity from cm/s to m/s (×0.01) before helicity dot product with vorticity, fixing output unit from cm/s² to SI m/s²
- Add `rightHelicity` (max(H,0)) and `leftHelicity` (min(H,0)) fields to `VortexResult` for directional helical flow analysis
- Add `HelicityMagnitudeInSIUnits` test verifying analytical helicity value (18 m/s² for rotating cylinder with axial flow)
- Add `RightLeftHelicityDecomposition` test verifying decomposition identity H = rightH + leftH across all voxels

## Test Plan
- [x] All 28 vessel_analyzer_test cases pass
- [x] New `HelicityMagnitudeInSIUnits` validates analytical SI value within 10% tolerance
- [x] New `RightLeftHelicityDecomposition` validates sign constraints and identity for all voxels
- [x] Existing `HelicitySignMatchesRotationDirection` still passes (sign preserved after unit conversion)