### PR TITLE
feat(export): implement MAT-file v5 writer for MATLAB velocity field export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,6 +496,7 @@ add_library(export_service STATIC
     src/services/export/mesh_exporter.cpp
     src/services/export/dicom_sr_writer.cpp
     src/services/export/ensight_exporter.cpp
+    src/services/export/matlab_exporter.cpp
 )
 
 target_include_directories(export_service PUBLIC

--- a/include/services/export/matlab_exporter.hpp
+++ b/include/services/export/matlab_exporter.hpp
@@ -1,0 +1,145 @@
+#pragma once
+
+#include "services/export/data_exporter.hpp"
+
+#include <cstdint>
+#include <expected>
+#include <filesystem>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <itkImage.h>
+#include <itkVectorImage.h>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief MAT-file Level 5 writer and velocity field exporter
+ *
+ * Writes MATLAB .mat files in Level 5 binary format without external
+ * library dependencies. Supports float32/float64 numeric arrays (up to 4D)
+ * and struct data elements with string fields.
+ *
+ * Data is stored in column-major (Fortran) order as required by MATLAB.
+ *
+ * File naming follows the Heartflow convention:
+ *   4DPC_vel_AP.mat, 4DPC_vel_FH.mat, 4DPC_vel_RL.mat,
+ *   4DPC_M_FFE.mat (magnitude)
+ *
+ * @trace SRS-FR-050
+ */
+class MatlabExporter {
+public:
+    using FloatImage3D = itk::Image<float, 3>;
+    using VectorImage3D = itk::VectorImage<float, 3>;
+
+    /**
+     * @brief Configuration for velocity field export
+     */
+    struct ExportConfig {
+        std::filesystem::path outputDir;
+        std::string prefix = "4DPC";
+        int vencValue = 150;
+        bool exportMagnitude = true;
+    };
+
+    /**
+     * @brief DICOM metadata to embed in MAT files
+     */
+    struct DicomMeta {
+        std::string seriesDescription;
+        std::string sequenceName;
+        std::string imageType;
+        double pixelSpacingX = 1.0;
+        double pixelSpacingY = 1.0;
+        double sliceThickness = 1.0;
+    };
+
+    // =====================================================================
+    // High-level velocity export
+    // =====================================================================
+
+    /**
+     * @brief Export multi-phase velocity fields to MAT files
+     *
+     * Generates separate files for AP, FH, RL components and optionally
+     * magnitude. Each file contains a 4D array (x, y, z, t) and metadata.
+     *
+     * @param velocityPhases Per-phase 3-component velocity (VectorImage3D)
+     * @param magnitudePhases Per-phase magnitude (FloatImage3D), optional
+     * @param meta DICOM metadata to embed
+     * @param config Export configuration
+     * @return Success or ExportError
+     */
+    [[nodiscard]] static std::expected<void, ExportError>
+    exportVelocityFields(
+        const std::vector<VectorImage3D::Pointer>& velocityPhases,
+        const std::vector<FloatImage3D::Pointer>& magnitudePhases,
+        const DicomMeta& meta,
+        const ExportConfig& config);
+
+    // =====================================================================
+    // Low-level MAT-file v5 format writer (public for testing)
+    // =====================================================================
+
+    /**
+     * @brief Write MAT-file v5 header (128 bytes)
+     *
+     * Layout: 116 bytes descriptive text + 8 bytes subsys offset +
+     *         2 bytes version (0x0100) + 2 bytes endian ('IM')
+     *
+     * @param out Output buffer to append to
+     * @param description Text description (max 116 chars)
+     */
+    static void writeHeader(std::vector<uint8_t>& out,
+                            const std::string& description);
+
+    /**
+     * @brief Write a miMATRIX data element containing a float array
+     *
+     * @param out Output buffer to append to
+     * @param name Variable name in MATLAB workspace
+     * @param data Float data in column-major order
+     * @param dimensions Array dimensions (e.g., {nx, ny, nz, nt})
+     */
+    static void writeFloatArray(std::vector<uint8_t>& out,
+                                const std::string& name,
+                                const std::vector<float>& data,
+                                const std::vector<int32_t>& dimensions);
+
+    /**
+     * @brief Write a miMATRIX data element containing a MATLAB struct
+     *
+     * @param out Output buffer to append to
+     * @param name Variable name
+     * @param fields Map of field name → string value
+     */
+    static void writeStruct(std::vector<uint8_t>& out,
+                            const std::string& name,
+                            const std::map<std::string, std::string>& fields);
+
+    /**
+     * @brief Convert a 3D ITK float image to column-major flat array
+     *
+     * MATLAB uses column-major (Fortran) order: x varies fastest,
+     * then y, then z. ITK stores in row-major (C) order.
+     *
+     * @param image Input ITK image
+     * @return Flat array in column-major order
+     */
+    [[nodiscard]] static std::vector<float>
+    itkToColumnMajor(const FloatImage3D* image);
+
+    /**
+     * @brief Extract a single component from a VectorImage3D
+     *
+     * @param image Input vector image (3 components)
+     * @param component Component index (0, 1, or 2)
+     * @return Flat array of the selected component in column-major order
+     */
+    [[nodiscard]] static std::vector<float>
+    extractComponentColumnMajor(const VectorImage3D* image, int component);
+};
+
+}  // namespace dicom_viewer::services

