### PR TITLE
feat(core): implement SeriesClassifier for DICOM series type detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,6 +545,7 @@ add_library(enhanced_dicom_service STATIC
     src/services/enhanced_dicom/functional_group_parser.cpp
     src/services/enhanced_dicom/frame_extractor.cpp
     src/services/enhanced_dicom/dimension_index_sorter.cpp
+    src/services/enhanced_dicom/series_classifier.cpp
 )
 
 target_link_libraries(enhanced_dicom_service PUBLIC

--- a/include/services/enhanced_dicom/series_classifier.hpp
+++ b/include/services/enhanced_dicom/series_classifier.hpp
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <itkMetaDataDictionary.h>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Classification of DICOM series modality/acquisition type
+ *
+ * Covers 4D Flow components, standard MRI sequences, and CT.
+ *
+ * @trace SRS-FR-049
+ */
+enum class SeriesType {
+    Flow4D_Magnitude,   ///< 4D Flow magnitude image
+    Flow4D_Phase_AP,    ///< 4D Flow phase — Anterior-Posterior
+    Flow4D_Phase_FH,    ///< 4D Flow phase — Foot-Head
+    Flow4D_Phase_RL,    ///< 4D Flow phase — Right-Left
+    PC_MRA,             ///< Phase-contrast MR angiography
+    CINE,               ///< Cardiac CINE MRI
+    DIXON,              ///< DIXON water/fat separation
+    Starvibe,           ///< Siemens StarVIBE (radial VIBE)
+    CT,                 ///< Computed Tomography
+    TOF,                ///< Time-of-Flight angiography
+    VENC_2D,            ///< 2D phase-contrast velocity encoding
+    Unknown             ///< Unrecognized series type
+};
+
+/**
+ * @brief Result of DICOM series classification
+ */
+struct ClassifiedSeries {
+    SeriesType type = SeriesType::Unknown;
+    std::string seriesUid;
+    std::string description;
+    std::string modality;
+    bool is4DFlow = false;  ///< true for magnitude + phase series
+};
+
+/**
+ * @brief Convert SeriesType enum to human-readable string
+ */
+[[nodiscard]] inline std::string seriesToString(SeriesType type) {
+    switch (type) {
+        case SeriesType::Flow4D_Magnitude: return "4D Flow Magnitude";
+        case SeriesType::Flow4D_Phase_AP: return "4D Flow Phase AP";
+        case SeriesType::Flow4D_Phase_FH: return "4D Flow Phase FH";
+        case SeriesType::Flow4D_Phase_RL: return "4D Flow Phase RL";
+        case SeriesType::PC_MRA: return "PC-MRA";
+        case SeriesType::CINE: return "CINE";
+        case SeriesType::DIXON: return "DIXON";
+        case SeriesType::Starvibe: return "StarVIBE";
+        case SeriesType::CT: return "CT";
+        case SeriesType::TOF: return "TOF";
+        case SeriesType::VENC_2D: return "2D VENC";
+        case SeriesType::Unknown: return "Unknown";
+    }
+    return "Unknown";
+}
+
+/**
+ * @brief Classifier for multi-modal DICOM series
+ *
+ * Identifies series types from DICOM header tags:
+ * - Modality (0008,0060)
+ * - SeriesDescription (0008,103E)
+ * - ImageType (0008,0008)
+ * - Scanning Sequence (0018,0020)
+ * - Velocity encoding tags (vendor-specific)
+ *
+ * Stateless — all methods are static.
+ *
+ * @trace SRS-FR-049
+ */
+class SeriesClassifier {
+public:
+    /**
+     * @brief Classify a single DICOM series from a file path
+     *
+     * Reads the first file's metadata and classifies the series.
+     *
+     * @param filePath Path to one DICOM file from the series
+     * @return Classification result
+     */
+    [[nodiscard]] static ClassifiedSeries classifyFile(
+        const std::string& filePath);
+
+    /**
+     * @brief Classify from a pre-read ITK metadata dictionary
+     *
+     * Useful when metadata has already been loaded (avoids re-reading).
+     * Also used for testing with synthetic metadata.
+     *
+     * @param metadata ITK metadata dictionary from GDCMImageIO
+     * @return Classification result
+     */
+    [[nodiscard]] static ClassifiedSeries classify(
+        const itk::MetaDataDictionary& metadata);
+
+    /**
+     * @brief Classify all series in a study
+     *
+     * Takes a list of representative file paths (one per series)
+     * and returns the classification for each.
+     *
+     * @param seriesFiles One DICOM file path per series
+     * @return Vector of classification results (same order)
+     */
+    [[nodiscard]] static std::vector<ClassifiedSeries> classifyStudy(
+        const std::vector<std::string>& seriesFiles);
+
+    /**
+     * @brief Check if a SeriesType is a 4D Flow component
+     */
+    [[nodiscard]] static bool is4DFlowType(SeriesType type) noexcept;
+};
+
+}  // namespace dicom_viewer::services

