### PR TITLE
feat(segmentation): implement Boolean mask operations (Union/Difference/Intersection)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,6 +418,7 @@ add_library(segmentation_service STATIC
     src/services/segmentation/mpr_segmentation_renderer.cpp
     src/services/segmentation/segmentation_command.cpp
     src/services/segmentation/brush_stroke_command.cpp
+    src/services/segmentation/mask_boolean_operations.cpp
 )
 
 target_link_libraries(segmentation_service PUBLIC

--- a/include/services/segmentation/mask_boolean_operations.hpp
+++ b/include/services/segmentation/mask_boolean_operations.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <expected>
+#include <vector>
+
+#include <itkImage.h>
+
+#include "services/segmentation/threshold_segmenter.hpp"
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Boolean operations between segmentation label maps
+ *
+ * Provides voxel-wise set operations on 3D label maps:
+ * - Union: A ∪ B (combine, A takes priority at overlap)
+ * - Difference: A \ B (remove B-labeled voxels from A)
+ * - Intersection: A ∩ B (keep only overlapping labeled voxels)
+ *
+ * All operations produce a NEW label map, preserving originals.
+ * Input maps must have identical dimensions, spacing, and origin.
+ *
+ * @trace SRS-FR-023
+ */
+class MaskBooleanOperations {
+public:
+    using LabelMapType = itk::Image<uint8_t, 3>;
+
+    /**
+     * @brief Union of two label maps (A ∪ B)
+     *
+     * For each voxel:
+     *   result = A if A != 0, else B
+     *
+     * @param maskA First label map (takes priority at overlap)
+     * @param maskB Second label map
+     * @return New label map with union result
+     */
+    [[nodiscard]] static std::expected<LabelMapType::Pointer, SegmentationError>
+    computeUnion(LabelMapType::Pointer maskA,
+                 LabelMapType::Pointer maskB);
+
+    /**
+     * @brief Difference of two label maps (A \ B)
+     *
+     * For each voxel:
+     *   result = A if (A != 0 && B == 0), else 0
+     *
+     * @param maskA Label map to subtract from
+     * @param maskB Label map to subtract
+     * @return New label map with difference result
+     */
+    [[nodiscard]] static std::expected<LabelMapType::Pointer, SegmentationError>
+    computeDifference(LabelMapType::Pointer maskA,
+                      LabelMapType::Pointer maskB);
+
+    /**
+     * @brief Intersection of two label maps (A ∩ B)
+     *
+     * For each voxel:
+     *   result = A if (A != 0 && B != 0), else 0
+     *
+     * @param maskA First label map (label values come from A)
+     * @param maskB Second label map
+     * @return New label map with intersection result
+     */
+    [[nodiscard]] static std::expected<LabelMapType::Pointer, SegmentationError>
+    computeIntersection(LabelMapType::Pointer maskA,
+                        LabelMapType::Pointer maskB);
+
+    /**
+     * @brief Union of multiple label maps
+     *
+     * Sequentially applies union: result = (...((m[0] ∪ m[1]) ∪ m[2]) ... ∪ m[n])
+     * Earlier masks take priority at overlapping voxels.
+     *
+     * @param masks Vector of label maps (minimum 2)
+     * @return New label map with combined union result
+     */
+    [[nodiscard]] static std::expected<LabelMapType::Pointer, SegmentationError>
+    computeUnionMultiple(const std::vector<LabelMapType::Pointer>& masks);
+
+private:
+    /**
+     * @brief Validate that two masks have compatible geometry
+     */
+    [[nodiscard]] static std::expected<void, SegmentationError>
+    validateCompatibility(LabelMapType::Pointer maskA,
+                          LabelMapType::Pointer maskB);
+
+    /**
+     * @brief Create a new label map with the same geometry as the source
+     */
+    [[nodiscard]] static LabelMapType::Pointer
+    createOutputMap(LabelMapType::Pointer source);
+};
+
+}  // namespace dicom_viewer::services

