### PR TITLE
feat(segmentation): implement PhaseTracker for temporal mask propagation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,6 +421,7 @@ add_library(segmentation_service STATIC
     src/services/segmentation/brush_stroke_command.cpp
     src/services/segmentation/mask_boolean_operations.cpp
     src/services/segmentation/snapshot_command.cpp
+    src/services/segmentation/phase_tracker.cpp
 )
 
 target_link_libraries(segmentation_service PUBLIC

--- a/include/services/segmentation/phase_tracker.hpp
+++ b/include/services/segmentation/phase_tracker.hpp
@@ -1,0 +1,156 @@
+#pragma once
+
+#include "services/segmentation/threshold_segmenter.hpp"
+
+#include <cstdint>
+#include <expected>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include <itkImage.h>
+#include <itkVector.h>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Temporal mask propagation across cardiac phases
+ *
+ * Propagates a segmentation mask from a reference phase to all other
+ * phases using deformable image registration. The displacement field
+ * between consecutive phases is computed via ITK Demons registration,
+ * and the mask is warped accordingly.
+ *
+ * Propagation is bidirectional:
+ *   Reference → phase+1 → phase+2 → ... → last (forward)
+ *   Reference → phase-1 → phase-2 → ... → first (backward)
+ *
+ * @trace SRS-FR-047
+ */
+class PhaseTracker {
+public:
+    using FloatImage3D = itk::Image<float, 3>;
+    using LabelMapType = itk::Image<uint8_t, 3>;
+    using DisplacementFieldType =
+        itk::Image<itk::Vector<float, 3>, 3>;
+
+    /// Progress callback: (currentPhase, totalPhases) → void
+    using ProgressCallback = std::function<void(int current, int total)>;
+
+    /**
+     * @brief Configuration for phase tracking
+     */
+    struct TrackingConfig {
+        int referencePhase = 0;            ///< Index of the reference phase
+        double smoothingSigma = 1.0;       ///< Gaussian smoothing sigma (mm)
+        int registrationIterations = 50;   ///< Demons registration iterations
+        bool applyMorphologicalClosing = true;  ///< Fill small gaps after warping
+        int closingRadius = 1;             ///< Structuring element radius (voxels)
+        double volumeDeviationThreshold = 0.20; ///< Flag phases with >20% volume change
+    };
+
+    /**
+     * @brief Per-phase tracking result
+     */
+    struct PhaseResult {
+        LabelMapType::Pointer mask;        ///< Propagated mask for this phase
+        double volumeRatio = 1.0;          ///< Volume relative to reference (1.0 = same)
+        bool qualityWarning = false;       ///< true if volume deviation > threshold
+    };
+
+    /**
+     * @brief Complete tracking result across all phases
+     */
+    struct TrackingResult {
+        std::vector<PhaseResult> phases;   ///< One per input phase
+        int referencePhase = 0;            ///< Index of the reference phase
+        int warningCount = 0;              ///< Number of phases with quality warnings
+    };
+
+    PhaseTracker();
+    ~PhaseTracker();
+
+    PhaseTracker(const PhaseTracker&) = delete;
+    PhaseTracker& operator=(const PhaseTracker&) = delete;
+    PhaseTracker(PhaseTracker&&) noexcept;
+    PhaseTracker& operator=(PhaseTracker&&) noexcept;
+
+    /**
+     * @brief Set progress callback
+     */
+    void setProgressCallback(ProgressCallback callback);
+
+    /**
+     * @brief Propagate mask from reference phase to all phases
+     *
+     * @param referenceMask Segmentation mask at the reference phase
+     * @param magnitudePhases Magnitude images for all cardiac phases
+     * @param config Tracking configuration
+     * @return Tracking result with masks for all phases
+     */
+    [[nodiscard]] std::expected<TrackingResult, SegmentationError>
+    propagateMask(
+        LabelMapType::Pointer referenceMask,
+        const std::vector<FloatImage3D::Pointer>& magnitudePhases,
+        const TrackingConfig& config) const;
+
+    // =====================================================================
+    // Low-level methods (public for testing)
+    // =====================================================================
+
+    /**
+     * @brief Compute displacement field between two phases
+     *
+     * Uses ITK Demons registration to find the deformation that maps
+     * fixedImage to movingImage.
+     *
+     * @param fixedImage Target phase magnitude
+     * @param movingImage Source phase magnitude
+     * @param iterations Number of registration iterations
+     * @param smoothingSigma Gaussian smoothing sigma
+     * @return Displacement field or error
+     */
+    [[nodiscard]] static std::expected<DisplacementFieldType::Pointer,
+                                       SegmentationError>
+    computeDisplacementField(
+        FloatImage3D::Pointer fixedImage,
+        FloatImage3D::Pointer movingImage,
+        int iterations,
+        double smoothingSigma);
+
+    /**
+     * @brief Warp a label map using a displacement field
+     *
+     * Uses nearest-neighbor interpolation to preserve label values.
+     *
+     * @param mask Input label map
+     * @param displacementField Deformation field
+     * @return Warped label map or error
+     */
+    [[nodiscard]] static std::expected<LabelMapType::Pointer,
+                                       SegmentationError>
+    warpMask(LabelMapType::Pointer mask,
+             DisplacementFieldType::Pointer displacementField);
+
+    /**
+     * @brief Apply morphological closing to fill small gaps
+     *
+     * @param mask Input label map
+     * @param radius Structuring element radius in voxels
+     * @return Closed label map
+     */
+    [[nodiscard]] static LabelMapType::Pointer
+    applyClosing(LabelMapType::Pointer mask, int radius);
+
+    /**
+     * @brief Count non-zero voxels in a label map
+     */
+    [[nodiscard]] static size_t countNonZeroVoxels(
+        LabelMapType::Pointer mask);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace dicom_viewer::services

--- a/src/services/segmentation/phase_tracker.cpp
+++ b/src/services/segmentation/phase_tracker.cpp
@@ -1,0 +1,327 @@
+#include "services/segmentation/phase_tracker.hpp"
+
+#include <cmath>
+#include <format>
+
+#include <itkBinaryBallStructuringElement.h>
+#include <itkBinaryMorphologicalClosingImageFilter.h>
+#include <itkCastImageFilter.h>
+#include <itkDemonsRegistrationFilter.h>
+#include <itkImageRegionConstIterator.h>
+#include <itkNearestNeighborInterpolateImageFunction.h>
+#include <itkResampleImageFilter.h>
+#include <itkWarpImageFilter.h>
+
+namespace dicom_viewer::services {
+
+// =========================================================================
+// Pimpl
+// =========================================================================
+
+class PhaseTracker::Impl {
+public:
+    PhaseTracker::ProgressCallback progressCallback;
+
+    void reportProgress(int current, int total) const {
+        if (progressCallback) {
+            progressCallback(current, total);
+        }
+    }
+};
+
+PhaseTracker::PhaseTracker()
+    : impl_(std::make_unique<Impl>()) {}
+
+PhaseTracker::~PhaseTracker() = default;
+
+PhaseTracker::PhaseTracker(PhaseTracker&&) noexcept = default;
+PhaseTracker& PhaseTracker::operator=(PhaseTracker&&) noexcept = default;
+
+void PhaseTracker::setProgressCallback(ProgressCallback callback) {
+    impl_->progressCallback = std::move(callback);
+}
+
+// =========================================================================
+// Static: Displacement field computation
+// =========================================================================
+
+std::expected<PhaseTracker::DisplacementFieldType::Pointer, SegmentationError>
+PhaseTracker::computeDisplacementField(
+    FloatImage3D::Pointer fixedImage,
+    FloatImage3D::Pointer movingImage,
+    int iterations,
+    double smoothingSigma) {
+
+    if (!fixedImage || !movingImage) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Null image passed to computeDisplacementField"});
+    }
+
+    try {
+        using DemonsFilterType =
+            itk::DemonsRegistrationFilter<FloatImage3D, FloatImage3D,
+                                          DisplacementFieldType>;
+
+        auto demons = DemonsFilterType::New();
+        demons->SetFixedImage(fixedImage);
+        demons->SetMovingImage(movingImage);
+        demons->SetNumberOfIterations(iterations);
+        demons->SetStandardDeviations(smoothingSigma);
+        demons->Update();
+
+        return demons->GetOutput();
+    } catch (const itk::ExceptionObject& e) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::ProcessingFailed,
+            std::format("Demons registration failed: {}", e.GetDescription())});
+    }
+}
+
+// =========================================================================
+// Static: Mask warping
+// =========================================================================
+
+std::expected<PhaseTracker::LabelMapType::Pointer, SegmentationError>
+PhaseTracker::warpMask(
+    LabelMapType::Pointer mask,
+    DisplacementFieldType::Pointer displacementField) {
+
+    if (!mask || !displacementField) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Null input passed to warpMask"});
+    }
+
+    try {
+        // Cast uint8 → float for warping (WarpImageFilter requires matching types)
+        using CastToFloat =
+            itk::CastImageFilter<LabelMapType, FloatImage3D>;
+        auto castIn = CastToFloat::New();
+        castIn->SetInput(mask);
+
+        // Warp with nearest-neighbor to preserve label values
+        using WarpFilterType =
+            itk::WarpImageFilter<FloatImage3D, FloatImage3D,
+                                 DisplacementFieldType>;
+        auto warp = WarpFilterType::New();
+        warp->SetInput(castIn->GetOutput());
+        warp->SetDisplacementField(displacementField);
+        warp->SetOutputSpacing(mask->GetSpacing());
+        warp->SetOutputOrigin(mask->GetOrigin());
+        warp->SetOutputDirection(mask->GetDirection());
+        warp->SetOutputSize(mask->GetLargestPossibleRegion().GetSize());
+
+        // Use nearest-neighbor interpolation for label data
+        using InterpolatorType =
+            itk::NearestNeighborInterpolateImageFunction<FloatImage3D, double>;
+        auto interpolator = InterpolatorType::New();
+        warp->SetInterpolator(interpolator);
+        warp->Update();
+
+        // Cast back float → uint8
+        using CastToLabel =
+            itk::CastImageFilter<FloatImage3D, LabelMapType>;
+        auto castOut = CastToLabel::New();
+        castOut->SetInput(warp->GetOutput());
+        castOut->Update();
+
+        return castOut->GetOutput();
+    } catch (const itk::ExceptionObject& e) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::ProcessingFailed,
+            std::format("Mask warping failed: {}", e.GetDescription())});
+    }
+}
+
+// =========================================================================
+// Static: Morphological closing
+// =========================================================================
+
+PhaseTracker::LabelMapType::Pointer
+PhaseTracker::applyClosing(LabelMapType::Pointer mask, int radius) {
+    if (!mask || radius <= 0) {
+        return mask;
+    }
+
+    using StructuringElementType =
+        itk::BinaryBallStructuringElement<uint8_t, 3>;
+    StructuringElementType se;
+    se.SetRadius(radius);
+    se.CreateStructuringElement();
+
+    using ClosingFilterType =
+        itk::BinaryMorphologicalClosingImageFilter<LabelMapType,
+                                                    LabelMapType,
+                                                    StructuringElementType>;
+    auto closing = ClosingFilterType::New();
+    closing->SetInput(mask);
+    closing->SetKernel(se);
+    closing->SetForegroundValue(1);
+    closing->Update();
+
+    return closing->GetOutput();
+}
+
+// =========================================================================
+// Static: Voxel counting
+// =========================================================================
+
+size_t PhaseTracker::countNonZeroVoxels(LabelMapType::Pointer mask) {
+    if (!mask) {
+        return 0;
+    }
+
+    size_t count = 0;
+    itk::ImageRegionConstIterator<LabelMapType> it(
+        mask, mask->GetLargestPossibleRegion());
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        if (it.Get() != 0) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+// =========================================================================
+// Main propagation
+// =========================================================================
+
+std::expected<PhaseTracker::TrackingResult, SegmentationError>
+PhaseTracker::propagateMask(
+    LabelMapType::Pointer referenceMask,
+    const std::vector<FloatImage3D::Pointer>& magnitudePhases,
+    const TrackingConfig& config) const {
+
+    if (!referenceMask) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Reference mask is null"});
+    }
+
+    const int numPhases = static_cast<int>(magnitudePhases.size());
+
+    if (numPhases < 2) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "At least 2 magnitude phases are required"});
+    }
+
+    if (config.referencePhase < 0 || config.referencePhase >= numPhases) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            std::format("Reference phase {} out of range [0, {})",
+                        config.referencePhase, numPhases)});
+    }
+
+    for (int i = 0; i < numPhases; ++i) {
+        if (!magnitudePhases[i]) {
+            return std::unexpected(SegmentationError{
+                SegmentationError::Code::InvalidInput,
+                std::format("Magnitude phase {} is null", i)});
+        }
+    }
+
+    // Initialize result
+    TrackingResult result;
+    result.referencePhase = config.referencePhase;
+    result.phases.resize(numPhases);
+
+    // Reference phase: copy mask directly
+    result.phases[config.referencePhase].mask = referenceMask;
+    result.phases[config.referencePhase].volumeRatio = 1.0;
+
+    const size_t refVolume = countNonZeroVoxels(referenceMask);
+    int progressCount = 0;
+    const int totalSteps = numPhases - 1;
+
+    // Forward propagation: reference → reference+1 → ... → last
+    auto currentMask = referenceMask;
+    for (int i = config.referencePhase + 1; i < numPhases; ++i) {
+        // Compute displacement: phase[i-1] → phase[i]
+        auto fieldResult = computeDisplacementField(
+            magnitudePhases[i], magnitudePhases[i - 1],
+            config.registrationIterations, config.smoothingSigma);
+
+        if (!fieldResult) {
+            return std::unexpected(fieldResult.error());
+        }
+
+        // Warp current mask with displacement field
+        auto warpResult = warpMask(currentMask, *fieldResult);
+        if (!warpResult) {
+            return std::unexpected(warpResult.error());
+        }
+
+        currentMask = *warpResult;
+
+        // Optional morphological closing
+        if (config.applyMorphologicalClosing) {
+            currentMask = applyClosing(currentMask, config.closingRadius);
+        }
+
+        // Volume consistency check
+        const size_t phaseVolume = countNonZeroVoxels(currentMask);
+        double ratio = (refVolume > 0)
+            ? static_cast<double>(phaseVolume) / static_cast<double>(refVolume)
+            : 0.0;
+
+        result.phases[i].mask = currentMask;
+        result.phases[i].volumeRatio = ratio;
+        result.phases[i].qualityWarning =
+            std::abs(ratio - 1.0) > config.volumeDeviationThreshold;
+        if (result.phases[i].qualityWarning) {
+            ++result.warningCount;
+        }
+
+        ++progressCount;
+        impl_->reportProgress(progressCount, totalSteps);
+    }
+
+    // Backward propagation: reference → reference-1 → ... → first
+    currentMask = referenceMask;
+    for (int i = config.referencePhase - 1; i >= 0; --i) {
+        // Compute displacement: phase[i+1] → phase[i]
+        auto fieldResult = computeDisplacementField(
+            magnitudePhases[i], magnitudePhases[i + 1],
+            config.registrationIterations, config.smoothingSigma);
+
+        if (!fieldResult) {
+            return std::unexpected(fieldResult.error());
+        }
+
+        // Warp current mask with displacement field
+        auto warpResult = warpMask(currentMask, *fieldResult);
+        if (!warpResult) {
+            return std::unexpected(warpResult.error());
+        }
+
+        currentMask = *warpResult;
+
+        // Optional morphological closing
+        if (config.applyMorphologicalClosing) {
+            currentMask = applyClosing(currentMask, config.closingRadius);
+        }
+
+        // Volume consistency check
+        const size_t phaseVolume = countNonZeroVoxels(currentMask);
+        double ratio = (refVolume > 0)
+            ? static_cast<double>(phaseVolume) / static_cast<double>(refVolume)
+            : 0.0;
+
+        result.phases[i].mask = currentMask;
+        result.phases[i].volumeRatio = ratio;
+        result.phases[i].qualityWarning =
+            std::abs(ratio - 1.0) > config.volumeDeviationThreshold;
+        if (result.phases[i].qualityWarning) {
+            ++result.warningCount;
+        }
+
+        ++progressCount;
+        impl_->reportProgress(progressCount, totalSteps);
+    }
+
+    return result;
+}
+
+}  // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1549,6 +1549,24 @@ target_include_directories(snapshot_command_test PRIVATE
 
 gtest_discover_tests(snapshot_command_test DISCOVERY_TIMEOUT 60)
 