--- a/src/services/export/matlab_exporter.cpp
+++ b/src/services/export/matlab_exporter.cpp
@@ -1,0 +1,409 @@
+#include "services/export/matlab_exporter.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <format>
+#include <fstream>
+#include <numeric>
+
+#include <itkImageRegionConstIterator.h>
+
+namespace {
+
+// =========================================================================
+// MAT-file Level 5 constants
+// =========================================================================
+
+// Data type tags
+constexpr int32_t miINT8      = 1;
+constexpr int32_t miUINT8     = 2;
+constexpr int32_t miINT32     = 5;
+constexpr int32_t miUINT32    = 6;
+constexpr int32_t miSINGLE    = 7;
+constexpr int32_t miMATRIX    = 14;
+
+// Array class flags (stored in upper byte of flags)
+constexpr uint8_t mxDOUBLE_CLASS = 6;
+constexpr uint8_t mxSINGLE_CLASS = 7;
+constexpr uint8_t mxCHAR_CLASS   = 4;
+constexpr uint8_t mxSTRUCT_CLASS = 2;
+
+// MAT-file version and endian marker
+constexpr uint16_t kMATVersion    = 0x0100;
+constexpr uint16_t kEndianMarker  = 0x4D49;  // 'IM' in little-endian
+
+/// Pad size to 8-byte boundary
+size_t padTo8(size_t n) {
+    return (n + 7) & ~static_cast<size_t>(7);
+}
+
+/// Write raw bytes to output buffer
+void writeBytes(std::vector<uint8_t>& out, const void* data, size_t n) {
+    auto p = reinterpret_cast<const uint8_t*>(data);
+    out.insert(out.end(), p, p + n);
+}
+
+/// Write zero padding to reach 8-byte alignment
+void writePadding(std::vector<uint8_t>& out, size_t dataSize) {
+    size_t padded = padTo8(dataSize);
+    if (padded > dataSize) {
+        out.resize(out.size() + (padded - dataSize), 0);
+    }
+}
+
+/// Write a data element tag (8 bytes: type + nbytes)
+void writeTag(std::vector<uint8_t>& out, int32_t type, int32_t nbytes) {
+    writeBytes(out, &type, 4);
+    writeBytes(out, &nbytes, 4);
+}
+
+/// Write a small data element (tag compressed to 4 bytes when data <= 4 bytes)
+void writeSmallElement(std::vector<uint8_t>& out, int32_t type,
+                       const void* data, int32_t nbytes) {
+    if (nbytes <= 4) {
+        // Compressed format: upper 2 bytes = nbytes, lower 2 bytes = type
+        uint32_t packed = (static_cast<uint32_t>(nbytes) << 16) |
+                          (static_cast<uint32_t>(type) & 0xFFFF);
+        writeBytes(out, &packed, 4);
+        uint8_t buf[4] = {0};
+        std::memcpy(buf, data, nbytes);
+        writeBytes(out, buf, 4);
+    } else {
+        writeTag(out, type, nbytes);
+        writeBytes(out, data, nbytes);
+        writePadding(out, nbytes);
+    }
+}
+
+/// Write array flags subelement (2 x uint32: [class|flags, 0])
+void writeArrayFlags(std::vector<uint8_t>& out, uint8_t arrayClass) {
+    writeTag(out, miUINT32, 8);
+    uint32_t flags = arrayClass;
+    writeBytes(out, &flags, 4);
+    uint32_t zero = 0;
+    writeBytes(out, &zero, 4);
+}
+
+/// Write dimensions subelement
+void writeDimensions(std::vector<uint8_t>& out,
+                     const std::vector<int32_t>& dims) {
+    int32_t nbytes = static_cast<int32_t>(dims.size() * 4);
+    writeTag(out, miINT32, nbytes);
+    writeBytes(out, dims.data(), nbytes);
+    writePadding(out, nbytes);
+}
+
+/// Write array name subelement
+void writeArrayName(std::vector<uint8_t>& out, const std::string& name) {
+    int32_t nbytes = static_cast<int32_t>(name.size());
+    writeSmallElement(out, miINT8, name.data(), nbytes);
+}
+
+}  // anonymous namespace
+
+namespace dicom_viewer::services {
+
+// =========================================================================
+// MAT-file header (128 bytes)
+// =========================================================================
+
+void MatlabExporter::writeHeader(std::vector<uint8_t>& out,
+                                  const std::string& description) {
+    // 116 bytes descriptive text (space-padded)
+    std::string text = description;
+    text.resize(116, ' ');
+    writeBytes(out, text.data(), 116);
+
+    // 8 bytes subsystem data offset (unused, set to 0)
+    uint8_t zeros[8] = {0};
+    writeBytes(out, zeros, 8);
+
+    // 2 bytes version
+    writeBytes(out, &kMATVersion, 2);
+
+    // 2 bytes endian indicator
+    writeBytes(out, &kEndianMarker, 2);
+}
+
+// =========================================================================
+// Float array (miMATRIX with mxSINGLE_CLASS)
+// =========================================================================
+
+void MatlabExporter::writeFloatArray(std::vector<uint8_t>& out,
+                                      const std::string& name,
+                                      const std::vector<float>& data,
+                                      const std::vector<int32_t>& dimensions) {
+    // Build the matrix content into a temporary buffer
+    std::vector<uint8_t> content;
+
+    // 1. Array flags
+    writeArrayFlags(content, mxSINGLE_CLASS);
+
+    // 2. Dimensions
+    writeDimensions(content, dimensions);
+
+    // 3. Array name
+    writeArrayName(content, name);
+
+    // 4. Real part data (miSINGLE)
+    int32_t dataBytes = static_cast<int32_t>(data.size() * sizeof(float));
+    writeTag(content, miSINGLE, dataBytes);
+    writeBytes(content, data.data(), dataBytes);
+    writePadding(content, dataBytes);
+
+    // Write the miMATRIX tag + content
+    writeTag(out, miMATRIX, static_cast<int32_t>(content.size()));
+    out.insert(out.end(), content.begin(), content.end());
+}
+
+// =========================================================================
+// Struct (miMATRIX with mxSTRUCT_CLASS)
+// =========================================================================
+
+void MatlabExporter::writeStruct(std::vector<uint8_t>& out,
+                                  const std::string& name,
+                                  const std::map<std::string, std::string>& fields) {
+    std::vector<uint8_t> content;
+
+    // 1. Array flags
+    writeArrayFlags(content, mxSTRUCT_CLASS);
+
+    // 2. Dimensions (1x1 struct)
+    std::vector<int32_t> dims = {1, 1};
+    writeDimensions(content, dims);
+
+    // 3. Struct name
+    writeArrayName(content, name);
+
+    // 4. Field name length (max field name length, padded to 8-byte multiple)
+    int32_t maxNameLen = 0;
+    for (const auto& [k, _] : fields) {
+        maxNameLen = std::max(maxNameLen,
+                              static_cast<int32_t>(k.size()));
+    }
+    // MATLAB requires field name length to be at least 32 for compatibility
+    int32_t fieldNameLen = std::max(maxNameLen + 1, static_cast<int32_t>(32));
+    writeSmallElement(content, miINT32, &fieldNameLen, 4);
+
+    // 5. Field names (concatenated, each padded to fieldNameLen)
+    {
+        std::vector<char> nameData(fieldNameLen * fields.size(), '\0');
+        int idx = 0;
+        for (const auto& [k, _] : fields) {
+            std::memcpy(&nameData[idx * fieldNameLen], k.data(),
+                        std::min(static_cast<size_t>(fieldNameLen - 1), k.size()));
+            ++idx;
+        }
+        int32_t nameBytes = static_cast<int32_t>(nameData.size());
+        writeTag(content, miINT8, nameBytes);
+        writeBytes(content, nameData.data(), nameBytes);
+        writePadding(content, nameBytes);
+    }
+
+    // 6. Field values (each as a char array miMATRIX)
+    for (const auto& [_, v] : fields) {
+        std::vector<uint8_t> charArray;
+        writeArrayFlags(charArray, mxCHAR_CLASS);
+
+        std::vector<int32_t> charDims = {1, static_cast<int32_t>(v.size())};
+        writeDimensions(charArray, charDims);
+
+        // Empty name for struct field value
+        writeArrayName(charArray, "");
+
+        // Character data as miUINT8 (UTF-8 / ASCII)
+        int32_t strBytes = static_cast<int32_t>(v.size());
+        writeTag(charArray, miUINT8, strBytes);
+        writeBytes(charArray, v.data(), strBytes);
+        writePadding(charArray, strBytes);
+
+        writeTag(content, miMATRIX, static_cast<int32_t>(charArray.size()));
+        content.insert(content.end(), charArray.begin(), charArray.end());
+    }
+
+    // Write the miMATRIX tag + content
+    writeTag(out, miMATRIX, static_cast<int32_t>(content.size()));
+    out.insert(out.end(), content.begin(), content.end());
+}
+
+// =========================================================================
+// ITK image to column-major conversion
+// =========================================================================
+
+std::vector<float> MatlabExporter::itkToColumnMajor(const FloatImage3D* image) {
+    if (!image) {
+        return {};
+    }
+
+    auto region = image->GetLargestPossibleRegion();
+    auto size = region.GetSize();
+    const int nx = static_cast<int>(size[0]);
+    const int ny = static_cast<int>(size[1]);
+    const int nz = static_cast<int>(size[2]);
+
+    std::vector<float> result(nx * ny * nz);
+
+    // MATLAB column-major: x varies fastest, then y, then z
+    // ITK buffer is stored in row-major (z varies slowest, x fastest for a given row)
+    itk::ImageRegionConstIterator<FloatImage3D> it(image, region);
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        auto idx = it.GetIndex();
+        // Column-major index: x + y*nx + z*nx*ny
+        size_t colIdx = idx[0] + idx[1] * nx + idx[2] * nx * ny;
+        result[colIdx] = it.Get();
+    }
+
+    return result;
+}
+
+std::vector<float> MatlabExporter::extractComponentColumnMajor(
+    const VectorImage3D* image, int component) {
+    if (!image || component < 0 || component >= 3) {
+        return {};
+    }
+
+    auto region = image->GetLargestPossibleRegion();
+    auto size = region.GetSize();
+    const int nx = static_cast<int>(size[0]);
+    const int ny = static_cast<int>(size[1]);
+    const int nz = static_cast<int>(size[2]);
+
+    std::vector<float> result(nx * ny * nz);
+
+    itk::ImageRegionConstIterator<VectorImage3D> it(image, region);
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        auto idx = it.GetIndex();
+        size_t colIdx = idx[0] + idx[1] * nx + idx[2] * nx * ny;
+        result[colIdx] = it.Get()[component];
+    }
+
+    return result;
+}
+
+// =========================================================================
+// High-level velocity field export
+// =========================================================================
+
+std::expected<void, ExportError> MatlabExporter::exportVelocityFields(
+    const std::vector<VectorImage3D::Pointer>& velocityPhases,
+    const std::vector<FloatImage3D::Pointer>& magnitudePhases,
+    const DicomMeta& meta,
+    const ExportConfig& config) {
+
+    if (velocityPhases.empty()) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            "No velocity phases provided"});
+    }
+
+    if (!std::filesystem::exists(config.outputDir)) {
+        return std::unexpected(ExportError{
+            ExportError::Code::FileAccessDenied,
+            std::format("Output directory does not exist: {}",
+                        config.outputDir.string())});
+    }
+
+    // Get dimensions from first phase
+    auto size = velocityPhases[0]->GetLargestPossibleRegion().GetSize();
+    const int nx = static_cast<int>(size[0]);
+    const int ny = static_cast<int>(size[1]);
+    const int nz = static_cast<int>(size[2]);
+    const int nt = static_cast<int>(velocityPhases.size());
+
+    std::vector<int32_t> dims4d = {
+        static_cast<int32_t>(nx),
+        static_cast<int32_t>(ny),
+        static_cast<int32_t>(nz),
+        static_cast<int32_t>(nt)
+    };
+
+    // Build metadata struct fields
+    std::map<std::string, std::string> metaFields;
+    metaFields["SeriesDescription"] = meta.seriesDescription;
+    metaFields["SequenceName"] = meta.sequenceName;
+    metaFields["ImageType"] = meta.imageType;
+    metaFields["PixelSpacingX"] = std::format("{:.6f}", meta.pixelSpacingX);
+    metaFields["PixelSpacingY"] = std::format("{:.6f}", meta.pixelSpacingY);
+    metaFields["SliceThickness"] = std::format("{:.6f}", meta.sliceThickness);
+
+    // Component names and file suffixes
+    struct ComponentInfo {
+        int index;
+        std::string suffix;
+    };
+    std::vector<ComponentInfo> components = {
+        {0, "vel_AP"},
+        {1, "vel_FH"},
+        {2, "vel_RL"}
+    };
+
+    // Export each velocity component
+    for (const auto& comp : components) {
+        // Concatenate all phases for this component into 4D array
+        std::vector<float> data4d;
+        data4d.reserve(nx * ny * nz * nt);
+
+        for (const auto& phase : velocityPhases) {
+            auto phaseData = extractComponentColumnMajor(phase.GetPointer(),
+                                                         comp.index);
+            data4d.insert(data4d.end(), phaseData.begin(), phaseData.end());
+        }
+
+        // Build MAT file
+        std::vector<uint8_t> matFile;
+        std::string desc = std::format("MATLAB 5.0 MAT-file, {}_{}",
+                                        config.prefix, comp.suffix);
+        writeHeader(matFile, desc);
+        writeFloatArray(matFile, "data", data4d, dims4d);
+        writeStruct(matFile, "metadata", metaFields);
+
+        // Write to disk
+        auto path = config.outputDir /
+            std::format("{}_{}.mat", config.prefix, comp.suffix);
+        std::ofstream file(path, std::ios::binary);
+        if (!file.is_open()) {
+            return std::unexpected(ExportError{
+                ExportError::Code::FileAccessDenied,
+                std::format("Cannot create file: {}", path.string())});
+        }
+        file.write(reinterpret_cast<const char*>(matFile.data()),
+                    static_cast<std::streamsize>(matFile.size()));
+    }
+
+    // Export magnitude if requested
+    if (config.exportMagnitude && !magnitudePhases.empty()) {
+        std::vector<float> magData;
+        magData.reserve(nx * ny * nz * nt);
+
+        for (const auto& phase : magnitudePhases) {
+            auto phaseData = itkToColumnMajor(phase.GetPointer());
+            magData.insert(magData.end(), phaseData.begin(), phaseData.end());
+        }
+
+        std::vector<int32_t> magDims = dims4d;
+        if (static_cast<int>(magnitudePhases.size()) != nt) {
+            magDims[3] = static_cast<int32_t>(magnitudePhases.size());
+        }
+
+        std::vector<uint8_t> matFile;
+        writeHeader(matFile,
+            std::format("MATLAB 5.0 MAT-file, {}_M_FFE", config.prefix));
+        writeFloatArray(matFile, "data", magData, magDims);
+        writeStruct(matFile, "metadata", metaFields);
+
+        auto path = config.outputDir /
+            std::format("{}_M_FFE.mat", config.prefix);
+        std::ofstream file(path, std::ios::binary);
+        if (!file.is_open()) {
+            return std::unexpected(ExportError{
+                ExportError::Code::FileAccessDenied,
+                std::format("Cannot create file: {}", path.string())});
+        }
+        file.write(reinterpret_cast<const char*>(matFile.data()),
+                    static_cast<std::streamsize>(matFile.size()));
+    }
+
+    return {};
+}
+
+}  // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1584,3 +1584,21 @@ target_include_directories(ensight_exporter_test PRIVATE
 )
 
 gtest_discover_tests(ensight_exporter_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for MATLAB MAT-file v5 exporter
+add_executable(matlab_exporter_test
+    unit/matlab_exporter_test.cpp
+)
+
+target_link_libraries(matlab_exporter_test PRIVATE
+    export_service
+    ${ITK_LIBRARIES}
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(matlab_exporter_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(matlab_exporter_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/matlab_exporter_test.cpp
+++ b/tests/unit/matlab_exporter_test.cpp
@@ -1,0 +1,402 @@
+#include "services/export/matlab_exporter.hpp"
+
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+
+#include <gtest/gtest.h>
+#include <itkImageRegionIterator.h>
+
+using namespace dicom_viewer::services;
+
+namespace {
+
+/// MAT-file v5 data type tags
+constexpr int32_t miINT8    = 1;
+constexpr int32_t miINT32   = 5;
+constexpr int32_t miUINT32  = 6;
+constexpr int32_t miSINGLE  = 7;
+constexpr int32_t miMATRIX  = 14;
+
+/// Read a little-endian int32 at offset
+int32_t readInt32(const std::vector<uint8_t>& buf, size_t offset) {
+    int32_t v = 0;
+    std::memcpy(&v, &buf[offset], 4);
+    return v;
+}
+
+/// Read a little-endian uint16 at offset
+uint16_t readUint16(const std::vector<uint8_t>& buf, size_t offset) {
+    uint16_t v = 0;
+    std::memcpy(&v, &buf[offset], 2);
+    return v;
+}
+
+/// Read a float at offset
+float readFloat(const std::vector<uint8_t>& buf, size_t offset) {
+    float v = 0;
+    std::memcpy(&v, &buf[offset], 4);
+    return v;
+}
+
+/// Create a 3D float ITK image with given value
+MatlabExporter::FloatImage3D::Pointer createFloatImage(
+    int sx, int sy, int sz, float value = 0.0f) {
+    auto image = MatlabExporter::FloatImage3D::New();
+    MatlabExporter::FloatImage3D::SizeType size = {{
+        static_cast<unsigned long>(sx),
+        static_cast<unsigned long>(sy),
+        static_cast<unsigned long>(sz)
+    }};
+    MatlabExporter::FloatImage3D::IndexType start = {{0, 0, 0}};
+    MatlabExporter::FloatImage3D::RegionType region{start, size};
+    image->SetRegions(region);
+    image->Allocate();
+    image->FillBuffer(value);
+    return image;
+}
+
+/// Create a 3-component vector image
+MatlabExporter::VectorImage3D::Pointer createVectorImage(
+    int sx, int sy, int sz) {
+    auto image = MatlabExporter::VectorImage3D::New();
+    MatlabExporter::VectorImage3D::SizeType size = {{
+        static_cast<unsigned long>(sx),
+        static_cast<unsigned long>(sy),
+        static_cast<unsigned long>(sz)
+    }};
+    MatlabExporter::VectorImage3D::IndexType start = {{0, 0, 0}};
+    MatlabExporter::VectorImage3D::RegionType region{start, size};
+    image->SetRegions(region);
+    image->SetNumberOfComponentsPerPixel(3);
+    image->Allocate();
+
+    // Fill with known pattern: voxel (x,y,z) → [x*10, y*10, z*10]
+    itk::ImageRegionIterator<MatlabExporter::VectorImage3D> it(image, region);
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        auto idx = it.GetIndex();
+        MatlabExporter::VectorImage3D::PixelType pixel(3);
+        pixel[0] = static_cast<float>(idx[0] * 10);
+        pixel[1] = static_cast<float>(idx[1] * 10);
+        pixel[2] = static_cast<float>(idx[2] * 10);
+        it.Set(pixel);
+    }
+    return image;
+}
+
+}  // anonymous namespace
+
+// =============================================================================
+// MAT-file header tests
+// =============================================================================
+
+TEST(MatlabExporterTest, HeaderIs128Bytes) {
+    std::vector<uint8_t> buf;
+    MatlabExporter::writeHeader(buf, "Test MAT file");
+    EXPECT_EQ(buf.size(), 128u);
+}
+
+TEST(MatlabExporterTest, HeaderVersionAndEndian) {
+    std::vector<uint8_t> buf;
+    MatlabExporter::writeHeader(buf, "Test");
+
+    // Version at offset 124
+    uint16_t version = readUint16(buf, 124);
+    EXPECT_EQ(version, 0x0100);
+
+    // Endian marker at offset 126: 'IM' = 0x4D49 in little-endian
+    uint16_t endian = readUint16(buf, 126);
+    EXPECT_EQ(endian, 0x4D49);
+}
+
+TEST(MatlabExporterTest, HeaderDescriptionText) {
+    std::vector<uint8_t> buf;
+    MatlabExporter::writeHeader(buf, "MATLAB 5.0 MAT-file, 4DPC");
+
+    // First 116 bytes are the description text (space-padded)
+    std::string desc(reinterpret_cast<const char*>(buf.data()), 116);
+    // Trim trailing spaces
+    auto end = desc.find_last_not_of(' ');
+    if (end != std::string::npos) desc.resize(end + 1);
+    EXPECT_EQ(desc, "MATLAB 5.0 MAT-file, 4DPC");
+}
+
+// =============================================================================
+// Float array tests
+// =============================================================================
+
+TEST(MatlabExporterTest, FloatArrayTag) {
+    std::vector<uint8_t> buf;
+    std::vector<float> data = {1.0f, 2.0f, 3.0f, 4.0f};
+    std::vector<int32_t> dims = {2, 2};
+
+    MatlabExporter::writeFloatArray(buf, "test", data, dims);
+
+    // First 8 bytes: miMATRIX tag
+    EXPECT_EQ(readInt32(buf, 0), miMATRIX);
+    int32_t totalSize = readInt32(buf, 4);
+    EXPECT_GT(totalSize, 0);
+    EXPECT_EQ(buf.size(), static_cast<size_t>(8 + totalSize));
+}
+
+TEST(MatlabExporterTest, FloatArrayDimensions) {
+    std::vector<uint8_t> buf;
+    std::vector<float> data(24, 0.0f);  // 2x3x4
+    std::vector<int32_t> dims = {2, 3, 4};
+
+    MatlabExporter::writeFloatArray(buf, "arr", data, dims);
+
+    // After header tag (8) + array flags (16) = offset 24 should be dimensions
+    // Dimensions tag: miINT32 (5), 12 bytes
+    EXPECT_EQ(readInt32(buf, 8 + 16), miINT32);
+    int32_t dimBytes = readInt32(buf, 8 + 16 + 4);
+    EXPECT_EQ(dimBytes, 12);  // 3 dimensions * 4 bytes
+
+    // Read dimension values
+    EXPECT_EQ(readInt32(buf, 8 + 16 + 8), 2);      // nx
+    EXPECT_EQ(readInt32(buf, 8 + 16 + 8 + 4), 3);  // ny
+    EXPECT_EQ(readInt32(buf, 8 + 16 + 8 + 8), 4);  // nz
+}
+
+TEST(MatlabExporterTest, FloatArrayDataValues) {
+    std::vector<uint8_t> buf;
+    std::vector<float> data = {1.5f, 2.5f, 3.5f, 4.5f};
+    std::vector<int32_t> dims = {4};
+
+    MatlabExporter::writeFloatArray(buf, "v", data, dims);
+
+    // Find the miSINGLE data tag (type=7)
+    // Must check both tag type AND valid nbytes to avoid matching
+    // mxSINGLE_CLASS (also value 7) inside array flags
+    bool found = false;
+    for (size_t i = 8; i + 24 <= buf.size(); i += 1) {
+        if (readInt32(buf, i) == miSINGLE) {
+            int32_t nbytes = readInt32(buf, i + 4);
+            if (nbytes == 16) {  // 4 floats * 4 bytes
+                EXPECT_FLOAT_EQ(readFloat(buf, i + 8), 1.5f);
+                EXPECT_FLOAT_EQ(readFloat(buf, i + 12), 2.5f);
+                EXPECT_FLOAT_EQ(readFloat(buf, i + 16), 3.5f);
+                EXPECT_FLOAT_EQ(readFloat(buf, i + 20), 4.5f);
+                found = true;
+                break;
+            }
+        }
+    }
+    EXPECT_TRUE(found) << "miSINGLE data element not found";
+}
+
+// =============================================================================
+// Struct tests
+// =============================================================================
+
+TEST(MatlabExporterTest, StructTag) {
+    std::vector<uint8_t> buf;
+    std::map<std::string, std::string> fields;
+    fields["key1"] = "value1";
+
+    MatlabExporter::writeStruct(buf, "meta", fields);
+
+    EXPECT_EQ(readInt32(buf, 0), miMATRIX);
+    int32_t totalSize = readInt32(buf, 4);
+    EXPECT_GT(totalSize, 0);
+}
+
+TEST(MatlabExporterTest, StructMultipleFields) {
+    std::vector<uint8_t> buf;
+    std::map<std::string, std::string> fields;
+    fields["alpha"] = "hello";
+    fields["beta"] = "world";
+
+    MatlabExporter::writeStruct(buf, "s", fields);
+
+    // Should be a valid miMATRIX element
+    EXPECT_EQ(readInt32(buf, 0), miMATRIX);
+    EXPECT_GT(buf.size(), 128u);  // Struct with 2 fields needs meaningful space
+}
+
+// =============================================================================
+// ITK to column-major conversion
+// =============================================================================
+
+TEST(MatlabExporterTest, ItkToColumnMajorOrdering) {
+    auto image = createFloatImage(3, 4, 2, 0.0f);
+
+    // Set specific voxels
+    MatlabExporter::FloatImage3D::IndexType idx;
+    idx[0] = 1; idx[1] = 2; idx[2] = 0;
+    image->SetPixel(idx, 42.0f);
+
+    idx[0] = 0; idx[1] = 0; idx[2] = 1;
+    image->SetPixel(idx, 99.0f);
+
+    auto result = MatlabExporter::itkToColumnMajor(image.GetPointer());
+    EXPECT_EQ(result.size(), 24u);  // 3*4*2
+
+    // Column-major index: x + y*nx + z*nx*ny
+    // (1,2,0) → 1 + 2*3 + 0*3*4 = 7
+    EXPECT_FLOAT_EQ(result[7], 42.0f);
+
+    // (0,0,1) → 0 + 0*3 + 1*3*4 = 12
+    EXPECT_FLOAT_EQ(result[12], 99.0f);
+}
+
+TEST(MatlabExporterTest, ItkToColumnMajorNullReturnsEmpty) {
+    auto result = MatlabExporter::itkToColumnMajor(nullptr);
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(MatlabExporterTest, ExtractComponentColumnMajor) {
+    auto image = createVectorImage(2, 2, 2);
+
+    // Component 0 = x*10
+    auto comp0 = MatlabExporter::extractComponentColumnMajor(
+        image.GetPointer(), 0);
+    EXPECT_EQ(comp0.size(), 8u);
+    // Voxel (1,0,0): comp0 = 10.0, column-major index = 1
+    EXPECT_FLOAT_EQ(comp0[1], 10.0f);
+
+    // Component 1 = y*10
+    auto comp1 = MatlabExporter::extractComponentColumnMajor(
+        image.GetPointer(), 1);
+    // Voxel (0,1,0): comp1 = 10.0, column-major index = 0 + 1*2 = 2
+    EXPECT_FLOAT_EQ(comp1[2], 10.0f);
+
+    // Component 2 = z*10
+    auto comp2 = MatlabExporter::extractComponentColumnMajor(
+        image.GetPointer(), 2);
+    // Voxel (0,0,1): comp2 = 10.0, column-major index = 0 + 0 + 1*2*2 = 4
+    EXPECT_FLOAT_EQ(comp2[4], 10.0f);
+}
+
+TEST(MatlabExporterTest, ExtractComponentInvalidReturnsEmpty) {
+    auto image = createVectorImage(2, 2, 2);
+    EXPECT_TRUE(MatlabExporter::extractComponentColumnMajor(nullptr, 0).empty());
+    EXPECT_TRUE(MatlabExporter::extractComponentColumnMajor(
+        image.GetPointer(), 3).empty());
+    EXPECT_TRUE(MatlabExporter::extractComponentColumnMajor(
+        image.GetPointer(), -1).empty());
+}
+
+// =============================================================================
+// Full velocity export
+// =============================================================================
+
+TEST(MatlabExporterTest, ExportVelocityFieldsCreatesFiles) {
+    auto tmpDir = std::filesystem::temp_directory_path() / "matlab_test";
+    std::filesystem::create_directories(tmpDir);
+
+    auto vel = createVectorImage(4, 4, 4);
+    auto mag = createFloatImage(4, 4, 4, 100.0f);
+
+    std::vector<MatlabExporter::VectorImage3D::Pointer> velPhases = {vel, vel};
+    std::vector<MatlabExporter::FloatImage3D::Pointer> magPhases = {mag, mag};
+
+    MatlabExporter::DicomMeta meta;
+    meta.seriesDescription = "4D Flow";
+    meta.sequenceName = "fl3d1r21";
+    meta.imageType = "ORIGINAL\\PRIMARY\\P\\ND";
+    meta.pixelSpacingX = 1.5;
+    meta.pixelSpacingY = 1.5;
+    meta.sliceThickness = 2.0;
+
+    MatlabExporter::ExportConfig config;
+    config.outputDir = tmpDir;
+    config.prefix = "4DPC";
+    config.exportMagnitude = true;
+
+    auto result = MatlabExporter::exportVelocityFields(
+        velPhases, magPhases, meta, config);
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+
+    // Check files exist
+    EXPECT_TRUE(std::filesystem::exists(tmpDir / "4DPC_vel_AP.mat"));
+    EXPECT_TRUE(std::filesystem::exists(tmpDir / "4DPC_vel_FH.mat"));
+    EXPECT_TRUE(std::filesystem::exists(tmpDir / "4DPC_vel_RL.mat"));
+    EXPECT_TRUE(std::filesystem::exists(tmpDir / "4DPC_M_FFE.mat"));
+
+    // Verify file size is reasonable (header 128 + data + metadata)
+    auto fileSize = std::filesystem::file_size(tmpDir / "4DPC_vel_AP.mat");
+    EXPECT_GT(fileSize, 128u);  // At least header
+    // 4*4*4 * 2 phases * 4 bytes = 512 bytes of float data minimum
+    EXPECT_GT(fileSize, 512u);
+
+    // Cleanup
+    std::filesystem::remove_all(tmpDir);
+}
+
+TEST(MatlabExporterTest, ExportVelocityFieldsValidatesHeader) {
+    auto tmpDir = std::filesystem::temp_directory_path() / "matlab_hdr_test";
+    std::filesystem::create_directories(tmpDir);
+
+    auto vel = createVectorImage(2, 2, 2);
+    std::vector<MatlabExporter::VectorImage3D::Pointer> velPhases = {vel};
+
+    MatlabExporter::DicomMeta meta;
+    MatlabExporter::ExportConfig config;
+    config.outputDir = tmpDir;
+    config.exportMagnitude = false;
+
+    auto result = MatlabExporter::exportVelocityFields(
+        velPhases, {}, meta, config);
+    ASSERT_TRUE(result.has_value());
+
+    // Read back and validate header
+    auto path = tmpDir / "4DPC_vel_AP.mat";
+    std::ifstream file(path, std::ios::binary);
+    std::vector<uint8_t> buf(128);
+    file.read(reinterpret_cast<char*>(buf.data()), 128);
+
+    // Version
+    EXPECT_EQ(readUint16(buf, 124), 0x0100);
+    // Endian
+    EXPECT_EQ(readUint16(buf, 126), 0x4D49);
+
+    std::filesystem::remove_all(tmpDir);
+}
+
+TEST(MatlabExporterTest, ExportEmptyPhasesReturnsError) {
+    std::vector<MatlabExporter::VectorImage3D::Pointer> empty;
+    MatlabExporter::DicomMeta meta;
+    MatlabExporter::ExportConfig config;
+    config.outputDir = "/tmp/claude";
+
+    auto result = MatlabExporter::exportVelocityFields(empty, {}, meta, config);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, ExportError::Code::InvalidData);
+}
+
+TEST(MatlabExporterTest, ExportNonexistentDirReturnsError) {
+    auto vel = createVectorImage(2, 2, 2);
+    std::vector<MatlabExporter::VectorImage3D::Pointer> velPhases = {vel};
+    MatlabExporter::DicomMeta meta;
+    MatlabExporter::ExportConfig config;
+    config.outputDir = "/nonexistent/dir/that/should/not/exist";
+
+    auto result = MatlabExporter::exportVelocityFields(
+        velPhases, {}, meta, config);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, ExportError::Code::FileAccessDenied);
+}
+
+// =============================================================================
+// Complete MAT file binary structure
+// =============================================================================
+
+TEST(MatlabExporterTest, CompleteMATFileStructure) {
+    std::vector<uint8_t> matFile;
+    MatlabExporter::writeHeader(matFile, "Test file");
+
+    std::vector<float> data = {1.0f, 2.0f, 3.0f};
+    std::vector<int32_t> dims = {3, 1};
+    MatlabExporter::writeFloatArray(matFile, "x", data, dims);
+
+    // Total size: 128 (header) + miMATRIX element
+    EXPECT_GT(matFile.size(), 128u);
+
+    // First data element starts at offset 128
+    EXPECT_EQ(readInt32(matFile, 128), miMATRIX);
+
+    // The miMATRIX size + 8 (tag) should reach end of buffer
+    int32_t matrixSize = readInt32(matFile, 132);
+    EXPECT_EQ(matFile.size(), static_cast<size_t>(128 + 8 + matrixSize));
+}


### PR DESCRIPTION
Closes #296

## Summary
- Add MatlabExporter class implementing MAT-file Level 5 binary format writer
- Pure C++ implementation with no external library dependencies (no matio)
- Support for float32 numeric arrays (up to 4D) and struct data elements with string fields
- Column-major (Fortran) ordering conversion from ITK row-major images
- High-level exportVelocityFields() API for 4D PC-MRI velocity data (AP, FH, RL components + magnitude)
- 17 unit tests covering binary format correctness, data integrity, ITK conversion, and error handling

Part of #249

## Test Plan
- [x] All 17 unit tests pass (matlab_exporter_test)
- [x] MAT-file header format validated (128 bytes, version 0x0100, endian marker IM)
- [x] Float array data written in correct column-major order with proper miMATRIX structure
- [x] Struct data elements contain correct field names and char array values
- [x] ITK-to-column-major conversion verified with known index mappings
- [x] VectorImage3D component extraction verified per-component
- [x] End-to-end velocity export creates expected .mat files on disk
- [x] Error handling for empty input and missing output directory