--- a/src/services/segmentation/mask_boolean_operations.cpp
+++ b/src/services/segmentation/mask_boolean_operations.cpp
@@ -1,0 +1,156 @@
+#include "services/segmentation/mask_boolean_operations.hpp"
+
+#include <sstream>
+
+namespace dicom_viewer::services {
+
+std::expected<void, SegmentationError>
+MaskBooleanOperations::validateCompatibility(
+    LabelMapType::Pointer maskA,
+    LabelMapType::Pointer maskB)
+{
+    if (!maskA || !maskB) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Null label map pointer"});
+    }
+
+    auto sizeA = maskA->GetLargestPossibleRegion().GetSize();
+    auto sizeB = maskB->GetLargestPossibleRegion().GetSize();
+
+    if (sizeA != sizeB) {
+        std::ostringstream oss;
+        oss << "Dimension mismatch: A=" << sizeA[0] << "x" << sizeA[1] << "x" << sizeA[2]
+            << " vs B=" << sizeB[0] << "x" << sizeB[1] << "x" << sizeB[2];
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            oss.str()});
+    }
+
+    auto spacingA = maskA->GetSpacing();
+    auto spacingB = maskB->GetSpacing();
+    constexpr double kTolerance = 1e-6;
+    for (unsigned int d = 0; d < 3; ++d) {
+        if (std::abs(spacingA[d] - spacingB[d]) > kTolerance) {
+            return std::unexpected(SegmentationError{
+                SegmentationError::Code::InvalidInput,
+                "Spacing mismatch between masks"});
+        }
+    }
+
+    return {};
+}
+
+MaskBooleanOperations::LabelMapType::Pointer
+MaskBooleanOperations::createOutputMap(LabelMapType::Pointer source)
+{
+    auto output = LabelMapType::New();
+    output->SetRegions(source->GetLargestPossibleRegion());
+    output->SetSpacing(source->GetSpacing());
+    output->SetOrigin(source->GetOrigin());
+    output->SetDirection(source->GetDirection());
+    output->Allocate(true);
+    return output;
+}
+
+std::expected<MaskBooleanOperations::LabelMapType::Pointer, SegmentationError>
+MaskBooleanOperations::computeUnion(
+    LabelMapType::Pointer maskA,
+    LabelMapType::Pointer maskB)
+{
+    auto validation = validateCompatibility(maskA, maskB);
+    if (!validation) {
+        return std::unexpected(validation.error());
+    }
+
+    auto output = createOutputMap(maskA);
+    auto* bufA = maskA->GetBufferPointer();
+    auto* bufB = maskB->GetBufferPointer();
+    auto* bufOut = output->GetBufferPointer();
+
+    auto size = maskA->GetLargestPossibleRegion().GetSize();
+    size_t totalVoxels = size[0] * size[1] * size[2];
+
+    for (size_t i = 0; i < totalVoxels; ++i) {
+        bufOut[i] = (bufA[i] != 0) ? bufA[i] : bufB[i];
+    }
+
+    return output;
+}
+
+std::expected<MaskBooleanOperations::LabelMapType::Pointer, SegmentationError>
+MaskBooleanOperations::computeDifference(
+    LabelMapType::Pointer maskA,
+    LabelMapType::Pointer maskB)
+{
+    auto validation = validateCompatibility(maskA, maskB);
+    if (!validation) {
+        return std::unexpected(validation.error());
+    }
+
+    auto output = createOutputMap(maskA);
+    auto* bufA = maskA->GetBufferPointer();
+    auto* bufB = maskB->GetBufferPointer();
+    auto* bufOut = output->GetBufferPointer();
+
+    auto size = maskA->GetLargestPossibleRegion().GetSize();
+    size_t totalVoxels = size[0] * size[1] * size[2];
+
+    for (size_t i = 0; i < totalVoxels; ++i) {
+        bufOut[i] = (bufA[i] != 0 && bufB[i] == 0) ? bufA[i] : 0;
+    }
+
+    return output;
+}
+
+std::expected<MaskBooleanOperations::LabelMapType::Pointer, SegmentationError>
+MaskBooleanOperations::computeIntersection(
+    LabelMapType::Pointer maskA,
+    LabelMapType::Pointer maskB)
+{
+    auto validation = validateCompatibility(maskA, maskB);
+    if (!validation) {
+        return std::unexpected(validation.error());
+    }
+
+    auto output = createOutputMap(maskA);
+    auto* bufA = maskA->GetBufferPointer();
+    auto* bufB = maskB->GetBufferPointer();
+    auto* bufOut = output->GetBufferPointer();
+
+    auto size = maskA->GetLargestPossibleRegion().GetSize();
+    size_t totalVoxels = size[0] * size[1] * size[2];
+
+    for (size_t i = 0; i < totalVoxels; ++i) {
+        bufOut[i] = (bufA[i] != 0 && bufB[i] != 0) ? bufA[i] : 0;
+    }
+
+    return output;
+}
+
+std::expected<MaskBooleanOperations::LabelMapType::Pointer, SegmentationError>
+MaskBooleanOperations::computeUnionMultiple(
+    const std::vector<LabelMapType::Pointer>& masks)
+{
+    if (masks.size() < 2) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "At least 2 masks required for multi-mask union"});
+    }
+
+    auto result = computeUnion(masks[0], masks[1]);
+    if (!result) {
+        return result;
+    }
+
+    for (size_t i = 2; i < masks.size(); ++i) {
+        result = computeUnion(*result, masks[i]);
+        if (!result) {
+            return result;
+        }
+    }
+
+    return result;
+}
+
+}  // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -295,6 +295,23 @@ target_include_directories(morphological_processor_test PRIVATE
 
 gtest_discover_tests(morphological_processor_test DISCOVERY_TIMEOUT 60)
 