--- a/src/services/enhanced_dicom/series_classifier.cpp
+++ b/src/services/enhanced_dicom/series_classifier.cpp
@@ -1,0 +1,322 @@
+#include "services/enhanced_dicom/series_classifier.hpp"
+
+#include <algorithm>
+#include <string>
+
+#include <itkGDCMImageIO.h>
+#include <itkMetaDataObject.h>
+
+namespace {
+
+/// Extract a trimmed string value from an ITK metadata dictionary
+std::string getMetaString(const itk::MetaDataDictionary& dict,
+                          const std::string& key) {
+    std::string value;
+    itk::ExposeMetaData<std::string>(dict, key, value);
+    while (!value.empty() && (value.back() == ' ' || value.back() == '\0')) {
+        value.pop_back();
+    }
+    return value;
+}
+
+/// Convert a string to upper case (in-place copy)
+std::string toUpper(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(), ::toupper);
+    return s;
+}
+
+/// Read DICOM metadata from a file via GDCMImageIO
+itk::MetaDataDictionary readDicomMetadata(const std::string& filePath) {
+    auto gdcmIO = itk::GDCMImageIO::New();
+    gdcmIO->SetFileName(filePath.c_str());
+    gdcmIO->ReadImageInformation();
+    return gdcmIO->GetMetaDataDictionary();
+}
+
+// =========================================================================
+// DICOM tag keys (format: "GROUP|ELEMENT")
+// =========================================================================
+constexpr const char* kModality           = "0008|0060";
+constexpr const char* kImageType          = "0008|0008";
+constexpr const char* kSeriesDescription  = "0008|103e";
+constexpr const char* kSeriesInstanceUID  = "0020|000e";
+constexpr const char* kScanningSequence   = "0018|0020";
+constexpr const char* kPhaseContrast      = "0018|9014";
+constexpr const char* kManufacturer       = "0008|0070";
+constexpr const char* kNumberOfFrames     = "0028|0008";
+
+// Vendor-specific velocity direction tags
+constexpr const char* kSiemensFlowDir     = "0051|1014";
+constexpr const char* kPhilipsPrivateVenc = "2001|101a";
+constexpr const char* kGEPrivateVenc      = "0019|10cc";
+
+using dicom_viewer::services::SeriesType;
+
+/// Check if the series has phase-contrast indicators
+bool hasPhaseContrastIndicators(const itk::MetaDataDictionary& dict) {
+    auto scanSeq = toUpper(getMetaString(dict, kScanningSequence));
+    if (scanSeq.find("PC") != std::string::npos) {
+        return true;
+    }
+
+    auto pc = toUpper(getMetaString(dict, kPhaseContrast));
+    if (pc.find("YES") != std::string::npos) {
+        return true;
+    }
+
+    return false;
+}
+
+/// Detect velocity encoding direction from vendor-specific tags
+/// Returns the specific 4D Flow phase direction, or Unknown if not a phase image
+SeriesType detect4DFlowDirection(const itk::MetaDataDictionary& dict) {
+    auto imageType = toUpper(getMetaString(dict, kImageType));
+
+    // Check if this is a magnitude image
+    if (imageType.find("\\M\\") != std::string::npos ||
+        imageType.find("\\M_") != std::string::npos ||
+        imageType.find("MAG") != std::string::npos) {
+        return SeriesType::Flow4D_Magnitude;
+    }
+
+    // Check if this is a phase/velocity image
+    bool isPhase = imageType.find("\\P\\") != std::string::npos ||
+                   imageType.find("VELOCITY") != std::string::npos ||
+                   imageType.find("PHASE") != std::string::npos;
+
+    if (!isPhase) {
+        // If no phase/magnitude indicator, check for any velocity encoding
+        auto venc = getMetaString(dict, "0018|9197");
+        if (venc.empty()) {
+            return SeriesType::Flow4D_Magnitude;
+        }
+        isPhase = true;
+    }
+
+    // Determine direction from vendor-specific tags
+
+    // Siemens: private tag (0051,1014)
+    auto siemensDir = toUpper(getMetaString(dict, kSiemensFlowDir));
+    if (!siemensDir.empty()) {
+        if (siemensDir.find("AP") != std::string::npos) {
+            return SeriesType::Flow4D_Phase_AP;
+        }
+        if (siemensDir.find("FH") != std::string::npos ||
+            siemensDir.find("SI") != std::string::npos) {
+            return SeriesType::Flow4D_Phase_FH;
+        }
+        if (siemensDir.find("RL") != std::string::npos) {
+            return SeriesType::Flow4D_Phase_RL;
+        }
+    }
+
+    // Philips: private tags (2001,xxxx) or series description
+    auto philipsVenc = getMetaString(dict, kPhilipsPrivateVenc);
+    if (!philipsVenc.empty()) {
+        auto desc = toUpper(getMetaString(dict, kSeriesDescription));
+        if (desc.find("_AP") != std::string::npos ||
+            desc.find("AP_") != std::string::npos ||
+            desc.find("_AP_") != std::string::npos) {
+            return SeriesType::Flow4D_Phase_AP;
+        }
+        if (desc.find("_FH") != std::string::npos ||
+            desc.find("FH_") != std::string::npos ||
+            desc.find("_FH_") != std::string::npos) {
+            return SeriesType::Flow4D_Phase_FH;
+        }
+        if (desc.find("_RL") != std::string::npos ||
+            desc.find("RL_") != std::string::npos ||
+            desc.find("_RL_") != std::string::npos) {
+            return SeriesType::Flow4D_Phase_RL;
+        }
+    }
+
+    // GE: private tag (0019,10cc) or series description
+    auto geVenc = getMetaString(dict, kGEPrivateVenc);
+    if (!geVenc.empty()) {
+        auto desc = toUpper(getMetaString(dict, kSeriesDescription));
+        if (desc.find("AP") != std::string::npos) {
+            return SeriesType::Flow4D_Phase_AP;
+        }
+        if (desc.find("FH") != std::string::npos ||
+            desc.find("SI") != std::string::npos) {
+            return SeriesType::Flow4D_Phase_FH;
+        }
+        if (desc.find("RL") != std::string::npos) {
+            return SeriesType::Flow4D_Phase_RL;
+        }
+    }
+
+    // Fallback: check series description for direction hints
+    auto desc = toUpper(getMetaString(dict, kSeriesDescription));
+    if (desc.find("_AP") != std::string::npos || desc.find("AP_") != std::string::npos) {
+        return SeriesType::Flow4D_Phase_AP;
+    }
+    if (desc.find("_FH") != std::string::npos || desc.find("FH_") != std::string::npos) {
+        return SeriesType::Flow4D_Phase_FH;
+    }
+    if (desc.find("_RL") != std::string::npos || desc.find("RL_") != std::string::npos) {
+        return SeriesType::Flow4D_Phase_RL;
+    }
+
+    // Phase image but direction undetermined — default to AP
+    return SeriesType::Flow4D_Phase_AP;
+}
+
+/// Check if series is 2D (single frame or small number)
+bool is2DSeries(const itk::MetaDataDictionary& dict) {
+    auto nFrames = getMetaString(dict, kNumberOfFrames);
+    if (nFrames.empty()) {
+        return true;
+    }
+    try {
+        return std::stoi(nFrames) <= 1;
+    } catch (...) {
+        return true;
+    }
+}
+
+}  // anonymous namespace
+
+namespace dicom_viewer::services {
+
+ClassifiedSeries SeriesClassifier::classifyFile(const std::string& filePath) {
+    try {
+        auto dict = readDicomMetadata(filePath);
+        return classify(dict);
+    } catch (...) {
+        return ClassifiedSeries{SeriesType::Unknown, "", "", "", false};
+    }
+}
+
+ClassifiedSeries SeriesClassifier::classify(
+    const itk::MetaDataDictionary& metadata) {
+
+    ClassifiedSeries result;
+    result.seriesUid = getMetaString(metadata, kSeriesInstanceUID);
+    result.description = getMetaString(metadata, kSeriesDescription);
+    result.modality = getMetaString(metadata, kModality);
+
+    auto modalityUpper = toUpper(result.modality);
+    auto descUpper = toUpper(result.description);
+    auto imageType = toUpper(getMetaString(metadata, kImageType));
+
+    // ------------------------------------------------------------------
+    // Rule 1: CT — modality tag is definitive
+    // ------------------------------------------------------------------
+    if (modalityUpper == "CT") {
+        result.type = SeriesType::CT;
+        result.is4DFlow = false;
+        return result;
+    }
+
+    // ------------------------------------------------------------------
+    // Rule 2: DIXON — description-based (before 4D Flow check)
+    // ------------------------------------------------------------------
+    if (descUpper.find("DIXON") != std::string::npos) {
+        result.type = SeriesType::DIXON;
+        result.is4DFlow = false;
+        return result;
+    }
+
+    // ------------------------------------------------------------------
+    // Rule 3: StarVIBE — description-based
+    // ------------------------------------------------------------------
+    if (descUpper.find("STARVIBE") != std::string::npos ||
+        descUpper.find("STAR_VIBE") != std::string::npos) {
+        result.type = SeriesType::Starvibe;
+        result.is4DFlow = false;
+        return result;
+    }
+
+    // ------------------------------------------------------------------
+    // Rule 4: TOF — description-based
+    // ------------------------------------------------------------------
+    if (descUpper.find("TOF") != std::string::npos &&
+        descUpper.find("TIME OF FLIGHT") != std::string::npos
+        ? true
+        : descUpper.find("TOF") != std::string::npos) {
+        result.type = SeriesType::TOF;
+        result.is4DFlow = false;
+        return result;
+    }
+
+    // ------------------------------------------------------------------
+    // Rule 5: CINE — description-based (must not be phase contrast)
+    // ------------------------------------------------------------------
+    if (descUpper.find("CINE") != std::string::npos &&
+        !hasPhaseContrastIndicators(metadata)) {
+        result.type = SeriesType::CINE;
+        result.is4DFlow = false;
+        return result;
+    }
+
+    // ------------------------------------------------------------------
+    // Rule 6: Phase contrast series (4D Flow or 2D VENC)
+    // ------------------------------------------------------------------
+    if (hasPhaseContrastIndicators(metadata) ||
+        imageType.find("VELOCITY") != std::string::npos) {
+
+        // 2D VENC: single-slice phase contrast
+        if (is2DSeries(metadata) &&
+            descUpper.find("2D") != std::string::npos) {
+            result.type = SeriesType::VENC_2D;
+            result.is4DFlow = false;
+            return result;
+        }
+
+        // 4D Flow: determine direction
+        result.type = detect4DFlowDirection(metadata);
+        result.is4DFlow = true;
+        return result;
+    }
+
+    // ------------------------------------------------------------------
+    // Rule 7: PC-MRA — often reconstructed from 4D Flow
+    // ------------------------------------------------------------------
+    if (descUpper.find("MRA") != std::string::npos ||
+        descUpper.find("ANGIO") != std::string::npos ||
+        descUpper.find("PC-MRA") != std::string::npos ||
+        descUpper.find("PCMRA") != std::string::npos) {
+        result.type = SeriesType::PC_MRA;
+        result.is4DFlow = false;
+        return result;
+    }
+
+    // ------------------------------------------------------------------
+    // Rule 8: CINE fallback (description contains CINE even with PC)
+    // ------------------------------------------------------------------
+    if (descUpper.find("CINE") != std::string::npos) {
+        result.type = SeriesType::CINE;
+        result.is4DFlow = false;
+        return result;
+    }
+
+    result.type = SeriesType::Unknown;
+    result.is4DFlow = false;
+    return result;
+}
+
+std::vector<ClassifiedSeries> SeriesClassifier::classifyStudy(
+    const std::vector<std::string>& seriesFiles) {
+    std::vector<ClassifiedSeries> results;
+    results.reserve(seriesFiles.size());
+    for (const auto& file : seriesFiles) {
+        results.push_back(classifyFile(file));
+    }
+    return results;
+}
+
+bool SeriesClassifier::is4DFlowType(SeriesType type) noexcept {
+    switch (type) {
+        case SeriesType::Flow4D_Magnitude:
+        case SeriesType::Flow4D_Phase_AP:
+        case SeriesType::Flow4D_Phase_FH:
+        case SeriesType::Flow4D_Phase_RL:
+            return true;
+        default:
+            return false;
+    }
+}
+
+}  // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -956,6 +956,24 @@ target_include_directories(dimension_index_sorter_test PRIVATE
 
 gtest_discover_tests(dimension_index_sorter_test DISCOVERY_TIMEOUT 60)
 