+# Unit tests for PhaseTracker (temporal mask propagation)
+add_executable(phase_tracker_test
+    unit/phase_tracker_test.cpp
+)
+
+target_link_libraries(phase_tracker_test PRIVATE
+    segmentation_service
+    ${ITK_LIBRARIES}
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(phase_tracker_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(phase_tracker_test DISCOVERY_TIMEOUT 120)
+
 # Unit tests for Ensight Gold format exporter
 add_executable(ensight_exporter_test
     unit/ensight_exporter_test.cpp

--- a/tests/unit/phase_tracker_test.cpp
+++ b/tests/unit/phase_tracker_test.cpp
@@ -1,0 +1,353 @@
+#include "services/segmentation/phase_tracker.hpp"
+
+#include <cmath>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <itkImageRegionIterator.h>
+
+using namespace dicom_viewer::services;
+using FloatImage3D = PhaseTracker::FloatImage3D;
+using LabelMapType = PhaseTracker::LabelMapType;
+using DisplacementFieldType = PhaseTracker::DisplacementFieldType;
+
+namespace {
+
+/// Create a float 3D image of given size with uniform value
+FloatImage3D::Pointer createFloatImage(int sx, int sy, int sz, float value = 0.0f) {
+    auto image = FloatImage3D::New();
+    FloatImage3D::SizeType size = {{
+        static_cast<unsigned long>(sx),
+        static_cast<unsigned long>(sy),
+        static_cast<unsigned long>(sz)
+    }};
+    FloatImage3D::IndexType start = {{0, 0, 0}};
+    FloatImage3D::RegionType region{start, size};
+    image->SetRegions(region);
+
+    FloatImage3D::SpacingType spacing;
+    spacing.Fill(1.0);
+    image->SetSpacing(spacing);
+
+    FloatImage3D::PointType origin;
+    origin.Fill(0.0);
+    image->SetOrigin(origin);
+
+    image->Allocate();
+    image->FillBuffer(value);
+    return image;
+}
+
+/// Create a label map of given size with all zeros
+LabelMapType::Pointer createLabelMap(int sx, int sy, int sz) {
+    auto image = LabelMapType::New();
+    LabelMapType::SizeType size = {{
+        static_cast<unsigned long>(sx),
+        static_cast<unsigned long>(sy),
+        static_cast<unsigned long>(sz)
+    }};
+    LabelMapType::IndexType start = {{0, 0, 0}};
+    LabelMapType::RegionType region{start, size};
+    image->SetRegions(region);
+
+    LabelMapType::SpacingType spacing;
+    spacing.Fill(1.0);
+    image->SetSpacing(spacing);
+
+    LabelMapType::PointType origin;
+    origin.Fill(0.0);
+    image->SetOrigin(origin);
+
+    image->Allocate();
+    image->FillBuffer(0);
+    return image;
+}
+
+/// Draw a filled sphere in a float image
+void drawSphereFloat(FloatImage3D::Pointer image,
+                     double cx, double cy, double cz,
+                     double radius, float intensity) {
+    auto region = image->GetLargestPossibleRegion();
+    itk::ImageRegionIterator<FloatImage3D> it(image, region);
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        auto idx = it.GetIndex();
+        double dx = idx[0] - cx;
+        double dy = idx[1] - cy;
+        double dz = idx[2] - cz;
+        if (dx*dx + dy*dy + dz*dz <= radius*radius) {
+            it.Set(intensity);
+        }
+    }
+}
+
+/// Draw a filled sphere in a label map
+void drawSphereLabel(LabelMapType::Pointer image,
+                     double cx, double cy, double cz,
+                     double radius, uint8_t label) {
+    auto region = image->GetLargestPossibleRegion();
+    itk::ImageRegionIterator<LabelMapType> it(image, region);
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        auto idx = it.GetIndex();
+        double dx = idx[0] - cx;
+        double dy = idx[1] - cy;
+        double dz = idx[2] - cz;
+        if (dx*dx + dy*dy + dz*dz <= radius*radius) {
+            it.Set(label);
+        }
+    }
+}
+
+/// Create a constant displacement field
+DisplacementFieldType::Pointer createConstantField(
+    int sx, int sy, int sz,
+    float dx, float dy, float dz) {
+    auto field = DisplacementFieldType::New();
+    DisplacementFieldType::SizeType size = {{
+        static_cast<unsigned long>(sx),
+        static_cast<unsigned long>(sy),
+        static_cast<unsigned long>(sz)
+    }};
+    DisplacementFieldType::IndexType start = {{0, 0, 0}};
+    DisplacementFieldType::RegionType region{start, size};
+    field->SetRegions(region);
+
+    DisplacementFieldType::SpacingType spacing;
+    spacing.Fill(1.0);
+    field->SetSpacing(spacing);
+
+    DisplacementFieldType::PointType origin;
+    origin.Fill(0.0);
+    field->SetOrigin(origin);
+
+    field->Allocate();
+
+    itk::Vector<float, 3> displacement;
+    displacement[0] = dx;
+    displacement[1] = dy;
+    displacement[2] = dz;
+    field->FillBuffer(displacement);
+
+    return field;
+}
+
+}  // anonymous namespace
+
+// =============================================================================
+// Static method tests
+// =============================================================================
+
+TEST(PhaseTrackerTest, CountNonZeroVoxels) {
+    auto mask = createLabelMap(10, 10, 10);
+    EXPECT_EQ(PhaseTracker::countNonZeroVoxels(mask), 0u);
+
+    drawSphereLabel(mask, 5.0, 5.0, 5.0, 3.0, 1);
+    size_t count = PhaseTracker::countNonZeroVoxels(mask);
+    EXPECT_GT(count, 0u);
+    EXPECT_LT(count, 1000u);
+}
+
+TEST(PhaseTrackerTest, CountNonZeroVoxelsNullReturnsZero) {
+    EXPECT_EQ(PhaseTracker::countNonZeroVoxels(nullptr), 0u);
+}
+
+TEST(PhaseTrackerTest, WarpMaskWithConstantField) {
+    const int dim = 20;
+    auto mask = createLabelMap(dim, dim, dim);
+    drawSphereLabel(mask, 10.0, 10.0, 10.0, 4.0, 1);
+
+    size_t originalCount = PhaseTracker::countNonZeroVoxels(mask);
+    EXPECT_GT(originalCount, 50u);
+
+    // Shift mask by (2, 0, 0) using a constant displacement field
+    auto field = createConstantField(dim, dim, dim, 2.0f, 0.0f, 0.0f);
+    auto result = PhaseTracker::warpMask(mask, field);
+
+    ASSERT_TRUE(result.has_value());
+    auto warped = result.value();
+    size_t warpedCount = PhaseTracker::countNonZeroVoxels(warped);
+
+    // Warped mask should have similar voxel count (some boundary loss expected)
+    EXPECT_GT(warpedCount, originalCount / 2);
+
+    // Check that center shifted: original center (10,10,10) → new center ~(12,10,10)
+    // The original center should now be empty or the new center should be filled
+    LabelMapType::IndexType shiftedCenter = {{12, 10, 10}};
+    EXPECT_EQ(warped->GetPixel(shiftedCenter), 1);
+}
+
+TEST(PhaseTrackerTest, WarpMaskNullInputReturnsError) {
+    auto mask = createLabelMap(10, 10, 10);
+    auto result = PhaseTracker::warpMask(nullptr, nullptr);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+TEST(PhaseTrackerTest, ApplyClosingFillsSmallGaps) {
+    auto mask = createLabelMap(20, 20, 20);
+    drawSphereLabel(mask, 10.0, 10.0, 10.0, 5.0, 1);
+
+    // Remove center voxel to create a gap
+    LabelMapType::IndexType center = {{10, 10, 10}};
+    mask->SetPixel(center, 0);
+    EXPECT_EQ(mask->GetPixel(center), 0);
+
+    auto closed = PhaseTracker::applyClosing(mask, 1);
+    EXPECT_NE(closed, nullptr);
+    // After closing, the gap should be filled
+    EXPECT_EQ(closed->GetPixel(center), 1);
+}
+
+TEST(PhaseTrackerTest, ApplyClosingNullReturnsNull) {
+    auto result = PhaseTracker::applyClosing(nullptr, 1);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST(PhaseTrackerTest, ApplyClosingZeroRadiusReturnsOriginal) {
+    auto mask = createLabelMap(10, 10, 10);
+    auto result = PhaseTracker::applyClosing(mask, 0);
+    EXPECT_EQ(result.GetPointer(), mask.GetPointer());
+}
+
+// =============================================================================
+// Displacement field computation
+// =============================================================================
+
+TEST(PhaseTrackerTest, ComputeDisplacementFieldIdenticalImages) {
+    const int dim = 16;
+    auto img = createFloatImage(dim, dim, dim, 0.0f);
+    drawSphereFloat(img, 8.0, 8.0, 8.0, 4.0, 100.0f);
+
+    // Identical images → displacement field should be near zero
+    auto result = PhaseTracker::computeDisplacementField(img, img, 10, 1.0);
+    ASSERT_TRUE(result.has_value());
+
+    auto field = result.value();
+    DisplacementFieldType::IndexType center = {{8, 8, 8}};
+    auto disp = field->GetPixel(center);
+
+    // Each component should be near zero
+    EXPECT_NEAR(disp[0], 0.0f, 0.5f);
+    EXPECT_NEAR(disp[1], 0.0f, 0.5f);
+    EXPECT_NEAR(disp[2], 0.0f, 0.5f);
+}
+
+TEST(PhaseTrackerTest, ComputeDisplacementFieldNullReturnsError) {
+    auto result = PhaseTracker::computeDisplacementField(
+        nullptr, nullptr, 10, 1.0);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+// =============================================================================
+// Full propagation pipeline
+// =============================================================================
+
+TEST(PhaseTrackerTest, PropagateMaskNullMaskReturnsError) {
+    std::vector<FloatImage3D::Pointer> phases;
+    phases.push_back(createFloatImage(10, 10, 10));
+    phases.push_back(createFloatImage(10, 10, 10));
+
+    PhaseTracker tracker;
+    PhaseTracker::TrackingConfig config;
+    config.referencePhase = 0;
+
+    auto result = tracker.propagateMask(nullptr, phases, config);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(PhaseTrackerTest, PropagateMaskTooFewPhasesReturnsError) {
+    auto mask = createLabelMap(10, 10, 10);
+    std::vector<FloatImage3D::Pointer> phases;
+    phases.push_back(createFloatImage(10, 10, 10));
+
+    PhaseTracker tracker;
+    PhaseTracker::TrackingConfig config;
+    auto result = tracker.propagateMask(mask, phases, config);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(PhaseTrackerTest, PropagateMaskInvalidReferenceReturnsError) {
+    auto mask = createLabelMap(10, 10, 10);
+    std::vector<FloatImage3D::Pointer> phases;
+    phases.push_back(createFloatImage(10, 10, 10));
+    phases.push_back(createFloatImage(10, 10, 10));
+
+    PhaseTracker tracker;
+    PhaseTracker::TrackingConfig config;
+    config.referencePhase = 5;  // Out of range
+
+    auto result = tracker.propagateMask(mask, phases, config);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+TEST(PhaseTrackerTest, PropagateMaskStaticPhases) {
+    // All phases have the same image → mask should propagate unchanged
+    const int dim = 16;
+    const int numPhases = 3;
+
+    auto mag = createFloatImage(dim, dim, dim, 0.0f);
+    drawSphereFloat(mag, 8.0, 8.0, 8.0, 4.0, 100.0f);
+
+    std::vector<FloatImage3D::Pointer> phases(numPhases, mag);
+
+    auto mask = createLabelMap(dim, dim, dim);
+    drawSphereLabel(mask, 8.0, 8.0, 8.0, 3.0, 1);
+
+    PhaseTracker tracker;
+    PhaseTracker::TrackingConfig config;
+    config.referencePhase = 1;  // Middle phase
+    config.registrationIterations = 10;
+    config.smoothingSigma = 1.0;
+    config.applyMorphologicalClosing = false;
+
+    auto result = tracker.propagateMask(mask, phases, config);
+    ASSERT_TRUE(result.has_value());
+
+    auto& tracking = result.value();
+    EXPECT_EQ(tracking.phases.size(), static_cast<size_t>(numPhases));
+    EXPECT_EQ(tracking.referencePhase, 1);
+
+    // All phases should have masks
+    for (int i = 0; i < numPhases; ++i) {
+        ASSERT_NE(tracking.phases[i].mask, nullptr);
+        size_t count = PhaseTracker::countNonZeroVoxels(tracking.phases[i].mask);
+        EXPECT_GT(count, 0u) << "Phase " << i << " has empty mask";
+    }
+
+    // Volume ratios should be close to 1.0 for static phases
+    size_t refCount = PhaseTracker::countNonZeroVoxels(mask);
+    for (int i = 0; i < numPhases; ++i) {
+        EXPECT_NEAR(tracking.phases[i].volumeRatio, 1.0, 0.3)
+            << "Phase " << i << " volume ratio out of range";
+    }
+}
+
+TEST(PhaseTrackerTest, ProgressCallbackInvoked) {
+    const int dim = 16;
+    const int numPhases = 3;
+
+    auto mag = createFloatImage(dim, dim, dim, 50.0f);
+    std::vector<FloatImage3D::Pointer> phases(numPhases, mag);
+
+    auto mask = createLabelMap(dim, dim, dim);
+    drawSphereLabel(mask, 8.0, 8.0, 8.0, 3.0, 1);
+
+    PhaseTracker tracker;
+    int callCount = 0;
+    tracker.setProgressCallback([&](int current, int total) {
+        ++callCount;
+        EXPECT_LE(current, total);
+    });
+
+    PhaseTracker::TrackingConfig config;
+    config.referencePhase = 1;
+    config.registrationIterations = 5;
+    config.applyMorphologicalClosing = false;
+
+    auto result = tracker.propagateMask(mask, phases, config);
+    ASSERT_TRUE(result.has_value());
+
+    // Should be called once per non-reference phase (numPhases - 1)
+    EXPECT_EQ(callCount, numPhases - 1);
+}


### PR DESCRIPTION
Closes #294
Part of #253

## Summary
- Add `PhaseTracker` class for propagating segmentation masks across cardiac phases using ITK Demons registration
- Bidirectional propagation: reference phase → forward to last phase + backward to first phase
- Displacement field computed via `itk::DemonsRegistrationFilter` between consecutive magnitude images
- Mask warping with `itk::WarpImageFilter` using nearest-neighbor interpolation to preserve label values
- Morphological closing (`itk::BinaryMorphologicalClosingImageFilter`) to fill small gaps from interpolation artifacts
- Per-phase volume consistency check: flags phases with >20% volume deviation from reference

## Test Plan
- [x] CountNonZeroVoxels — counts labeled voxels in sphere
- [x] CountNonZeroVoxelsNullReturnsZero — null safety
- [x] WarpMaskWithConstantField — verifies sphere shifts correctly with known displacement
- [x] WarpMaskNullInputReturnsError — null safety
- [x] ApplyClosingFillsSmallGaps — verifies single-voxel gap is filled
- [x] ApplyClosingNullReturnsNull — null safety
- [x] ApplyClosingZeroRadiusReturnsOriginal — no-op check
- [x] ComputeDisplacementFieldIdenticalImages — identical images → near-zero displacement
- [x] ComputeDisplacementFieldNullReturnsError — null safety
- [x] PropagateMaskNullMaskReturnsError — input validation
- [x] PropagateMaskTooFewPhasesReturnsError — minimum 2 phases required
- [x] PropagateMaskInvalidReferenceReturnsError — out-of-range reference phase
- [x] PropagateMaskStaticPhases — static phases → masks preserved with near-1.0 volume ratio
- [x] ProgressCallbackInvoked — callback fires once per non-reference phase
- All 14 tests pass (24ms)