+# Unit tests for Mask Boolean Operations
+add_executable(mask_boolean_operations_test
+    unit/mask_boolean_operations_test.cpp
+)
+
+target_link_libraries(mask_boolean_operations_test PRIVATE
+    segmentation_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(mask_boolean_operations_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(mask_boolean_operations_test DISCOVERY_TIMEOUT 60)
+
 # Unit tests for ROI Statistics Calculator
 add_executable(roi_statistics_test
     unit/roi_statistics_test.cpp

--- a/tests/unit/mask_boolean_operations_test.cpp
+++ b/tests/unit/mask_boolean_operations_test.cpp
@@ -1,0 +1,341 @@
+#include <gtest/gtest.h>
+
+#include "services/segmentation/mask_boolean_operations.hpp"
+
+using namespace dicom_viewer::services;
+using LabelMapType = MaskBooleanOperations::LabelMapType;
+
+namespace {
+
+/**
+ * @brief Create a label map filled with zeros
+ */
+LabelMapType::Pointer createEmptyMap(int nx, int ny, int nz) {
+    auto map = LabelMapType::New();
+    LabelMapType::RegionType region;
+    LabelMapType::SizeType size;
+    size[0] = nx; size[1] = ny; size[2] = nz;
+    region.SetSize(size);
+    map->SetRegions(region);
+
+    LabelMapType::SpacingType spacing;
+    spacing[0] = 1.0; spacing[1] = 1.0; spacing[2] = 1.0;
+    map->SetSpacing(spacing);
+
+    map->Allocate(true);
+    return map;
+}
+
+/**
+ * @brief Count non-zero voxels in a label map
+ */
+int countNonZero(LabelMapType::Pointer map) {
+    auto* buf = map->GetBufferPointer();
+    auto size = map->GetLargestPossibleRegion().GetSize();
+    size_t total = size[0] * size[1] * size[2];
+    int count = 0;
+    for (size_t i = 0; i < total; ++i) {
+        if (buf[i] != 0) ++count;
+    }
+    return count;
+}
+
+/**
+ * @brief Count voxels with a specific label
+ */
+int countLabel(LabelMapType::Pointer map, uint8_t label) {
+    auto* buf = map->GetBufferPointer();
+    auto size = map->GetLargestPossibleRegion().GetSize();
+    size_t total = size[0] * size[1] * size[2];
+    int count = 0;
+    for (size_t i = 0; i < total; ++i) {
+        if (buf[i] == label) ++count;
+    }
+    return count;
+}
+
+}  // namespace
+
+// =============================================================================
+// Validation tests
+// =============================================================================
+
+TEST(MaskBooleanOperations, NullInputReturnsError) {
+    auto mapA = createEmptyMap(10, 10, 1);
+
+    auto r1 = MaskBooleanOperations::computeUnion(nullptr, mapA);
+    EXPECT_FALSE(r1.has_value());
+
+    auto r2 = MaskBooleanOperations::computeUnion(mapA, nullptr);
+    EXPECT_FALSE(r2.has_value());
+
+    auto r3 = MaskBooleanOperations::computeDifference(nullptr, nullptr);
+    EXPECT_FALSE(r3.has_value());
+}
+
+TEST(MaskBooleanOperations, DimensionMismatchReturnsError) {
+    auto mapA = createEmptyMap(10, 10, 1);
+    auto mapB = createEmptyMap(20, 10, 1);
+
+    auto result = MaskBooleanOperations::computeUnion(mapA, mapB);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_NE(result.error().message.find("Dimension mismatch"), std::string::npos);
+}
+
+TEST(MaskBooleanOperations, SpacingMismatchReturnsError) {
+    auto mapA = createEmptyMap(10, 10, 1);
+    auto mapB = createEmptyMap(10, 10, 1);
+
+    LabelMapType::SpacingType differentSpacing;
+    differentSpacing[0] = 2.0; differentSpacing[1] = 1.0; differentSpacing[2] = 1.0;
+    mapB->SetSpacing(differentSpacing);
+
+    auto result = MaskBooleanOperations::computeIntersection(mapA, mapB);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_NE(result.error().message.find("Spacing mismatch"), std::string::npos);
+}
+
+// =============================================================================
+// Union tests
+// =============================================================================
+
+TEST(MaskBooleanOperations, UnionNonOverlapping) {
+    // A: left half labeled 1, B: right half labeled 2
+    auto mapA = createEmptyMap(10, 10, 1);
+    auto mapB = createEmptyMap(10, 10, 1);
+    auto* bufA = mapA->GetBufferPointer();
+    auto* bufB = mapB->GetBufferPointer();
+
+    for (int y = 0; y < 10; ++y) {
+        for (int x = 0; x < 5; ++x) {
+            bufA[y * 10 + x] = 1;
+        }
+        for (int x = 5; x < 10; ++x) {
+            bufB[y * 10 + x] = 2;
+        }
+    }
+
+    auto result = MaskBooleanOperations::computeUnion(mapA, mapB);
+    ASSERT_TRUE(result.has_value());
+
+    EXPECT_EQ(countNonZero(*result), 100);
+    EXPECT_EQ(countLabel(*result, 1), 50);
+    EXPECT_EQ(countLabel(*result, 2), 50);
+}
+
+TEST(MaskBooleanOperations, UnionOverlappingAPriority) {
+    // Both A and B cover entire map with different labels
+    auto mapA = createEmptyMap(10, 10, 1);
+    auto mapB = createEmptyMap(10, 10, 1);
+    auto* bufA = mapA->GetBufferPointer();
+    auto* bufB = mapB->GetBufferPointer();
+
+    for (int i = 0; i < 100; ++i) {
+        bufA[i] = 1;
+        bufB[i] = 2;
+    }
+
+    auto result = MaskBooleanOperations::computeUnion(mapA, mapB);
+    ASSERT_TRUE(result.has_value());
+
+    // A takes priority → all should be label 1
+    EXPECT_EQ(countLabel(*result, 1), 100);
+    EXPECT_EQ(countLabel(*result, 2), 0);
+}
+
+TEST(MaskBooleanOperations, UnionBothEmpty) {
+    auto mapA = createEmptyMap(10, 10, 1);
+    auto mapB = createEmptyMap(10, 10, 1);
+
+    auto result = MaskBooleanOperations::computeUnion(mapA, mapB);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(countNonZero(*result), 0);
+}
+
+TEST(MaskBooleanOperations, UnionPreservesOriginals) {
+    auto mapA = createEmptyMap(10, 10, 1);
+    auto mapB = createEmptyMap(10, 10, 1);
+    mapA->GetBufferPointer()[0] = 1;
+
+    auto result = MaskBooleanOperations::computeUnion(mapA, mapB);
+    ASSERT_TRUE(result.has_value());
+
+    // Original maps unmodified
+    EXPECT_EQ(mapA->GetBufferPointer()[0], 1);
+    EXPECT_EQ(mapB->GetBufferPointer()[0], 0);
+    // Result is a different pointer
+    EXPECT_NE(result->GetPointer(), mapA.GetPointer());
+}
+
+// =============================================================================
+// Difference tests
+// =============================================================================
+
+TEST(MaskBooleanOperations, DifferenceRemovesOverlap) {
+    // A: entire row y=0 labeled 1
+    // B: first 5 columns labeled 2
+    auto mapA = createEmptyMap(10, 10, 1);
+    auto mapB = createEmptyMap(10, 10, 1);
+    auto* bufA = mapA->GetBufferPointer();
+    auto* bufB = mapB->GetBufferPointer();
+
+    for (int x = 0; x < 10; ++x) {
+        bufA[x] = 1;  // y=0, all x
+    }
+    for (int x = 0; x < 5; ++x) {
+        bufB[x] = 2;  // y=0, x=0..4
+    }
+
+    auto result = MaskBooleanOperations::computeDifference(mapA, mapB);
+    ASSERT_TRUE(result.has_value());
+
+    auto* bufOut = result->GetPointer()->GetBufferPointer();
+
+    // x=0..4 removed (overlap), x=5..9 remain
+    for (int x = 0; x < 5; ++x) {
+        EXPECT_EQ(bufOut[x], 0) << "Overlapping voxel at x=" << x << " should be removed";
+    }
+    for (int x = 5; x < 10; ++x) {
+        EXPECT_EQ(bufOut[x], 1) << "Non-overlapping voxel at x=" << x << " should remain";
+    }
+}
+
+TEST(MaskBooleanOperations, DifferenceNoOverlap) {
+    auto mapA = createEmptyMap(10, 10, 1);
+    auto mapB = createEmptyMap(10, 10, 1);
+
+    // A: left, B: right → no overlap
+    for (int i = 0; i < 50; ++i) mapA->GetBufferPointer()[i] = 1;
+    for (int i = 50; i < 100; ++i) mapB->GetBufferPointer()[i] = 2;
+
+    auto result = MaskBooleanOperations::computeDifference(mapA, mapB);
+    ASSERT_TRUE(result.has_value());
+
+    // A preserved entirely since no overlap
+    EXPECT_EQ(countLabel(*result, 1), 50);
+}
+
+TEST(MaskBooleanOperations, DifferenceCompleteSubtraction) {
+    auto mapA = createEmptyMap(10, 10, 1);
+    auto mapB = createEmptyMap(10, 10, 1);
+
+    // Both cover all voxels
+    for (int i = 0; i < 100; ++i) {
+        mapA->GetBufferPointer()[i] = 1;
+        mapB->GetBufferPointer()[i] = 2;
+    }
+
+    auto result = MaskBooleanOperations::computeDifference(mapA, mapB);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(countNonZero(*result), 0)
+        << "Complete overlap should produce empty result";
+}
+
+// =============================================================================
+// Intersection tests
+// =============================================================================
+
+TEST(MaskBooleanOperations, IntersectionKeepsOverlapOnly) {
+    auto mapA = createEmptyMap(10, 10, 1);
+    auto mapB = createEmptyMap(10, 10, 1);
+    auto* bufA = mapA->GetBufferPointer();
+    auto* bufB = mapB->GetBufferPointer();
+
+    // A: x=0..6, B: x=3..9 → overlap x=3..6
+    for (int y = 0; y < 10; ++y) {
+        for (int x = 0; x <= 6; ++x) bufA[y * 10 + x] = 1;
+        for (int x = 3; x <= 9; ++x) bufB[y * 10 + x] = 2;
+    }
+
+    auto result = MaskBooleanOperations::computeIntersection(mapA, mapB);
+    ASSERT_TRUE(result.has_value());
+
+    // Overlap: x=3..6 → 4 columns × 10 rows = 40 voxels
+    EXPECT_EQ(countNonZero(*result), 40);
+    // Label from A
+    EXPECT_EQ(countLabel(*result, 1), 40);
+}
+
+TEST(MaskBooleanOperations, IntersectionNoOverlapProducesEmpty) {
+    auto mapA = createEmptyMap(10, 10, 1);
+    auto mapB = createEmptyMap(10, 10, 1);
+
+    for (int i = 0; i < 50; ++i) mapA->GetBufferPointer()[i] = 1;
+    for (int i = 50; i < 100; ++i) mapB->GetBufferPointer()[i] = 2;
+
+    auto result = MaskBooleanOperations::computeIntersection(mapA, mapB);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(countNonZero(*result), 0);
+}
+
+// =============================================================================
+// Multi-mask union tests
+// =============================================================================
+
+TEST(MaskBooleanOperations, UnionMultipleTooFewReturnsError) {
+    std::vector<LabelMapType::Pointer> masks;
+    masks.push_back(createEmptyMap(10, 10, 1));
+
+    auto result = MaskBooleanOperations::computeUnionMultiple(masks);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(MaskBooleanOperations, UnionMultipleThreeMasks) {
+    auto m1 = createEmptyMap(10, 1, 1);
+    auto m2 = createEmptyMap(10, 1, 1);
+    auto m3 = createEmptyMap(10, 1, 1);
+
+    // m1: x=0..2, m2: x=3..5, m3: x=6..8
+    for (int x = 0; x <= 2; ++x) m1->GetBufferPointer()[x] = 1;
+    for (int x = 3; x <= 5; ++x) m2->GetBufferPointer()[x] = 2;
+    for (int x = 6; x <= 8; ++x) m3->GetBufferPointer()[x] = 3;
+
+    auto result = MaskBooleanOperations::computeUnionMultiple({m1, m2, m3});
+    ASSERT_TRUE(result.has_value());
+
+    EXPECT_EQ(countNonZero(*result), 9);
+    EXPECT_EQ(countLabel(*result, 1), 3);
+    EXPECT_EQ(countLabel(*result, 2), 3);
+    EXPECT_EQ(countLabel(*result, 3), 3);
+}
+
+// =============================================================================
+// 3D volume test
+// =============================================================================
+
+TEST(MaskBooleanOperations, ThreeDimensionalVolume) {
+    // Test with an actual 3D volume
+    auto mapA = createEmptyMap(10, 10, 10);
+    auto mapB = createEmptyMap(10, 10, 10);
+
+    // A: slice 0-4 filled, B: slice 3-7 filled
+    auto* bufA = mapA->GetBufferPointer();
+    auto* bufB = mapB->GetBufferPointer();
+    int sliceSize = 10 * 10;
+
+    for (int z = 0; z < 5; ++z) {
+        for (int i = 0; i < sliceSize; ++i) {
+            bufA[z * sliceSize + i] = 1;
+        }
+    }
+    for (int z = 3; z < 8; ++z) {
+        for (int i = 0; i < sliceSize; ++i) {
+            bufB[z * sliceSize + i] = 2;
+        }
+    }
+
+    // Union: slices 0-7 = 800 voxels
+    auto unionResult = MaskBooleanOperations::computeUnion(mapA, mapB);
+    ASSERT_TRUE(unionResult.has_value());
+    EXPECT_EQ(countNonZero(*unionResult), 800);
+
+    // Intersection: slices 3-4 = 200 voxels
+    auto interResult = MaskBooleanOperations::computeIntersection(mapA, mapB);
+    ASSERT_TRUE(interResult.has_value());
+    EXPECT_EQ(countNonZero(*interResult), 200);
+
+    // Difference A\B: slices 0-2 = 300 voxels
+    auto diffResult = MaskBooleanOperations::computeDifference(mapA, mapB);
+    ASSERT_TRUE(diffResult.has_value());
+    EXPECT_EQ(countNonZero(*diffResult), 300);
+}


### PR DESCRIPTION
Closes #251

## Summary
- Add `MaskBooleanOperations` class with static methods for voxel-wise set operations on ITK `uint8_t` label maps
- **Union** (A ∪ B): combine two masks, mask A takes priority at overlapping voxels
- **Difference** (A \ B): keep A-labeled voxels only where B is empty (background)
- **Intersection** (A ∩ B): keep A-labeled voxels only where both masks have non-zero labels
- **Multi-mask union**: sequentially combine 3+ masks with left-to-right priority
- Validate dimension and spacing compatibility between input maps before operations
- All operations produce new label maps, preserving original inputs

## Design Decisions
- Used `itk::Image<uint8_t, 3>` (existing `LabelMapType`) instead of `vtkImageData` to stay consistent with the segmentation module
- Static methods (no state) since operations are pure functions
- Label priority in Union: mask A wins at overlap — this matches the expected workflow where users combine a "primary" segmentation with a "secondary" one

## Test Plan
- [x] All 15 mask_boolean_operations_test cases pass
- [x] Null input validation (3 tests)
- [x] Dimension mismatch detection
- [x] Spacing mismatch detection
- [x] Union: non-overlapping, overlapping with A-priority, both empty, preserves originals
- [x] Difference: removes overlap, no-overlap preservation, complete subtraction
- [x] Intersection: keeps overlap only, no-overlap produces empty
- [x] Multi-mask union: minimum 2 masks validation, 3-mask sequential union
- [x] Full 3D volume test (10×10×10) verifying Union/Intersection/Difference voxel counts