### PR TITLE
feat(core): implement data serialization for .flo project files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,6 +332,7 @@ add_library(dicom_viewer_core STATIC
     src/core/image/hounsfield_converter.cpp
     src/core/zip_archive.cpp
     src/core/project_manager.cpp
+    src/core/data_serializer.cpp
 )
 
 target_include_directories(dicom_viewer_core PUBLIC

--- a/include/core/data_serializer.hpp
+++ b/include/core/data_serializer.hpp
@@ -1,0 +1,188 @@
+#pragma once
+
+#include "core/project_manager.hpp"
+#include "core/zip_archive.hpp"
+
+#include <array>
+#include <cstdint>
+#include <expected>
+#include <string>
+#include <vector>
+
+#include <itkImage.h>
+#include <itkVectorImage.h>
+
+#include <nlohmann/json_fwd.hpp>
+
+namespace dicom_viewer::core {
+
+/**
+ * @brief Serializer for image data and analysis results into .flo project files
+ *
+ * Provides NRRD-based serialization for ITK images (scalar, vector, label map)
+ * and JSON-based serialization for analysis results. Designed to work with
+ * ZipArchive for the .flo project container format.
+ *
+ * ZIP entry layout:
+ * @code
+ * data/
+ * ├── velocity/
+ * │   ├── phase_0000.nrrd       // VectorImage3D (3-component velocity)
+ * │   ├── phase_0001.nrrd
+ * │   └── ...
+ * ├── magnitude/
+ * │   ├── phase_0000.nrrd       // FloatImage3D
+ * │   └── ...
+ * ├── mask/
+ * │   ├── label_map.nrrd        // uint8 label map
+ * │   └── labels.json           // label definitions (name, color, opacity)
+ * └── analysis/
+ *     └── results.json          // measurements, flow, hemodynamics
+ * @endcode
+ *
+ * NRRD uses raw encoding (ZIP handles compression via DEFLATE).
+ *
+ * @trace SRS-FR-050
+ */
+class DataSerializer {
+public:
+    using FloatImage3D = itk::Image<float, 3>;
+    using VectorImage3D = itk::VectorImage<float, 3>;
+    using LabelMapType = itk::Image<uint8_t, 3>;
+
+    /**
+     * @brief Definition of a segmentation label
+     */
+    struct LabelDefinition {
+        uint8_t id = 0;
+        std::string name;
+        std::array<float, 3> color = {1.0f, 0.0f, 0.0f};  ///< RGB [0,1]
+        float opacity = 1.0f;
+    };
+
+    // =========================================================================
+    // Low-level NRRD encoding/decoding (public for testing)
+    // =========================================================================
+
+    /**
+     * @brief Encode a scalar float image as NRRD bytes (raw encoding)
+     * @param image Source image (non-null)
+     * @return NRRD header + raw float data
+     */
+    [[nodiscard]] static std::vector<uint8_t>
+    scalarImageToNRRD(const FloatImage3D* image);
+
+    /**
+     * @brief Decode NRRD bytes to a scalar float image
+     * @param data NRRD bytes (header + raw data)
+     * @return Decoded image or ProjectError
+     */
+    [[nodiscard]] static std::expected<FloatImage3D::Pointer, ProjectError>
+    nrrdToScalarImage(const std::vector<uint8_t>& data);
+
+    /**
+     * @brief Encode a 3-component vector image as NRRD bytes
+     * @param image Source vector image (non-null, 3 components)
+     * @return NRRD header + raw float data
+     */
+    [[nodiscard]] static std::vector<uint8_t>
+    vectorImageToNRRD(const VectorImage3D* image);
+
+    /**
+     * @brief Decode NRRD bytes to a 3-component vector image
+     * @param data NRRD bytes (header + raw data)
+     * @return Decoded image or ProjectError
+     */
+    [[nodiscard]] static std::expected<VectorImage3D::Pointer, ProjectError>
+    nrrdToVectorImage(const std::vector<uint8_t>& data);
+
+    /**
+     * @brief Encode a uint8 label map as NRRD bytes
+     * @param image Source label map (non-null)
+     * @return NRRD header + raw uint8 data
+     */
+    [[nodiscard]] static std::vector<uint8_t>
+    labelMapToNRRD(const LabelMapType* image);
+
+    /**
+     * @brief Decode NRRD bytes to a uint8 label map
+     * @param data NRRD bytes (header + raw data)
+     * @return Decoded label map or ProjectError
+     */
+    [[nodiscard]] static std::expected<LabelMapType::Pointer, ProjectError>
+    nrrdToLabelMap(const std::vector<uint8_t>& data);
+
+    // =========================================================================
+    // High-level ZIP serialization
+    // =========================================================================
+
+    /**
+     * @brief Save velocity fields for all phases into a ZipArchive
+     *
+     * Each phase is stored as data/velocity/phase_NNNN.nrrd.
+     *
+     * @param zip Archive to add entries to
+     * @param velocityPhases Vector of velocity fields (VectorImage3D)
+     * @param magnitudePhases Vector of magnitude images (FloatImage3D)
+     */
+    [[nodiscard]] static std::expected<void, ProjectError>
+    saveVelocityData(ZipArchive& zip,
+                     const std::vector<VectorImage3D::Pointer>& velocityPhases,
+                     const std::vector<FloatImage3D::Pointer>& magnitudePhases);
+
+    /**
+     * @brief Load velocity fields from a ZipArchive
+     *
+     * @param zip Archive to read from
+     * @param[out] velocityPhases Loaded velocity fields
+     * @param[out] magnitudePhases Loaded magnitude images
+     */
+    [[nodiscard]] static std::expected<void, ProjectError>
+    loadVelocityData(const ZipArchive& zip,
+                     std::vector<VectorImage3D::Pointer>& velocityPhases,
+                     std::vector<FloatImage3D::Pointer>& magnitudePhases);
+
+    /**
+     * @brief Save segmentation mask and label definitions
+     *
+     * @param zip Archive to add entries to
+     * @param labelMap Label map image
+     * @param labels Label definitions (name, color, opacity per label)
+     */
+    [[nodiscard]] static std::expected<void, ProjectError>
+    saveMask(ZipArchive& zip,
+             const LabelMapType* labelMap,
+             const std::vector<LabelDefinition>& labels);
+
+    /**
+     * @brief Load segmentation mask and label definitions
+     *
+     * @param zip Archive to read from
+     * @param[out] labelMap Loaded label map
+     * @param[out] labels Loaded label definitions
+     */
+    [[nodiscard]] static std::expected<void, ProjectError>
+    loadMask(const ZipArchive& zip,
+             LabelMapType::Pointer& labelMap,
+             std::vector<LabelDefinition>& labels);
+
+    /**
+     * @brief Save analysis results as JSON
+     *
+     * @param zip Archive to add entries to
+     * @param results JSON object with flow metrics, hemodynamics, measurements
+     */
+    [[nodiscard]] static std::expected<void, ProjectError>
+    saveAnalysisResults(ZipArchive& zip, const nlohmann::json& results);
+
+    /**
+     * @brief Load analysis results from JSON
+     *
+     * @param zip Archive to read from
+     * @return JSON object or ProjectError
+     */
+    [[nodiscard]] static std::expected<nlohmann::json, ProjectError>
+    loadAnalysisResults(const ZipArchive& zip);
+};
+
+}  // namespace dicom_viewer::core

--- a/src/core/data_serializer.cpp
+++ b/src/core/data_serializer.cpp
@@ -1,0 +1,553 @@
+#include "core/data_serializer.hpp"
+
+#include <cstring>
+#include <iomanip>
+#include <sstream>
+#include <stdexcept>
+
+#include <nlohmann/json.hpp>
+
+namespace dicom_viewer::core {
+
+// =============================================================================
+// NRRD header helpers
+// =============================================================================
+
+namespace {
+
+/**
+ * @brief Build NRRD header + raw data for a 3D image
+ *
+ * NRRD format: text header terminated by blank line, followed by raw bytes.
+ */
+std::vector<uint8_t> buildNRRD(const std::string& type,
+                               int dimension,
+                               const std::vector<int>& sizes,
+                               const std::vector<double>& spacings,
+                               const std::array<double, 3>& origin,
+                               const uint8_t* rawData,
+                               size_t rawBytes) {
+    std::ostringstream header;
+    header << "NRRD0004\n";
+    header << "type: " << type << "\n";
+    header << "dimension: " << dimension << "\n";
+
+    header << "sizes:";
+    for (int s : sizes) header << " " << s;
+    header << "\n";
+
+    header << "spacings:";
+    for (double sp : spacings) {
+        header << " " << std::fixed << std::setprecision(6) << sp;
+    }
+    header << "\n";
+
+    header << "space origin: ("
+           << std::fixed << std::setprecision(6)
+           << origin[0] << "," << origin[1] << "," << origin[2]
+           << ")\n";
+
+    header << "encoding: raw\n";
+    header << "endian: little\n";
+    header << "\n";  // Blank line terminates header
+
+    std::string hdr = header.str();
+    std::vector<uint8_t> result;
+    result.reserve(hdr.size() + rawBytes);
+    result.insert(result.end(), hdr.begin(), hdr.end());
+    result.insert(result.end(), rawData, rawData + rawBytes);
+    return result;
+}
+
+/**
+ * @brief Parse NRRD header, returning header fields and offset to raw data
+ */
+struct NRRDHeader {
+    std::string type;
+    int dimension = 0;
+    std::vector<int> sizes;
+    std::vector<double> spacings;
+    std::array<double, 3> origin = {0, 0, 0};
+    size_t dataOffset = 0;
+};
+
+std::expected<NRRDHeader, ProjectError>
+parseNRRDHeader(const std::vector<uint8_t>& data) {
+    // Find the blank line that separates header from data
+    std::string content(data.begin(), data.end());
+    size_t headerEnd = content.find("\n\n");
+    if (headerEnd == std::string::npos) {
+        return std::unexpected(ProjectError::InvalidFormat);
+    }
+
+    NRRDHeader hdr;
+    hdr.dataOffset = headerEnd + 2;  // Skip the two newlines
+
+    // Parse header lines
+    std::istringstream stream(content.substr(0, headerEnd));
+    std::string line;
+
+    // First line must be NRRD magic
+    if (!std::getline(stream, line) || line.substr(0, 4) != "NRRD") {
+        return std::unexpected(ProjectError::InvalidFormat);
+    }
+
+    while (std::getline(stream, line)) {
+        if (line.empty() || line[0] == '#') continue;
+
+        auto colonPos = line.find(':');
+        if (colonPos == std::string::npos) continue;
+
+        std::string key = line.substr(0, colonPos);
+        std::string value = line.substr(colonPos + 1);
+        // Trim leading whitespace
+        size_t start = value.find_first_not_of(" \t");
+        if (start != std::string::npos) value = value.substr(start);
+
+        if (key == "type") {
+            hdr.type = value;
+        } else if (key == "dimension") {
+            hdr.dimension = std::stoi(value);
+        } else if (key == "sizes") {
+            std::istringstream ss(value);
+            int s;
+            while (ss >> s) hdr.sizes.push_back(s);
+        } else if (key == "spacings") {
+            std::istringstream ss(value);
+            std::string token;
+            while (ss >> token) {
+                if (token == "nan" || token == "NaN" || token == "NAN") {
+                    hdr.spacings.push_back(
+                        std::numeric_limits<double>::quiet_NaN());
+                } else {
+                    try {
+                        hdr.spacings.push_back(std::stod(token));
+                    } catch (...) {
+                        hdr.spacings.push_back(1.0);
+                    }
+                }
+            }
+        } else if (key == "space origin") {
+            // Parse "(x,y,z)" format
+            auto start = value.find('(');
+            auto end = value.find(')');
+            if (start != std::string::npos && end != std::string::npos) {
+                std::string coords = value.substr(start + 1, end - start - 1);
+                std::istringstream ss(coords);
+                char comma;
+                ss >> hdr.origin[0] >> comma
+                   >> hdr.origin[1] >> comma
+                   >> hdr.origin[2];
+            }
+        }
+    }
+
+    return hdr;
+}
+
+std::string formatPhaseIndex(int index) {
+    std::ostringstream ss;
+    ss << std::setw(4) << std::setfill('0') << index;
+    return ss.str();
+}
+
+}  // anonymous namespace
+
+// =============================================================================
+// Scalar image NRRD
+// =============================================================================
+
+std::vector<uint8_t>
+DataSerializer::scalarImageToNRRD(const FloatImage3D* image) {
+    auto size = image->GetLargestPossibleRegion().GetSize();
+    auto spacing = image->GetSpacing();
+    auto origin = image->GetOrigin();
+
+    std::vector<int> sizes = {
+        static_cast<int>(size[0]),
+        static_cast<int>(size[1]),
+        static_cast<int>(size[2])
+    };
+    std::vector<double> spacings = {spacing[0], spacing[1], spacing[2]};
+    std::array<double, 3> org = {origin[0], origin[1], origin[2]};
+
+    size_t numVoxels = size[0] * size[1] * size[2];
+    auto* buf = reinterpret_cast<const uint8_t*>(image->GetBufferPointer());
+
+    return buildNRRD("float", 3, sizes, spacings, org,
+                     buf, numVoxels * sizeof(float));
+}
+
+std::expected<DataSerializer::FloatImage3D::Pointer, ProjectError>
+DataSerializer::nrrdToScalarImage(const std::vector<uint8_t>& data) {
+    auto hdrResult = parseNRRDHeader(data);
+    if (!hdrResult) return std::unexpected(hdrResult.error());
+    auto& hdr = *hdrResult;
+
+    if (hdr.type != "float" || hdr.dimension != 3 || hdr.sizes.size() != 3) {
+        return std::unexpected(ProjectError::InvalidFormat);
+    }
+
+    size_t numVoxels = static_cast<size_t>(hdr.sizes[0])
+                       * hdr.sizes[1] * hdr.sizes[2];
+    size_t expectedBytes = numVoxels * sizeof(float);
+    if (data.size() < hdr.dataOffset + expectedBytes) {
+        return std::unexpected(ProjectError::InvalidFormat);
+    }
+
+    auto image = FloatImage3D::New();
+    FloatImage3D::RegionType region;
+    FloatImage3D::SizeType sz;
+    sz[0] = hdr.sizes[0]; sz[1] = hdr.sizes[1]; sz[2] = hdr.sizes[2];
+    region.SetSize(sz);
+    image->SetRegions(region);
+
+    FloatImage3D::SpacingType sp;
+    sp[0] = hdr.spacings.size() > 0 ? hdr.spacings[0] : 1.0;
+    sp[1] = hdr.spacings.size() > 1 ? hdr.spacings[1] : 1.0;
+    sp[2] = hdr.spacings.size() > 2 ? hdr.spacings[2] : 1.0;
+    image->SetSpacing(sp);
+
+    FloatImage3D::PointType org;
+    org[0] = hdr.origin[0]; org[1] = hdr.origin[1]; org[2] = hdr.origin[2];
+    image->SetOrigin(org);
+
+    image->Allocate();
+    std::memcpy(image->GetBufferPointer(),
+                data.data() + hdr.dataOffset, expectedBytes);
+
+    return image;
+}
+
+// =============================================================================
+// Vector image NRRD
+// =============================================================================
+
+std::vector<uint8_t>
+DataSerializer::vectorImageToNRRD(const VectorImage3D* image) {
+    auto size = image->GetLargestPossibleRegion().GetSize();
+    auto spacing = image->GetSpacing();
+    auto origin = image->GetOrigin();
+    int numComponents = static_cast<int>(image->GetNumberOfComponentsPerPixel());
+
+    std::vector<int> sizes = {
+        numComponents,
+        static_cast<int>(size[0]),
+        static_cast<int>(size[1]),
+        static_cast<int>(size[2])
+    };
+    // NaN for the component axis spacing (not spatial)
+    std::vector<double> spacings = {
+        std::numeric_limits<double>::quiet_NaN(),
+        spacing[0], spacing[1], spacing[2]
+    };
+    std::array<double, 3> org = {origin[0], origin[1], origin[2]};
+
+    size_t numVoxels = size[0] * size[1] * size[2];
+    auto* buf = reinterpret_cast<const uint8_t*>(image->GetBufferPointer());
+
+    return buildNRRD("float", 4, sizes, spacings, org,
+                     buf, numVoxels * numComponents * sizeof(float));
+}
+
+std::expected<DataSerializer::VectorImage3D::Pointer, ProjectError>
+DataSerializer::nrrdToVectorImage(const std::vector<uint8_t>& data) {
+    auto hdrResult = parseNRRDHeader(data);
+    if (!hdrResult) return std::unexpected(hdrResult.error());
+    auto& hdr = *hdrResult;
+
+    if (hdr.type != "float" || hdr.dimension != 4 || hdr.sizes.size() != 4) {
+        return std::unexpected(ProjectError::InvalidFormat);
+    }
+
+    int numComponents = hdr.sizes[0];
+    int nx = hdr.sizes[1], ny = hdr.sizes[2], nz = hdr.sizes[3];
+    size_t numVoxels = static_cast<size_t>(nx) * ny * nz;
+    size_t expectedBytes = numVoxels * numComponents * sizeof(float);
+
+    if (data.size() < hdr.dataOffset + expectedBytes) {
+        return std::unexpected(ProjectError::InvalidFormat);
+    }
+
+    auto image = VectorImage3D::New();
+    VectorImage3D::RegionType region;
+    VectorImage3D::SizeType sz;
+    sz[0] = nx; sz[1] = ny; sz[2] = nz;
+    region.SetSize(sz);
+    image->SetRegions(region);
+    image->SetNumberOfComponentsPerPixel(numComponents);
+
+    VectorImage3D::SpacingType sp;
+    sp[0] = hdr.spacings.size() > 1 ? hdr.spacings[1] : 1.0;
+    sp[1] = hdr.spacings.size() > 2 ? hdr.spacings[2] : 1.0;
+    sp[2] = hdr.spacings.size() > 3 ? hdr.spacings[3] : 1.0;
+    image->SetSpacing(sp);
+
+    VectorImage3D::PointType org;
+    org[0] = hdr.origin[0]; org[1] = hdr.origin[1]; org[2] = hdr.origin[2];
+    image->SetOrigin(org);
+
+    image->Allocate();
+    std::memcpy(image->GetBufferPointer(),
+                data.data() + hdr.dataOffset, expectedBytes);
+
+    return image;
+}
+
+// =============================================================================
+// Label map NRRD
+// =============================================================================
+
+std::vector<uint8_t>
+DataSerializer::labelMapToNRRD(const LabelMapType* image) {
+    auto size = image->GetLargestPossibleRegion().GetSize();
+    auto spacing = image->GetSpacing();
+    auto origin = image->GetOrigin();
+
+    std::vector<int> sizes = {
+        static_cast<int>(size[0]),
+        static_cast<int>(size[1]),
+        static_cast<int>(size[2])
+    };
+    std::vector<double> spacings = {spacing[0], spacing[1], spacing[2]};
+    std::array<double, 3> org = {origin[0], origin[1], origin[2]};
+
+    size_t numVoxels = size[0] * size[1] * size[2];
+    auto* buf = image->GetBufferPointer();
+
+    return buildNRRD("unsigned char", 3, sizes, spacings, org,
+                     buf, numVoxels);
+}
+
+std::expected<DataSerializer::LabelMapType::Pointer, ProjectError>
+DataSerializer::nrrdToLabelMap(const std::vector<uint8_t>& data) {
+    auto hdrResult = parseNRRDHeader(data);
+    if (!hdrResult) return std::unexpected(hdrResult.error());
+    auto& hdr = *hdrResult;
+
+    if ((hdr.type != "unsigned char" && hdr.type != "uint8")
+        || hdr.dimension != 3 || hdr.sizes.size() != 3) {
+        return std::unexpected(ProjectError::InvalidFormat);
+    }
+
+    size_t numVoxels = static_cast<size_t>(hdr.sizes[0])
+                       * hdr.sizes[1] * hdr.sizes[2];
+
+    if (data.size() < hdr.dataOffset + numVoxels) {
+        return std::unexpected(ProjectError::InvalidFormat);
+    }
+
+    auto image = LabelMapType::New();
+    LabelMapType::RegionType region;
+    LabelMapType::SizeType sz;
+    sz[0] = hdr.sizes[0]; sz[1] = hdr.sizes[1]; sz[2] = hdr.sizes[2];
+    region.SetSize(sz);
+    image->SetRegions(region);
+
+    LabelMapType::SpacingType sp;
+    sp[0] = hdr.spacings.size() > 0 ? hdr.spacings[0] : 1.0;
+    sp[1] = hdr.spacings.size() > 1 ? hdr.spacings[1] : 1.0;
+    sp[2] = hdr.spacings.size() > 2 ? hdr.spacings[2] : 1.0;
+    image->SetSpacing(sp);
+
+    LabelMapType::PointType org;
+    org[0] = hdr.origin[0]; org[1] = hdr.origin[1]; org[2] = hdr.origin[2];
+    image->SetOrigin(org);
+
+    image->Allocate();
+    std::memcpy(image->GetBufferPointer(),
+                data.data() + hdr.dataOffset, numVoxels);
+
+    return image;
+}
+
+// =============================================================================
+// High-level ZIP serialization
+// =============================================================================
+
+std::expected<void, ProjectError>
+DataSerializer::saveVelocityData(
+    ZipArchive& zip,
+    const std::vector<VectorImage3D::Pointer>& velocityPhases,
+    const std::vector<FloatImage3D::Pointer>& magnitudePhases) {
+
+    for (size_t i = 0; i < velocityPhases.size(); ++i) {
+        if (!velocityPhases[i]) {
+            return std::unexpected(ProjectError::SerializationError);
+        }
+        std::string idx = formatPhaseIndex(static_cast<int>(i));
+        zip.addEntry("data/velocity/phase_" + idx + ".nrrd",
+                     vectorImageToNRRD(velocityPhases[i].GetPointer()));
+    }
+
+    for (size_t i = 0; i < magnitudePhases.size(); ++i) {
+        if (!magnitudePhases[i]) {
+            return std::unexpected(ProjectError::SerializationError);
+        }
+        std::string idx = formatPhaseIndex(static_cast<int>(i));
+        zip.addEntry("data/magnitude/phase_" + idx + ".nrrd",
+                     scalarImageToNRRD(magnitudePhases[i].GetPointer()));
+    }
+
+    // Store phase count for loading
+    nlohmann::json meta = {
+        {"velocity_count", static_cast<int>(velocityPhases.size())},
+        {"magnitude_count", static_cast<int>(magnitudePhases.size())}
+    };
+    zip.addEntry("data/velocity/meta.json", meta.dump(2));
+
+    return {};
+}
+
+std::expected<void, ProjectError>
+DataSerializer::loadVelocityData(
+    const ZipArchive& zip,
+    std::vector<VectorImage3D::Pointer>& velocityPhases,
+    std::vector<FloatImage3D::Pointer>& magnitudePhases) {
+
+    if (!zip.hasEntry("data/velocity/meta.json")) {
+        return std::unexpected(ProjectError::SerializationError);
+    }
+
+    auto metaStr = zip.readEntryAsString("data/velocity/meta.json");
+    if (!metaStr) {
+        return std::unexpected(ProjectError::SerializationError);
+    }
+
+    nlohmann::json meta;
+    try {
+        meta = nlohmann::json::parse(*metaStr);
+    } catch (...) {
+        return std::unexpected(ProjectError::InvalidFormat);
+    }
+
+    int velCount = meta.value("velocity_count", 0);
+    int magCount = meta.value("magnitude_count", 0);
+
+    velocityPhases.clear();
+    velocityPhases.reserve(velCount);
+
+    for (int i = 0; i < velCount; ++i) {
+        std::string idx = formatPhaseIndex(i);
+        std::string path = "data/velocity/phase_" + idx + ".nrrd";
+        auto entry = zip.readEntry(path);
+        if (!entry) {
+            return std::unexpected(ProjectError::SerializationError);
+        }
+        auto img = nrrdToVectorImage(*entry);
+        if (!img) return std::unexpected(img.error());
+        velocityPhases.push_back(*img);
+    }
+
+    magnitudePhases.clear();
+    magnitudePhases.reserve(magCount);
+
+    for (int i = 0; i < magCount; ++i) {
+        std::string idx = formatPhaseIndex(i);
+        std::string path = "data/magnitude/phase_" + idx + ".nrrd";
+        auto entry = zip.readEntry(path);
+        if (!entry) {
+            return std::unexpected(ProjectError::SerializationError);
+        }
+        auto img = nrrdToScalarImage(*entry);
+        if (!img) return std::unexpected(img.error());
+        magnitudePhases.push_back(*img);
+    }
+
+    return {};
+}
+
+std::expected<void, ProjectError>
+DataSerializer::saveMask(ZipArchive& zip,
+                         const LabelMapType* labelMap,
+                         const std::vector<LabelDefinition>& labels) {
+    if (!labelMap) {
+        return std::unexpected(ProjectError::SerializationError);
+    }
+
+    zip.addEntry("data/mask/label_map.nrrd", labelMapToNRRD(labelMap));
+
+    nlohmann::json labelsJson = nlohmann::json::array();
+    for (const auto& label : labels) {
+        labelsJson.push_back({
+            {"id", label.id},
+            {"name", label.name},
+            {"color", {label.color[0], label.color[1], label.color[2]}},
+            {"opacity", label.opacity}
+        });
+    }
+    zip.addEntry("data/mask/labels.json", labelsJson.dump(2));
+
+    return {};
+}
+
+std::expected<void, ProjectError>
+DataSerializer::loadMask(const ZipArchive& zip,
+                         LabelMapType::Pointer& labelMap,
+                         std::vector<LabelDefinition>& labels) {
+    if (!zip.hasEntry("data/mask/label_map.nrrd")) {
+        return std::unexpected(ProjectError::SerializationError);
+    }
+
+    auto nrrdData = zip.readEntry("data/mask/label_map.nrrd");
+    if (!nrrdData) {
+        return std::unexpected(ProjectError::SerializationError);
+    }
+    auto img = nrrdToLabelMap(*nrrdData);
+    if (!img) return std::unexpected(img.error());
+    labelMap = *img;
+
+    labels.clear();
+    if (zip.hasEntry("data/mask/labels.json")) {
+        auto labelsStr = zip.readEntryAsString("data/mask/labels.json");
+        if (labelsStr) {
+            try {
+                auto j = nlohmann::json::parse(*labelsStr);
+                for (const auto& item : j) {
+                    LabelDefinition def;
+                    def.id = item.value("id", uint8_t{0});
+                    def.name = item.value("name", "");
+                    if (item.contains("color") && item["color"].is_array()
+                        && item["color"].size() == 3) {
+                        def.color[0] = item["color"][0].get<float>();
+                        def.color[1] = item["color"][1].get<float>();
+                        def.color[2] = item["color"][2].get<float>();
+                    }
+                    def.opacity = item.value("opacity", 1.0f);
+                    labels.push_back(def);
+                }
+            } catch (...) {
+                // Labels metadata is optional; continue without it
+            }
+        }
+    }
+
+    return {};
+}
+
+std::expected<void, ProjectError>
+DataSerializer::saveAnalysisResults(ZipArchive& zip,
+                                    const nlohmann::json& results) {
+    zip.addEntry("data/analysis/results.json", results.dump(2));
+    return {};
+}
+
+std::expected<nlohmann::json, ProjectError>
+DataSerializer::loadAnalysisResults(const ZipArchive& zip) {
+    if (!zip.hasEntry("data/analysis/results.json")) {
+        return std::unexpected(ProjectError::SerializationError);
+    }
+
+    auto str = zip.readEntryAsString("data/analysis/results.json");
+    if (!str) {
+        return std::unexpected(ProjectError::SerializationError);
+    }
+
+    try {
+        return nlohmann::json::parse(*str);
+    } catch (...) {
+        return std::unexpected(ProjectError::InvalidFormat);
+    }
+}
+
+}  // namespace dicom_viewer::core

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1402,6 +1402,24 @@ target_include_directories(project_manager_test PRIVATE
 
 gtest_discover_tests(project_manager_test DISCOVERY_TIMEOUT 60)
 
+# Unit tests for DataSerializer (NRRD serialization + ZIP project files)
+add_executable(data_serializer_test
+    unit/data_serializer_test.cpp
+)
+
+target_link_libraries(data_serializer_test PRIVATE
+    dicom_viewer_core
+    ${ITK_LIBRARIES}
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(data_serializer_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(data_serializer_test DISCOVERY_TIMEOUT 60)
+
 # Unit tests for Hemodynamic Overlay Renderer
 add_executable(hemodynamic_overlay_renderer_test
     unit/hemodynamic_overlay_renderer_test.cpp

--- a/tests/unit/data_serializer_test.cpp
+++ b/tests/unit/data_serializer_test.cpp
@@ -1,0 +1,496 @@
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <filesystem>
+#include <vector>
+
+#include "core/data_serializer.hpp"
+#include "core/zip_archive.hpp"
+
+#include <nlohmann/json.hpp>
+
+using namespace dicom_viewer::core;
+using FloatImage3D = DataSerializer::FloatImage3D;
+using VectorImage3D = DataSerializer::VectorImage3D;
+using LabelMapType = DataSerializer::LabelMapType;
+
+namespace {
+
+FloatImage3D::Pointer createScalarImage(int nx, int ny, int nz,
+                                        double spacing = 1.5,
+                                        float fillValue = 0.0f) {
+    auto image = FloatImage3D::New();
+    FloatImage3D::RegionType region;
+    FloatImage3D::SizeType size;
+    size[0] = nx; size[1] = ny; size[2] = nz;
+    region.SetSize(size);
+    image->SetRegions(region);
+
+    FloatImage3D::SpacingType sp;
+    sp[0] = spacing; sp[1] = spacing; sp[2] = spacing;
+    image->SetSpacing(sp);
+
+    FloatImage3D::PointType origin;
+    origin[0] = -10.0; origin[1] = 5.0; origin[2] = 20.0;
+    image->SetOrigin(origin);
+
+    image->Allocate();
+    image->FillBuffer(fillValue);
+    return image;
+}
+
+VectorImage3D::Pointer createVectorImage(int nx, int ny, int nz,
+                                         float vx = 1.0f,
+                                         float vy = 2.0f,
+                                         float vz = 3.0f) {
+    auto image = VectorImage3D::New();
+    VectorImage3D::RegionType region;
+    VectorImage3D::SizeType size;
+    size[0] = nx; size[1] = ny; size[2] = nz;
+    region.SetSize(size);
+    image->SetRegions(region);
+    image->SetNumberOfComponentsPerPixel(3);
+
+    VectorImage3D::SpacingType sp;
+    sp[0] = 2.0; sp[1] = 2.0; sp[2] = 2.0;
+    image->SetSpacing(sp);
+
+    VectorImage3D::PointType origin;
+    origin[0] = -5.0; origin[1] = 0.0; origin[2] = 10.0;
+    image->SetOrigin(origin);
+
+    image->Allocate();
+    float* buf = image->GetBufferPointer();
+    size_t total = static_cast<size_t>(nx) * ny * nz;
+    for (size_t i = 0; i < total; ++i) {
+        buf[i * 3 + 0] = vx;
+        buf[i * 3 + 1] = vy;
+        buf[i * 3 + 2] = vz;
+    }
+    return image;
+}
+
+LabelMapType::Pointer createLabelMap(int nx, int ny, int nz) {
+    auto image = LabelMapType::New();
+    LabelMapType::RegionType region;
+    LabelMapType::SizeType size;
+    size[0] = nx; size[1] = ny; size[2] = nz;
+    region.SetSize(size);
+    image->SetRegions(region);
+
+    LabelMapType::SpacingType sp;
+    sp[0] = 1.0; sp[1] = 1.0; sp[2] = 1.0;
+    image->SetSpacing(sp);
+
+    image->Allocate(true);  // Fill with 0
+
+    // Add some labels
+    auto* buf = image->GetBufferPointer();
+    size_t total = static_cast<size_t>(nx) * ny * nz;
+    for (size_t i = 0; i < total / 3; ++i) buf[i] = 1;
+    for (size_t i = total / 3; i < total / 2; ++i) buf[i] = 2;
+
+    return image;
+}
+
+}  // anonymous namespace
+
+// =============================================================================
+// Scalar image NRRD roundtrip
+// =============================================================================
+
+TEST(DataSerializer, ScalarImageNRRDRoundtrip) {
+    auto original = createScalarImage(8, 6, 4);
+    float* buf = original->GetBufferPointer();
+    for (int i = 0; i < 8 * 6 * 4; ++i) {
+        buf[i] = static_cast<float>(i * 0.1);
+    }
+
+    auto nrrd = DataSerializer::scalarImageToNRRD(original.GetPointer());
+    EXPECT_GT(nrrd.size(), 0u);
+
+    auto result = DataSerializer::nrrdToScalarImage(nrrd);
+    ASSERT_TRUE(result.has_value());
+
+    auto decoded = *result;
+    auto origSize = original->GetLargestPossibleRegion().GetSize();
+    auto decSize = decoded->GetLargestPossibleRegion().GetSize();
+
+    EXPECT_EQ(decSize[0], origSize[0]);
+    EXPECT_EQ(decSize[1], origSize[1]);
+    EXPECT_EQ(decSize[2], origSize[2]);
+
+    // Check spacing preserved
+    EXPECT_DOUBLE_EQ(decoded->GetSpacing()[0], original->GetSpacing()[0]);
+    EXPECT_DOUBLE_EQ(decoded->GetSpacing()[1], original->GetSpacing()[1]);
+
+    // Check origin preserved
+    EXPECT_DOUBLE_EQ(decoded->GetOrigin()[0], original->GetOrigin()[0]);
+    EXPECT_DOUBLE_EQ(decoded->GetOrigin()[1], original->GetOrigin()[1]);
+    EXPECT_DOUBLE_EQ(decoded->GetOrigin()[2], original->GetOrigin()[2]);
+
+    // Check all voxel values
+    const float* origBuf = original->GetBufferPointer();
+    const float* decBuf = decoded->GetBufferPointer();
+    for (int i = 0; i < 8 * 6 * 4; ++i) {
+        EXPECT_FLOAT_EQ(decBuf[i], origBuf[i]) << "Mismatch at index " << i;
+    }
+}
+
+TEST(DataSerializer, ScalarImageNRRDHeader) {
+    auto image = createScalarImage(10, 20, 30);
+    auto nrrd = DataSerializer::scalarImageToNRRD(image.GetPointer());
+
+    // Header should contain NRRD magic and metadata
+    std::string header(nrrd.begin(), nrrd.begin() + std::min(nrrd.size(), size_t{500}));
+    EXPECT_NE(header.find("NRRD0004"), std::string::npos);
+    EXPECT_NE(header.find("type: float"), std::string::npos);
+    EXPECT_NE(header.find("dimension: 3"), std::string::npos);
+    EXPECT_NE(header.find("sizes: 10 20 30"), std::string::npos);
+    EXPECT_NE(header.find("encoding: raw"), std::string::npos);
+}
+
+// =============================================================================
+// Vector image NRRD roundtrip
+// =============================================================================
+
+TEST(DataSerializer, VectorImageNRRDRoundtrip) {
+    auto original = createVectorImage(6, 4, 3, 10.0f, -5.0f, 7.5f);
+
+    auto nrrd = DataSerializer::vectorImageToNRRD(original.GetPointer());
+    EXPECT_GT(nrrd.size(), 0u);
+
+    auto result = DataSerializer::nrrdToVectorImage(nrrd);
+    ASSERT_TRUE(result.has_value());
+
+    auto decoded = *result;
+    EXPECT_EQ(decoded->GetNumberOfComponentsPerPixel(), 3u);
+
+    auto origSize = original->GetLargestPossibleRegion().GetSize();
+    auto decSize = decoded->GetLargestPossibleRegion().GetSize();
+    EXPECT_EQ(decSize[0], origSize[0]);
+    EXPECT_EQ(decSize[1], origSize[1]);
+    EXPECT_EQ(decSize[2], origSize[2]);
+
+    // Check spacing preserved
+    EXPECT_DOUBLE_EQ(decoded->GetSpacing()[0], original->GetSpacing()[0]);
+
+    // Check all voxel values
+    const float* origBuf = original->GetBufferPointer();
+    const float* decBuf = decoded->GetBufferPointer();
+    size_t total = 6 * 4 * 3 * 3;
+    for (size_t i = 0; i < total; ++i) {
+        EXPECT_FLOAT_EQ(decBuf[i], origBuf[i]) << "Mismatch at index " << i;
+    }
+}
+
+TEST(DataSerializer, VectorImageNRRDHeader) {
+    auto image = createVectorImage(8, 8, 8);
+    auto nrrd = DataSerializer::vectorImageToNRRD(image.GetPointer());
+
+    std::string header(nrrd.begin(), nrrd.begin() + std::min(nrrd.size(), size_t{500}));
+    EXPECT_NE(header.find("dimension: 4"), std::string::npos);
+    EXPECT_NE(header.find("sizes: 3 8 8 8"), std::string::npos);
+}
+
+// =============================================================================
+// Label map NRRD roundtrip
+// =============================================================================
+
+TEST(DataSerializer, LabelMapNRRDRoundtrip) {
+    auto original = createLabelMap(16, 16, 8);
+
+    auto nrrd = DataSerializer::labelMapToNRRD(original.GetPointer());
+    auto result = DataSerializer::nrrdToLabelMap(nrrd);
+    ASSERT_TRUE(result.has_value());
+
+    auto decoded = *result;
+    auto origSize = original->GetLargestPossibleRegion().GetSize();
+    auto decSize = decoded->GetLargestPossibleRegion().GetSize();
+    EXPECT_EQ(decSize[0], origSize[0]);
+    EXPECT_EQ(decSize[1], origSize[1]);
+    EXPECT_EQ(decSize[2], origSize[2]);
+
+    // Check all voxel values
+    const uint8_t* origBuf = original->GetBufferPointer();
+    const uint8_t* decBuf = decoded->GetBufferPointer();
+    size_t total = 16 * 16 * 8;
+    for (size_t i = 0; i < total; ++i) {
+        EXPECT_EQ(decBuf[i], origBuf[i]) << "Mismatch at index " << i;
+    }
+}
+
+TEST(DataSerializer, LabelMapNRRDHeader) {
+    auto image = createLabelMap(32, 32, 32);
+    auto nrrd = DataSerializer::labelMapToNRRD(image.GetPointer());
+
+    std::string header(nrrd.begin(), nrrd.begin() + std::min(nrrd.size(), size_t{500}));
+    EXPECT_NE(header.find("type: unsigned char"), std::string::npos);
+    EXPECT_NE(header.find("dimension: 3"), std::string::npos);
+}
+
+// =============================================================================
+// Invalid NRRD decoding
+// =============================================================================
+
+TEST(DataSerializer, InvalidNRRDReturnsError) {
+    std::vector<uint8_t> garbage = {0, 1, 2, 3, 4, 5};
+    auto result = DataSerializer::nrrdToScalarImage(garbage);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(DataSerializer, WrongTypeNRRDReturnsError) {
+    // Create a valid label map NRRD (unsigned char) and try to decode as float
+    auto labelMap = createLabelMap(4, 4, 4);
+    auto nrrd = DataSerializer::labelMapToNRRD(labelMap.GetPointer());
+    auto result = DataSerializer::nrrdToScalarImage(nrrd);
+    EXPECT_FALSE(result.has_value());
+}
+
+// =============================================================================
+// ZIP velocity data roundtrip
+// =============================================================================
+
+TEST(DataSerializer, VelocityDataZipRoundtrip) {
+    std::vector<VectorImage3D::Pointer> velocities;
+    std::vector<FloatImage3D::Pointer> magnitudes;
+
+    for (int p = 0; p < 3; ++p) {
+        float v = static_cast<float>(p * 10 + 5);
+        velocities.push_back(createVectorImage(8, 8, 4, v, v * 0.5f, v * 0.1f));
+        magnitudes.push_back(createScalarImage(8, 8, 4, 1.5, v * 2.0f));
+    }
+
+    // Save to ZIP
+    ZipArchive zip;
+    auto saveResult = DataSerializer::saveVelocityData(zip, velocities, magnitudes);
+    ASSERT_TRUE(saveResult.has_value());
+
+    // Write ZIP to temp file and read back
+    auto tmpPath = std::filesystem::temp_directory_path()
+                   / "data_serializer_test_vel.flo";
+    auto writeResult = zip.writeTo(tmpPath);
+    ASSERT_TRUE(writeResult.has_value());
+
+    auto readResult = ZipArchive::readFrom(tmpPath);
+    ASSERT_TRUE(readResult.has_value());
+
+    // Load from ZIP
+    std::vector<VectorImage3D::Pointer> loadedVel;
+    std::vector<FloatImage3D::Pointer> loadedMag;
+    auto loadResult = DataSerializer::loadVelocityData(*readResult, loadedVel, loadedMag);
+    ASSERT_TRUE(loadResult.has_value());
+
+    EXPECT_EQ(loadedVel.size(), 3u);
+    EXPECT_EQ(loadedMag.size(), 3u);
+
+    // Verify first phase velocity values
+    const float* origBuf = velocities[0]->GetBufferPointer();
+    const float* loadBuf = loadedVel[0]->GetBufferPointer();
+    size_t total = 8 * 8 * 4 * 3;
+    for (size_t i = 0; i < total; ++i) {
+        EXPECT_FLOAT_EQ(loadBuf[i], origBuf[i]);
+    }
+
+    std::filesystem::remove(tmpPath);
+}
+
+// =============================================================================
+// ZIP mask roundtrip
+// =============================================================================
+
+TEST(DataSerializer, MaskZipRoundtrip) {
+    auto labelMap = createLabelMap(16, 16, 8);
+
+    std::vector<DataSerializer::LabelDefinition> labels = {
+        {1, "Aorta", {1.0f, 0.0f, 0.0f}, 0.8f},
+        {2, "Left Ventricle", {0.0f, 1.0f, 0.0f}, 0.7f}
+    };
+
+    ZipArchive zip;
+    auto saveResult = DataSerializer::saveMask(
+        zip, labelMap.GetPointer(), labels);
+    ASSERT_TRUE(saveResult.has_value());
+
+    auto tmpPath = std::filesystem::temp_directory_path()
+                   / "data_serializer_test_mask.flo";
+    auto writeResult = zip.writeTo(tmpPath);
+    ASSERT_TRUE(writeResult.has_value());
+
+    auto readResult = ZipArchive::readFrom(tmpPath);
+    ASSERT_TRUE(readResult.has_value());
+
+    LabelMapType::Pointer loadedMap;
+    std::vector<DataSerializer::LabelDefinition> loadedLabels;
+    auto loadResult = DataSerializer::loadMask(*readResult, loadedMap, loadedLabels);
+    ASSERT_TRUE(loadResult.has_value());
+
+    // Verify label map dimensions
+    auto origSize = labelMap->GetLargestPossibleRegion().GetSize();
+    auto loadSize = loadedMap->GetLargestPossibleRegion().GetSize();
+    EXPECT_EQ(loadSize[0], origSize[0]);
+    EXPECT_EQ(loadSize[1], origSize[1]);
+    EXPECT_EQ(loadSize[2], origSize[2]);
+
+    // Verify label definitions
+    ASSERT_EQ(loadedLabels.size(), 2u);
+    EXPECT_EQ(loadedLabels[0].id, 1);
+    EXPECT_EQ(loadedLabels[0].name, "Aorta");
+    EXPECT_FLOAT_EQ(loadedLabels[0].color[0], 1.0f);
+    EXPECT_FLOAT_EQ(loadedLabels[0].opacity, 0.8f);
+    EXPECT_EQ(loadedLabels[1].id, 2);
+    EXPECT_EQ(loadedLabels[1].name, "Left Ventricle");
+
+    // Verify voxel data
+    const uint8_t* origBuf = labelMap->GetBufferPointer();
+    const uint8_t* loadBuf = loadedMap->GetBufferPointer();
+    for (size_t i = 0; i < 16 * 16 * 8; ++i) {
+        EXPECT_EQ(loadBuf[i], origBuf[i]);
+    }
+
+    std::filesystem::remove(tmpPath);
+}
+
+// =============================================================================
+// ZIP analysis results roundtrip
+// =============================================================================
+
+TEST(DataSerializer, AnalysisResultsZipRoundtrip) {
+    nlohmann::json results = {
+        {"flow_metrics", {
+            {"mean_flow_rate", 42.5},
+            {"peak_velocity", 120.3},
+            {"cardiac_output", 5.2}
+        }},
+        {"hemodynamics", {
+            {"mean_wss", 1.5},
+            {"max_wss", 8.3},
+            {"total_energy_loss", 0.0015},
+            {"mean_kinetic_energy", 0.0082}
+        }},
+        {"measurements", {
+            {"distances", {{{"id", 1}, {"value_mm", 25.3}}}},
+            {"angles", {{{"id", 1}, {"value_deg", 45.0}}}}
+        }}
+    };
+
+    ZipArchive zip;
+    auto saveResult = DataSerializer::saveAnalysisResults(zip, results);
+    ASSERT_TRUE(saveResult.has_value());
+
+    auto tmpPath = std::filesystem::temp_directory_path()
+                   / "data_serializer_test_analysis.flo";
+    zip.writeTo(tmpPath);
+
+    auto readResult = ZipArchive::readFrom(tmpPath);
+    ASSERT_TRUE(readResult.has_value());
+
+    auto loadResult = DataSerializer::loadAnalysisResults(*readResult);
+    ASSERT_TRUE(loadResult.has_value());
+
+    auto& loaded = *loadResult;
+    EXPECT_DOUBLE_EQ(loaded["flow_metrics"]["mean_flow_rate"].get<double>(), 42.5);
+    EXPECT_DOUBLE_EQ(loaded["hemodynamics"]["total_energy_loss"].get<double>(), 0.0015);
+    EXPECT_EQ(loaded["measurements"]["distances"].size(), 1u);
+
+    std::filesystem::remove(tmpPath);
+}
+
+// =============================================================================
+// Full project file roundtrip (all data types)
+// =============================================================================
+
+TEST(DataSerializer, FullProjectRoundtrip) {
+    auto tmpPath = std::filesystem::temp_directory_path()
+                   / "data_serializer_full_roundtrip.flo";
+
+    // Create diverse data
+    std::vector<VectorImage3D::Pointer> velocities = {
+        createVectorImage(8, 8, 4, 50.0f, 25.0f, 10.0f),
+        createVectorImage(8, 8, 4, 60.0f, 30.0f, 15.0f)
+    };
+    std::vector<FloatImage3D::Pointer> magnitudes = {
+        createScalarImage(8, 8, 4, 1.5, 100.0f),
+        createScalarImage(8, 8, 4, 1.5, 120.0f)
+    };
+    auto mask = createLabelMap(8, 8, 4);
+    std::vector<DataSerializer::LabelDefinition> labels = {
+        {1, "Vessel", {1.0f, 0.0f, 0.0f}, 1.0f}
+    };
+    nlohmann::json analysis = {{"mean_wss", 2.5}};
+
+    // Save all data to single .flo file
+    {
+        ZipArchive zip;
+        ASSERT_TRUE(DataSerializer::saveVelocityData(zip, velocities, magnitudes).has_value());
+        ASSERT_TRUE(DataSerializer::saveMask(zip, mask.GetPointer(), labels).has_value());
+        ASSERT_TRUE(DataSerializer::saveAnalysisResults(zip, analysis).has_value());
+        ASSERT_TRUE(zip.writeTo(tmpPath).has_value());
+    }
+
+    // Load back
+    {
+        auto readResult = ZipArchive::readFrom(tmpPath);
+        ASSERT_TRUE(readResult.has_value());
+
+        std::vector<VectorImage3D::Pointer> loadedVel;
+        std::vector<FloatImage3D::Pointer> loadedMag;
+        ASSERT_TRUE(DataSerializer::loadVelocityData(*readResult, loadedVel, loadedMag).has_value());
+        EXPECT_EQ(loadedVel.size(), 2u);
+        EXPECT_EQ(loadedMag.size(), 2u);
+
+        LabelMapType::Pointer loadedMask;
+        std::vector<DataSerializer::LabelDefinition> loadedLabels;
+        ASSERT_TRUE(DataSerializer::loadMask(*readResult, loadedMask, loadedLabels).has_value());
+        EXPECT_EQ(loadedLabels.size(), 1u);
+        EXPECT_EQ(loadedLabels[0].name, "Vessel");
+
+        auto loadedAnalysis = DataSerializer::loadAnalysisResults(*readResult);
+        ASSERT_TRUE(loadedAnalysis.has_value());
+        EXPECT_DOUBLE_EQ((*loadedAnalysis)["mean_wss"].get<double>(), 2.5);
+    }
+
+    std::filesystem::remove(tmpPath);
+}
+
+// =============================================================================
+// Compression efficiency
+// =============================================================================
+
+TEST(DataSerializer, ZipCompressionReducesSize) {
+    // A 64^3 mostly-zero label map should compress well
+    auto mask = LabelMapType::New();
+    LabelMapType::RegionType region;
+    LabelMapType::SizeType size;
+    size[0] = 64; size[1] = 64; size[2] = 64;
+    region.SetSize(size);
+    mask->SetRegions(region);
+    mask->Allocate(true);  // All zeros
+
+    // Label a small cube
+    auto* buf = mask->GetBufferPointer();
+    for (int z = 20; z < 40; z++)
+        for (int y = 20; y < 40; y++)
+            for (int x = 20; x < 40; x++)
+                buf[z * 64 * 64 + y * 64 + x] = 1;
+
+    std::vector<DataSerializer::LabelDefinition> labels = {{1, "ROI", {1,0,0}, 1}};
+
+    ZipArchive zip;
+    DataSerializer::saveMask(zip, mask.GetPointer(), labels);
+
+    auto tmpPath = std::filesystem::temp_directory_path()
+                   / "data_serializer_compression.flo";
+    zip.writeTo(tmpPath);
+
+    auto fileSize = std::filesystem::file_size(tmpPath);
+    size_t rawSize = 64 * 64 * 64;  // 262144 bytes raw
+
+    // ZIP with DEFLATE should compress mostly-zero data significantly
+    EXPECT_LT(fileSize, rawSize / 2)
+        << "Compressed .flo should be <50% of raw label map size"
+        << "\n  Raw: " << rawSize << " bytes"
+        << "\n  Compressed: " << fileSize << " bytes";
+
+    std::filesystem::remove(tmpPath);
+}


### PR DESCRIPTION
Closes #273

## Summary
- Add `DataSerializer` class providing NRRD-based serialization for ITK images (scalar float, 3-component vector, uint8 label map) and JSON-based serialization for analysis results
- Low-level NRRD encoding/decoding with raw binary format (ZIP handles compression via DEFLATE)
- High-level ZIP save/load methods for velocity data, segmentation masks with label definitions, and analysis results
- Handle NaN spacings in vector image NRRD headers (component axis has no physical spacing)
- ZIP entry layout: `data/velocity/`, `data/magnitude/`, `data/mask/`, `data/analysis/`

## Test Plan
- [x] ScalarImageNRRDRoundtrip - dimensions, spacing, origin, voxel values preserved
- [x] VectorImageNRRDRoundtrip - 3-component vector data preserved with NaN spacing handling
- [x] LabelMapNRRDRoundtrip - uint8 label values preserved
- [x] NRRD header format validation (scalar, vector, label map)
- [x] Invalid/wrong-type NRRD returns appropriate errors
- [x] VelocityDataZipRoundtrip - multi-phase velocity + magnitude via ZipArchive
- [x] MaskZipRoundtrip - label map + label definitions via ZipArchive
- [x] AnalysisResultsZipRoundtrip - JSON metrics via ZipArchive
- [x] FullProjectRoundtrip - all data types combined in single archive
- [x] ZipCompressionReducesSize - verify DEFLATE compression effectiveness
- All 13 tests pass (2ms)