+# Unit tests for Series Classifier
+add_executable(series_classifier_test
+    unit/series_classifier_test.cpp
+)
+
+target_link_libraries(series_classifier_test PRIVATE
+    enhanced_dicom_service
+    ${ITK_LIBRARIES}
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(series_classifier_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(series_classifier_test DISCOVERY_TIMEOUT 60)
+
 # Unit tests for Cardiac Phase Detector
 add_executable(cardiac_phase_detector_test
     unit/cardiac_phase_detector_test.cpp

--- a/tests/unit/series_classifier_test.cpp
+++ b/tests/unit/series_classifier_test.cpp
@@ -1,0 +1,344 @@
+#include "services/enhanced_dicom/series_classifier.hpp"
+
+#include <gtest/gtest.h>
+#include <itkMetaDataObject.h>
+
+using namespace dicom_viewer::services;
+
+namespace {
+
+/// Helper to build a mock ITK MetaDataDictionary with given tags
+class MockDicomBuilder {
+public:
+    MockDicomBuilder& set(const std::string& key, const std::string& value) {
+        itk::EncapsulateMetaData<std::string>(dict_, key, value);
+        return *this;
+    }
+
+    /// Convenience setters for common tags
+    MockDicomBuilder& modality(const std::string& v)          { return set("0008|0060", v); }
+    MockDicomBuilder& seriesDescription(const std::string& v) { return set("0008|103e", v); }
+    MockDicomBuilder& imageType(const std::string& v)         { return set("0008|0008", v); }
+    MockDicomBuilder& seriesUid(const std::string& v)         { return set("0020|000e", v); }
+    MockDicomBuilder& scanningSequence(const std::string& v)  { return set("0018|0020", v); }
+    MockDicomBuilder& phaseContrast(const std::string& v)     { return set("0018|9014", v); }
+    MockDicomBuilder& manufacturer(const std::string& v)      { return set("0008|0070", v); }
+    MockDicomBuilder& numberOfFrames(const std::string& v)    { return set("0028|0008", v); }
+    MockDicomBuilder& siemensFlowDir(const std::string& v)    { return set("0051|1014", v); }
+    MockDicomBuilder& philipsVenc(const std::string& v)       { return set("2001|101a", v); }
+    MockDicomBuilder& geVenc(const std::string& v)            { return set("0019|10cc", v); }
+
+    const itk::MetaDataDictionary& build() const { return dict_; }
+
+private:
+    itk::MetaDataDictionary dict_;
+};
+
+}  // anonymous namespace
+
+// =============================================================================
+// CT Detection
+// =============================================================================
+
+TEST(SeriesClassifierTest, CTDetectedByModality) {
+    auto dict = MockDicomBuilder()
+        .modality("CT")
+        .seriesDescription("Body CT Angio")
+        .seriesUid("1.2.3.4")
+        .build();
+
+    auto result = SeriesClassifier::classify(dict);
+    EXPECT_EQ(result.type, SeriesType::CT);
+    EXPECT_FALSE(result.is4DFlow);
+    EXPECT_EQ(result.seriesUid, "1.2.3.4");
+}
+
+// =============================================================================
+// DIXON Detection
+// =============================================================================
+
+TEST(SeriesClassifierTest, DIXONDetectedByDescription) {
+    auto dict = MockDicomBuilder()
+        .modality("MR")
+        .seriesDescription("t1_vibe_dixon_tra_bh_W")
+        .build();
+
+    auto result = SeriesClassifier::classify(dict);
+    EXPECT_EQ(result.type, SeriesType::DIXON);
+    EXPECT_FALSE(result.is4DFlow);
+}
+
+// =============================================================================
+// StarVIBE Detection
+// =============================================================================
+
+TEST(SeriesClassifierTest, StarvibeDetectedByDescription) {
+    auto dict = MockDicomBuilder()
+        .modality("MR")
+        .seriesDescription("fl3d_starvibe_contrast")
+        .build();
+
+    auto result = SeriesClassifier::classify(dict);
+    EXPECT_EQ(result.type, SeriesType::Starvibe);
+    EXPECT_FALSE(result.is4DFlow);
+}
+
+// =============================================================================
+// TOF Detection
+// =============================================================================
+
+TEST(SeriesClassifierTest, TOFDetectedByDescription) {
+    auto dict = MockDicomBuilder()
+        .modality("MR")
+        .seriesDescription("TOF_3D_multi-slab")
+        .build();
+
+    auto result = SeriesClassifier::classify(dict);
+    EXPECT_EQ(result.type, SeriesType::TOF);
+    EXPECT_FALSE(result.is4DFlow);
+}
+
+// =============================================================================
+// CINE Detection
+// =============================================================================
+
+TEST(SeriesClassifierTest, CINEDetectedByDescription) {
+    auto dict = MockDicomBuilder()
+        .modality("MR")
+        .seriesDescription("CINE_retro_SA_stack")
+        .build();
+
+    auto result = SeriesClassifier::classify(dict);
+    EXPECT_EQ(result.type, SeriesType::CINE);
+    EXPECT_FALSE(result.is4DFlow);
+}
+
+TEST(SeriesClassifierTest, CINENotConfusedWithPhaseContrast) {
+    // CINE description but with PC scanning sequence → should be 4D Flow
+    auto dict = MockDicomBuilder()
+        .modality("MR")
+        .seriesDescription("CINE_PC_4Dflow")
+        .scanningSequence("GR\\PC")
+        .imageType("ORIGINAL\\PRIMARY\\P\\ND")
+        .build();
+
+    auto result = SeriesClassifier::classify(dict);
+    // Phase contrast takes priority over CINE description
+    EXPECT_TRUE(SeriesClassifier::is4DFlowType(result.type));
+    EXPECT_TRUE(result.is4DFlow);
+}
+
+// =============================================================================
+// 4D Flow — Siemens
+// =============================================================================
+
+TEST(SeriesClassifierTest, Flow4DMagnitudeSiemens) {
+    auto dict = MockDicomBuilder()
+        .modality("MR")
+        .seriesDescription("fl3d1r21_4DFlow")
+        .scanningSequence("GR\\PC")
+        .imageType("ORIGINAL\\PRIMARY\\M\\ND")
+        .manufacturer("SIEMENS")
+        .build();
+
+    auto result = SeriesClassifier::classify(dict);
+    EXPECT_EQ(result.type, SeriesType::Flow4D_Magnitude);
+    EXPECT_TRUE(result.is4DFlow);
+}
+
+TEST(SeriesClassifierTest, Flow4DPhaseAPSiemens) {
+    auto dict = MockDicomBuilder()
+        .modality("MR")
+        .seriesDescription("fl3d1r21_4DFlow_Phase_AP")
+        .scanningSequence("GR\\PC")
+        .imageType("ORIGINAL\\PRIMARY\\P\\ND")
+        .manufacturer("SIEMENS")
+        .siemensFlowDir("tp 0.0 AP 150.0")
+        .build();
+
+    auto result = SeriesClassifier::classify(dict);
+    EXPECT_EQ(result.type, SeriesType::Flow4D_Phase_AP);
+    EXPECT_TRUE(result.is4DFlow);
+}
+
+TEST(SeriesClassifierTest, Flow4DPhaseFHSiemens) {
+    auto dict = MockDicomBuilder()
+        .modality("MR")
+        .seriesDescription("fl3d1r21_4DFlow_Phase_FH")
+        .scanningSequence("GR\\PC")
+        .imageType("ORIGINAL\\PRIMARY\\P\\ND")
+        .manufacturer("SIEMENS")
+        .siemensFlowDir("tp 0.0 FH 150.0")
+        .build();
+
+    auto result = SeriesClassifier::classify(dict);
+    EXPECT_EQ(result.type, SeriesType::Flow4D_Phase_FH);
+    EXPECT_TRUE(result.is4DFlow);
+}
+
+TEST(SeriesClassifierTest, Flow4DPhaseRLSiemens) {
+    auto dict = MockDicomBuilder()
+        .modality("MR")
+        .seriesDescription("fl3d1r21_4DFlow_Phase_RL")
+        .scanningSequence("GR\\PC")
+        .imageType("ORIGINAL\\PRIMARY\\P\\ND")
+        .manufacturer("SIEMENS")
+        .siemensFlowDir("tp 0.0 RL 150.0")
+        .build();
+
+    auto result = SeriesClassifier::classify(dict);
+    EXPECT_EQ(result.type, SeriesType::Flow4D_Phase_RL);
+    EXPECT_TRUE(result.is4DFlow);
+}
+
+// =============================================================================
+// 4D Flow — Philips
+// =============================================================================
+
+TEST(SeriesClassifierTest, Flow4DPhaseAPPhilips) {
+    auto dict = MockDicomBuilder()
+        .modality("MR")
+        .seriesDescription("4DFlow_Phase_AP_150")
+        .scanningSequence("PC")
+        .imageType("ORIGINAL\\PRIMARY\\P\\NONE")
+        .manufacturer("Philips Medical Systems")
+        .philipsVenc("150")
+        .build();
+
+    auto result = SeriesClassifier::classify(dict);
+    EXPECT_EQ(result.type, SeriesType::Flow4D_Phase_AP);
+    EXPECT_TRUE(result.is4DFlow);
+}
+
+// =============================================================================
+// 4D Flow — GE
+// =============================================================================
+
+TEST(SeriesClassifierTest, Flow4DPhaseRLGE) {
+    auto dict = MockDicomBuilder()
+        .modality("MR")
+        .seriesDescription("4DFlow_RL_VENC150")
+        .scanningSequence("GR\\PC")
+        .imageType("ORIGINAL\\PRIMARY\\P\\NONE")
+        .manufacturer("GE MEDICAL SYSTEMS")
+        .geVenc("150")
+        .build();
+
+    auto result = SeriesClassifier::classify(dict);
+    EXPECT_EQ(result.type, SeriesType::Flow4D_Phase_RL);
+    EXPECT_TRUE(result.is4DFlow);
+}
+
+// =============================================================================
+// 2D VENC Detection
+// =============================================================================
+
+TEST(SeriesClassifierTest, VENC2DDetected) {
+    auto dict = MockDicomBuilder()
+        .modality("MR")
+        .seriesDescription("2D_VENC_through_plane")
+        .scanningSequence("GR\\PC")
+        .imageType("ORIGINAL\\PRIMARY\\P\\ND")
+        .numberOfFrames("1")
+        .build();
+
+    auto result = SeriesClassifier::classify(dict);
+    EXPECT_EQ(result.type, SeriesType::VENC_2D);
+    EXPECT_FALSE(result.is4DFlow);
+}
+
+// =============================================================================
+// PC-MRA Detection
+// =============================================================================
+
+TEST(SeriesClassifierTest, PCMRADetected) {
+    auto dict = MockDicomBuilder()
+        .modality("MR")
+        .seriesDescription("PC-MRA_reconstruction")
+        .build();
+
+    auto result = SeriesClassifier::classify(dict);
+    EXPECT_EQ(result.type, SeriesType::PC_MRA);
+    EXPECT_FALSE(result.is4DFlow);
+}
+
+TEST(SeriesClassifierTest, AngioDetectedAsPCMRA) {
+    auto dict = MockDicomBuilder()
+        .modality("MR")
+        .seriesDescription("MR_Angio_3D_sagittal")
+        .build();
+
+    auto result = SeriesClassifier::classify(dict);
+    EXPECT_EQ(result.type, SeriesType::PC_MRA);
+    EXPECT_FALSE(result.is4DFlow);
+}
+
+// =============================================================================
+// Unknown Series
+// =============================================================================
+
+TEST(SeriesClassifierTest, UnknownSeriesType) {
+    auto dict = MockDicomBuilder()
+        .modality("MR")
+        .seriesDescription("t2_tse_tra")
+        .imageType("ORIGINAL\\PRIMARY\\M\\ND")
+        .build();
+
+    auto result = SeriesClassifier::classify(dict);
+    EXPECT_EQ(result.type, SeriesType::Unknown);
+    EXPECT_FALSE(result.is4DFlow);
+}
+
+TEST(SeriesClassifierTest, EmptyMetadataReturnsUnknown) {
+    itk::MetaDataDictionary dict;
+    auto result = SeriesClassifier::classify(dict);
+    EXPECT_EQ(result.type, SeriesType::Unknown);
+    EXPECT_FALSE(result.is4DFlow);
+}
+
+// =============================================================================
+// Utility functions
+// =============================================================================
+
+TEST(SeriesClassifierTest, Is4DFlowTypeCheck) {
+    EXPECT_TRUE(SeriesClassifier::is4DFlowType(SeriesType::Flow4D_Magnitude));
+    EXPECT_TRUE(SeriesClassifier::is4DFlowType(SeriesType::Flow4D_Phase_AP));
+    EXPECT_TRUE(SeriesClassifier::is4DFlowType(SeriesType::Flow4D_Phase_FH));
+    EXPECT_TRUE(SeriesClassifier::is4DFlowType(SeriesType::Flow4D_Phase_RL));
+    EXPECT_FALSE(SeriesClassifier::is4DFlowType(SeriesType::CT));
+    EXPECT_FALSE(SeriesClassifier::is4DFlowType(SeriesType::CINE));
+    EXPECT_FALSE(SeriesClassifier::is4DFlowType(SeriesType::DIXON));
+    EXPECT_FALSE(SeriesClassifier::is4DFlowType(SeriesType::Unknown));
+}
+
+TEST(SeriesClassifierTest, SeriesToStringCoversAllTypes) {
+    EXPECT_EQ(seriesToString(SeriesType::Flow4D_Magnitude), "4D Flow Magnitude");
+    EXPECT_EQ(seriesToString(SeriesType::Flow4D_Phase_AP), "4D Flow Phase AP");
+    EXPECT_EQ(seriesToString(SeriesType::Flow4D_Phase_FH), "4D Flow Phase FH");
+    EXPECT_EQ(seriesToString(SeriesType::Flow4D_Phase_RL), "4D Flow Phase RL");
+    EXPECT_EQ(seriesToString(SeriesType::PC_MRA), "PC-MRA");
+    EXPECT_EQ(seriesToString(SeriesType::CINE), "CINE");
+    EXPECT_EQ(seriesToString(SeriesType::DIXON), "DIXON");
+    EXPECT_EQ(seriesToString(SeriesType::Starvibe), "StarVIBE");
+    EXPECT_EQ(seriesToString(SeriesType::CT), "CT");
+    EXPECT_EQ(seriesToString(SeriesType::TOF), "TOF");
+    EXPECT_EQ(seriesToString(SeriesType::VENC_2D), "2D VENC");
+    EXPECT_EQ(seriesToString(SeriesType::Unknown), "Unknown");
+}
+
+// =============================================================================
+// Metadata preservation
+// =============================================================================
+
+TEST(SeriesClassifierTest, MetadataFieldsPreserved) {
+    auto dict = MockDicomBuilder()
+        .modality("CT")
+        .seriesDescription("Chest CT w/ contrast")
+        .seriesUid("1.2.840.113619.2.55.1234")
+        .build();
+
+    auto result = SeriesClassifier::classify(dict);
+    EXPECT_EQ(result.modality, "CT");
+    EXPECT_EQ(result.description, "Chest CT w/ contrast");
+    EXPECT_EQ(result.seriesUid, "1.2.840.113619.2.55.1234");
+}


### PR DESCRIPTION
Closes #292
Part of #247

## Summary
- Add `SeriesClassifier` class that identifies 11 DICOM series types from header metadata tags
- Detection rules use Modality (0008,0060), ImageType (0008,0008), SeriesDescription (0008,103E), and Scanning Sequence (0018,0020)
- Vendor-specific velocity encoding direction via Siemens (0051,1014), Philips (2001,101a), and GE (0019,10cc) private tags
- Stateless API: `classify(MetaDataDictionary)`, `classifyFile(path)`, `classifyStudy(paths)`
- Series types covered: Flow4D_Magnitude, Flow4D_Phase_AP/FH/RL, PC-MRA, CINE, DIXON, StarVIBE, CT, TOF, VENC_2D

## Test Plan
- [x] CT detected by Modality tag
- [x] DIXON, StarVIBE, TOF, CINE detected by SeriesDescription
- [x] CINE not confused with Phase Contrast (PC scanning sequence takes priority)
- [x] 4D Flow Magnitude detected (Siemens ImageType `\M\` pattern)
- [x] 4D Flow Phase AP/FH/RL with Siemens private tag (0051,1014)
- [x] 4D Flow Phase AP with Philips private tag (2001,101a)
- [x] 4D Flow Phase RL with GE private tag (0019,10cc)
- [x] 2D VENC detected (single-frame + PC indicators)
- [x] PC-MRA and Angio detected by description
- [x] Unknown series returns Unknown type
- [x] Empty metadata returns Unknown type
- [x] is4DFlowType() utility validates all types
- [x] seriesToString() covers all 12 enum values
- [x] Metadata fields (UID, description, modality) preserved in result
- All 20 tests pass (0ms)