### PR TITLE
feat(flow): implement Energy Loss (3D) viscous dissipation calculation

### DIFF
--- a/include/services/flow/vessel_analyzer.hpp
+++ b/include/services/flow/vessel_analyzer.hpp
@@ -61,6 +61,23 @@ struct KineticEnergyResult {
 };
 
 /**
+ * @brief Viscous dissipation (Energy Loss) analysis result
+ *
+ * Φ = μ { 2(∂u/∂x)² + 2(∂v/∂y)² + 2(∂w/∂z)²
+ *       + (∂u/∂y + ∂v/∂x)² + (∂v/∂z + ∂w/∂y)² + (∂u/∂z + ∂w/∂x)² }
+ *
+ * Per-voxel dissipation rate in W/m³, total in Watts.
+ *
+ * @trace SRS-FR-047
+ */
+struct EnergyLossResult {
+    FloatImage3D::Pointer dissipationField;  ///< Per-voxel dissipation rate (W/m³)
+    double totalEnergyLoss = 0.0;            ///< Integrated energy loss (Watts)
+    double meanDissipation = 0.0;            ///< Mean per-voxel dissipation (W/m³)
+    int voxelCount = 0;                      ///< Number of voxels in computation
+};
+
+/**
  * @brief Advanced hemodynamic analysis for 4D Flow velocity data
  *
  * Computes Wall Shear Stress (WSS), Oscillatory Shear Index (OSI),
@@ -213,6 +230,23 @@ public:
     [[nodiscard]] std::expected<KineticEnergyResult, FlowError>
     computeKineticEnergy(const VelocityPhase& phase,
                          FloatImage3D::Pointer mask = nullptr) const;
+
+    // --- Energy Loss (Viscous Dissipation) ---
+
+    /**
+     * @brief Compute viscous dissipation rate (Energy Loss) from velocity field
+     *
+     * Φ = μ × (strain rate tensor double contraction)
+     * Uses all 9 partial derivatives of the velocity gradient tensor
+     * computed via central finite differences.
+     *
+     * @param phase Velocity field
+     * @param mask Optional mask restricting computation to ROI (non-zero voxels)
+     * @return EnergyLossResult with per-voxel dissipation and total energy loss
+     */
+    [[nodiscard]] std::expected<EnergyLossResult, FlowError>
+    computeEnergyLoss(const VelocityPhase& phase,
+                      FloatImage3D::Pointer mask = nullptr) const;
 
     // --- Relative Residence Time ---
 


### PR DESCRIPTION
Closes #238

## Summary
- Add `EnergyLossResult` struct and `computeEnergyLoss()` method to `VesselAnalyzer`
- Compute full 3x3 velocity gradient tensor (9 partial derivatives) via central finite differences
- Apply viscous dissipation formula: Φ = μ{2(∂u/∂x)² + 2(∂v/∂y)² + 2(∂w/∂z)² + (∂u/∂y + ∂v/∂x)² + (∂v/∂z + ∂w/∂y)² + (∂u/∂z + ∂w/∂x)²}
- Support optional mask for ROI-restricted computation
- Output per-voxel dissipation rate (W/m³) and volume-integrated total energy loss (Watts)
- Unit conversion: velocity cm/s, spacing mm → SI gradients (1/s) via ×10 factor

## Test Plan
- [x] Null input returns error
- [x] Uniform flow produces zero dissipation (all gradients zero)
- [x] Uniform shear flow matches analytical solution exactly (μ×γ̇² = 1.6 W/m³)
- [x] Poiseuille pipe flow within ±6% of analytical (EL = 2πμV²L)
- [x] Mask restricts computation to ROI with correct voxel count
- [x] Output image dimensions match input
- [x] Dissipation scales linearly with viscosity (2× μ → 2× Φ)
- [x] All 38 vessel analyzer tests pass (28 existing + 3 KE + 7 Energy Loss)