### PR TITLE
feat(segmentation): implement HollowTool and MaskSmoother for 3D label map processing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,8 @@ add_library(segmentation_service STATIC
     src/services/segmentation/mask_boolean_operations.cpp
     src/services/segmentation/snapshot_command.cpp
     src/services/segmentation/phase_tracker.cpp
+    src/services/segmentation/hollow_tool.cpp
+    src/services/segmentation/mask_smoother.cpp
 )
 
 target_link_libraries(segmentation_service PUBLIC

--- a/include/services/segmentation/hollow_tool.hpp
+++ b/include/services/segmentation/hollow_tool.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "threshold_segmenter.hpp"
+
+#include <expected>
+
+#include <itkImage.h>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Shell extraction direction
+ */
+enum class HollowDirection {
+    Inside,   ///< Shell grows inward from original surface
+    Outside,  ///< Shell grows outward from original surface
+    Both      ///< Shell extends in both directions
+};
+
+/**
+ * @brief Creates hollow shell masks from solid segmentation masks
+ *
+ * Extracts the boundary region of a binary mask at a configurable
+ * thickness. Useful for visualizing vessel walls and other thin
+ * structures without the filled interior.
+ *
+ * Shell thickness is specified in millimeters and converted to voxels
+ * using the image spacing. For anisotropic spacing, the minimum
+ * spacing dimension is used (conservative approach).
+ *
+ * @trace SRS-FR-025
+ */
+class HollowTool {
+public:
+    using BinaryMaskType = itk::Image<uint8_t, 3>;
+
+    /**
+     * @brief Configuration for hollow operation
+     */
+    struct Config {
+        double thicknessMm = 1.0;    ///< Shell thickness in millimeters
+        HollowDirection direction = HollowDirection::Inside;
+        uint8_t foregroundValue = 1;
+    };
+
+    /**
+     * @brief Create a hollow shell from a solid mask
+     *
+     * @param input Solid binary mask
+     * @param config Hollow operation configuration
+     * @return Shell mask or error
+     */
+    [[nodiscard]] static std::expected<BinaryMaskType::Pointer, SegmentationError>
+    makeHollow(BinaryMaskType::Pointer input, const Config& config);
+
+    /**
+     * @brief Create a hollow shell with default configuration (inside, 1mm)
+     *
+     * @param input Solid binary mask
+     * @param thicknessMm Shell thickness in millimeters
+     * @return Shell mask or error
+     */
+    [[nodiscard]] static std::expected<BinaryMaskType::Pointer, SegmentationError>
+    makeHollow(BinaryMaskType::Pointer input, double thicknessMm = 1.0);
+
+    /**
+     * @brief Convert thickness in mm to voxel radius
+     *
+     * Uses the minimum spacing dimension for conservative estimation.
+     *
+     * @param image Image to get spacing from
+     * @param thicknessMm Desired thickness in millimeters
+     * @return Radius in voxels (minimum 1)
+     */
+    [[nodiscard]] static int mmToVoxelRadius(
+        const BinaryMaskType* image, double thicknessMm);
+};
+
+}  // namespace dicom_viewer::services

--- a/include/services/segmentation/mask_smoother.hpp
+++ b/include/services/segmentation/mask_smoother.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "threshold_segmenter.hpp"
+
+#include <expected>
+
+#include <itkImage.h>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Volume-preserving Gaussian boundary smoother for binary masks
+ *
+ * Smooths the boundary of a binary segmentation mask using Gaussian
+ * blurring followed by adaptive re-thresholding. The key improvement
+ * over naive Gaussian blur is binary search for the threshold that
+ * preserves the original mask volume within a configurable tolerance.
+ *
+ * Algorithm:
+ * 1. Convert binary mask to float [0, 1]
+ * 2. Apply Gaussian smoothing with configurable sigma
+ * 3. Binary search for threshold that preserves volume (±tolerance)
+ * 4. Threshold smoothed image at optimal level
+ *
+ * @trace SRS-FR-025
+ */
+class MaskSmoother {
+public:
+    using BinaryMaskType = itk::Image<uint8_t, 3>;
+    using FloatImageType = itk::Image<float, 3>;
+
+    /**
+     * @brief Configuration for mask smoothing
+     */
+    struct Config {
+        double sigmaMm = 1.0;           ///< Gaussian sigma in millimeters
+        double volumeTolerance = 0.01;  ///< Acceptable volume deviation (1%)
+        int maxBinarySearchIter = 50;   ///< Max iterations for threshold search
+        uint8_t foregroundValue = 1;
+    };
+
+    /**
+     * @brief Smooth mask boundaries while preserving volume
+     *
+     * @param input Binary mask to smooth
+     * @param config Smoothing configuration
+     * @return Smoothed mask or error
+     */
+    [[nodiscard]] static std::expected<BinaryMaskType::Pointer, SegmentationError>
+    smooth(BinaryMaskType::Pointer input, const Config& config);
+
+    /**
+     * @brief Smooth mask with default configuration (1mm sigma)
+     *
+     * @param input Binary mask to smooth
+     * @param sigmaMm Gaussian sigma in millimeters
+     * @return Smoothed mask or error
+     */
+    [[nodiscard]] static std::expected<BinaryMaskType::Pointer, SegmentationError>
+    smooth(BinaryMaskType::Pointer input, double sigmaMm = 1.0);
+
+    /**
+     * @brief Count foreground voxels in a binary mask
+     *
+     * @param mask Binary mask
+     * @param foregroundValue Value to count
+     * @return Number of foreground voxels
+     */
+    [[nodiscard]] static size_t countForeground(
+        const BinaryMaskType* mask, uint8_t foregroundValue = 1);
+
+    /**
+     * @brief Count voxels above threshold in a float image
+     *
+     * @param image Float image (values in [0, 1])
+     * @param threshold Threshold value
+     * @return Number of voxels above threshold
+     */
+    [[nodiscard]] static size_t countAboveThreshold(
+        const FloatImageType* image, float threshold);
+};
+
+}  // namespace dicom_viewer::services

--- a/src/services/segmentation/hollow_tool.cpp
+++ b/src/services/segmentation/hollow_tool.cpp
@@ -1,0 +1,190 @@
+#include "services/segmentation/hollow_tool.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include <itkBinaryBallStructuringElement.h>
+#include <itkBinaryDilateImageFilter.h>
+#include <itkBinaryErodeImageFilter.h>
+#include <itkImageRegionConstIterator.h>
+#include <itkImageRegionIterator.h>
+#include <itkSubtractImageFilter.h>
+
+namespace dicom_viewer::services {
+
+int HollowTool::mmToVoxelRadius(const BinaryMaskType* image,
+                                 double thicknessMm) {
+    if (!image || thicknessMm <= 0.0) {
+        return 1;
+    }
+
+    auto spacing = image->GetSpacing();
+    double minSpacing = std::min({spacing[0], spacing[1], spacing[2]});
+    if (minSpacing <= 0.0) {
+        return 1;
+    }
+
+    int radius = static_cast<int>(std::round(thicknessMm / minSpacing));
+    return std::max(radius, 1);
+}
+
+namespace {
+
+using BinaryMaskType = HollowTool::BinaryMaskType;
+using StructuringElementType =
+    itk::BinaryBallStructuringElement<uint8_t, 3>;
+
+/// Create a ball structuring element with the given radius
+StructuringElementType createBall(int radius) {
+    StructuringElementType element;
+    element.SetRadius(radius);
+    element.CreateStructuringElement();
+    return element;
+}
+
+/// Erode a binary mask
+BinaryMaskType::Pointer erodeMask(BinaryMaskType::Pointer input,
+                                   int radius, uint8_t fg) {
+    auto element = createBall(radius);
+
+    using FilterType =
+        itk::BinaryErodeImageFilter<BinaryMaskType, BinaryMaskType,
+                                     StructuringElementType>;
+    auto filter = FilterType::New();
+    filter->SetInput(input);
+    filter->SetKernel(element);
+    filter->SetForegroundValue(fg);
+    filter->SetBackgroundValue(0);
+    filter->Update();
+    return filter->GetOutput();
+}
+
+/// Dilate a binary mask
+BinaryMaskType::Pointer dilateMask(BinaryMaskType::Pointer input,
+                                    int radius, uint8_t fg) {
+    auto element = createBall(radius);
+
+    using FilterType =
+        itk::BinaryDilateImageFilter<BinaryMaskType, BinaryMaskType,
+                                      StructuringElementType>;
+    auto filter = FilterType::New();
+    filter->SetInput(input);
+    filter->SetKernel(element);
+    filter->SetForegroundValue(fg);
+    filter->SetBackgroundValue(0);
+    filter->Update();
+    return filter->GetOutput();
+}
+
+/// Subtract B from A: result = A AND NOT B
+BinaryMaskType::Pointer subtractMask(BinaryMaskType::Pointer a,
+                                      BinaryMaskType::Pointer b,
+                                      uint8_t fg) {
+    auto result = BinaryMaskType::New();
+    result->SetRegions(a->GetLargestPossibleRegion());
+    result->SetSpacing(a->GetSpacing());
+    result->SetOrigin(a->GetOrigin());
+    result->SetDirection(a->GetDirection());
+    result->Allocate();
+    result->FillBuffer(0);
+
+    itk::ImageRegionConstIterator<BinaryMaskType> itA(
+        a, a->GetLargestPossibleRegion());
+    itk::ImageRegionConstIterator<BinaryMaskType> itB(
+        b, b->GetLargestPossibleRegion());
+    itk::ImageRegionIterator<BinaryMaskType> itOut(
+        result, result->GetLargestPossibleRegion());
+
+    for (itA.GoToBegin(), itB.GoToBegin(), itOut.GoToBegin();
+         !itA.IsAtEnd(); ++itA, ++itB, ++itOut) {
+        if (itA.Get() == fg && itB.Get() != fg) {
+            itOut.Set(fg);
+        }
+    }
+
+    return result;
+}
+
+/// OR two masks: result = A OR B
+BinaryMaskType::Pointer orMask(BinaryMaskType::Pointer a,
+                                BinaryMaskType::Pointer b,
+                                uint8_t fg) {
+    auto result = BinaryMaskType::New();
+    result->SetRegions(a->GetLargestPossibleRegion());
+    result->SetSpacing(a->GetSpacing());
+    result->SetOrigin(a->GetOrigin());
+    result->SetDirection(a->GetDirection());
+    result->Allocate();
+    result->FillBuffer(0);
+
+    itk::ImageRegionConstIterator<BinaryMaskType> itA(
+        a, a->GetLargestPossibleRegion());
+    itk::ImageRegionConstIterator<BinaryMaskType> itB(
+        b, b->GetLargestPossibleRegion());
+    itk::ImageRegionIterator<BinaryMaskType> itOut(
+        result, result->GetLargestPossibleRegion());
+
+    for (itA.GoToBegin(), itB.GoToBegin(), itOut.GoToBegin();
+         !itA.IsAtEnd(); ++itA, ++itB, ++itOut) {
+        if (itA.Get() == fg || itB.Get() == fg) {
+            itOut.Set(fg);
+        }
+    }
+
+    return result;
+}
+
+}  // anonymous namespace
+
+std::expected<BinaryMaskType::Pointer, SegmentationError>
+HollowTool::makeHollow(BinaryMaskType::Pointer input, const Config& config) {
+    if (!input) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Input mask is null"});
+    }
+
+    if (config.thicknessMm <= 0.0) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidParameters,
+            "Shell thickness must be positive"});
+    }
+
+    int radius = mmToVoxelRadius(input.GetPointer(), config.thicknessMm);
+    uint8_t fg = config.foregroundValue;
+
+    switch (config.direction) {
+        case HollowDirection::Inside: {
+            // Shell = original - eroded
+            auto eroded = erodeMask(input, radius, fg);
+            return subtractMask(input, eroded, fg);
+        }
+
+        case HollowDirection::Outside: {
+            // Shell = dilated - original
+            auto dilated = dilateMask(input, radius, fg);
+            return subtractMask(dilated, input, fg);
+        }
+
+        case HollowDirection::Both: {
+            // Shell = (dilated - eroded) where overlap with original boundary
+            int halfRadius = std::max(radius / 2, 1);
+            auto eroded = erodeMask(input, halfRadius, fg);
+            auto dilated = dilateMask(input, halfRadius, fg);
+            return subtractMask(dilated, eroded, fg);
+        }
+    }
+
+    return std::unexpected(SegmentationError{
+        SegmentationError::Code::InternalError,
+        "Unknown hollow direction"});
+}
+
+std::expected<BinaryMaskType::Pointer, SegmentationError>
+HollowTool::makeHollow(BinaryMaskType::Pointer input, double thicknessMm) {
+    Config config;
+    config.thicknessMm = thicknessMm;
+    return makeHollow(std::move(input), config);
+}
+
+}  // namespace dicom_viewer::services

--- a/src/services/segmentation/mask_smoother.cpp
+++ b/src/services/segmentation/mask_smoother.cpp
@@ -1,0 +1,157 @@
+#include "services/segmentation/mask_smoother.hpp"
+
+#include <cmath>
+
+#include <itkBinaryThresholdImageFilter.h>
+#include <itkCastImageFilter.h>
+#include <itkDiscreteGaussianImageFilter.h>
+#include <itkImageRegionConstIterator.h>
+
+namespace dicom_viewer::services {
+
+size_t MaskSmoother::countForeground(const BinaryMaskType* mask,
+                                      uint8_t foregroundValue) {
+    if (!mask) {
+        return 0;
+    }
+
+    size_t count = 0;
+    itk::ImageRegionConstIterator<BinaryMaskType> it(
+        mask, mask->GetLargestPossibleRegion());
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        if (it.Get() == foregroundValue) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+size_t MaskSmoother::countAboveThreshold(const FloatImageType* image,
+                                          float threshold) {
+    if (!image) {
+        return 0;
+    }
+
+    size_t count = 0;
+    itk::ImageRegionConstIterator<FloatImageType> it(
+        image, image->GetLargestPossibleRegion());
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        if (it.Get() >= threshold) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+std::expected<MaskSmoother::BinaryMaskType::Pointer, SegmentationError>
+MaskSmoother::smooth(BinaryMaskType::Pointer input, const Config& config) {
+    if (!input) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Input mask is null"});
+    }
+
+    if (config.sigmaMm <= 0.0) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidParameters,
+            "Sigma must be positive"});
+    }
+
+    // Count original foreground volume
+    size_t originalVolume = countForeground(input.GetPointer(),
+                                             config.foregroundValue);
+    if (originalVolume == 0) {
+        // Nothing to smooth — return copy of empty mask
+        using DuplicatorType =
+            itk::CastImageFilter<BinaryMaskType, BinaryMaskType>;
+        auto dup = DuplicatorType::New();
+        dup->SetInput(input);
+        dup->Update();
+        return dup->GetOutput();
+    }
+
+    // Step 1: Cast uint8 mask to float [0, 1]
+    using CastToFloatType =
+        itk::CastImageFilter<BinaryMaskType, FloatImageType>;
+    auto castToFloat = CastToFloatType::New();
+    castToFloat->SetInput(input);
+    castToFloat->Update();
+
+    // Normalize: foreground value → 1.0, background → 0.0
+    auto floatImage = castToFloat->GetOutput();
+    if (config.foregroundValue != 1) {
+        float scale = 1.0f / static_cast<float>(config.foregroundValue);
+        itk::ImageRegionIterator<FloatImageType> it(
+            floatImage, floatImage->GetLargestPossibleRegion());
+        for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+            it.Set(it.Get() * scale);
+        }
+    }
+
+    // Step 2: Apply Gaussian smoothing
+    using GaussianFilterType =
+        itk::DiscreteGaussianImageFilter<FloatImageType, FloatImageType>;
+    auto gaussian = GaussianFilterType::New();
+    gaussian->SetInput(floatImage);
+    gaussian->SetVariance(config.sigmaMm * config.sigmaMm);
+    gaussian->SetUseImageSpacingOn();
+    gaussian->Update();
+    auto smoothed = gaussian->GetOutput();
+
+    // Step 3: Binary search for threshold that preserves volume
+    float lo = 0.0f;
+    float hi = 1.0f;
+    float bestThreshold = 0.5f;
+    size_t bestDiff = originalVolume;
+
+    for (int i = 0; i < config.maxBinarySearchIter; ++i) {
+        float mid = (lo + hi) / 2.0f;
+        size_t midVolume = countAboveThreshold(smoothed, mid);
+
+        size_t diff = (midVolume > originalVolume)
+                          ? (midVolume - originalVolume)
+                          : (originalVolume - midVolume);
+
+        if (diff < bestDiff) {
+            bestDiff = diff;
+            bestThreshold = mid;
+        }
+
+        // Check tolerance
+        double ratio = static_cast<double>(diff) /
+                       static_cast<double>(originalVolume);
+        if (ratio <= config.volumeTolerance) {
+            break;
+        }
+
+        if (midVolume > originalVolume) {
+            // Too many voxels → raise threshold
+            lo = mid;
+        } else {
+            // Too few voxels → lower threshold
+            hi = mid;
+        }
+    }
+
+    // Step 4: Threshold at optimal level
+    using ThresholdFilterType =
+        itk::BinaryThresholdImageFilter<FloatImageType, BinaryMaskType>;
+    auto threshold = ThresholdFilterType::New();
+    threshold->SetInput(smoothed);
+    threshold->SetLowerThreshold(bestThreshold);
+    threshold->SetUpperThreshold(1.0f);
+    threshold->SetInsideValue(config.foregroundValue);
+    threshold->SetOutsideValue(0);
+    threshold->Update();
+
+    return threshold->GetOutput();
+}
+
+std::expected<MaskSmoother::BinaryMaskType::Pointer, SegmentationError>
+MaskSmoother::smooth(BinaryMaskType::Pointer input, double sigmaMm) {
+    Config config;
+    config.sigmaMm = sigmaMm;
+    return smooth(std::move(input), config);
+}
+
+}  // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1567,6 +1567,24 @@ target_include_directories(phase_tracker_test PRIVATE
 
 gtest_discover_tests(phase_tracker_test DISCOVERY_TIMEOUT 120)
 
+# Unit tests for HollowTool and MaskSmoother
+add_executable(hollow_smoother_test
+    unit/hollow_smoother_test.cpp
+)
+
+target_link_libraries(hollow_smoother_test PRIVATE
+    segmentation_service
+    ${ITK_LIBRARIES}
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(hollow_smoother_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(hollow_smoother_test DISCOVERY_TIMEOUT 120)
+
 # Unit tests for Ensight Gold format exporter
 add_executable(ensight_exporter_test
     unit/ensight_exporter_test.cpp

--- a/tests/unit/hollow_smoother_test.cpp
+++ b/tests/unit/hollow_smoother_test.cpp
@@ -1,0 +1,351 @@
+#include "services/segmentation/hollow_tool.hpp"
+#include "services/segmentation/mask_smoother.hpp"
+
+#include <cmath>
+
+#include <gtest/gtest.h>
+#include <itkImageRegionIterator.h>
+
+using namespace dicom_viewer::services;
+using BinaryMaskType = HollowTool::BinaryMaskType;
+
+namespace {
+
+/// Create a binary mask of given size with all zeros
+BinaryMaskType::Pointer createMask(int sx, int sy, int sz,
+                                    double spacingMm = 1.0) {
+    auto image = BinaryMaskType::New();
+    BinaryMaskType::SizeType size = {{
+        static_cast<unsigned long>(sx),
+        static_cast<unsigned long>(sy),
+        static_cast<unsigned long>(sz)
+    }};
+    BinaryMaskType::IndexType start = {{0, 0, 0}};
+    BinaryMaskType::RegionType region{start, size};
+    image->SetRegions(region);
+
+    BinaryMaskType::SpacingType spacing;
+    spacing.Fill(spacingMm);
+    image->SetSpacing(spacing);
+
+    BinaryMaskType::PointType origin;
+    origin.Fill(0.0);
+    image->SetOrigin(origin);
+
+    image->Allocate();
+    image->FillBuffer(0);
+    return image;
+}
+
+/// Draw a filled sphere in a binary mask
+void drawSphere(BinaryMaskType::Pointer image,
+                double cx, double cy, double cz,
+                double radius, uint8_t label = 1) {
+    auto region = image->GetLargestPossibleRegion();
+    itk::ImageRegionIterator<BinaryMaskType> it(image, region);
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        auto idx = it.GetIndex();
+        double dx = idx[0] - cx;
+        double dy = idx[1] - cy;
+        double dz = idx[2] - cz;
+        if (dx * dx + dy * dy + dz * dz <= radius * radius) {
+            it.Set(label);
+        }
+    }
+}
+
+/// Draw a filled cube in a binary mask
+void drawCube(BinaryMaskType::Pointer image,
+              int x0, int y0, int z0,
+              int x1, int y1, int z1, uint8_t label = 1) {
+    auto region = image->GetLargestPossibleRegion();
+    itk::ImageRegionIterator<BinaryMaskType> it(image, region);
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        auto idx = it.GetIndex();
+        if (idx[0] >= x0 && idx[0] <= x1 &&
+            idx[1] >= y0 && idx[1] <= y1 &&
+            idx[2] >= z0 && idx[2] <= z1) {
+            it.Set(label);
+        }
+    }
+}
+
+/// Count foreground voxels
+size_t countVoxels(BinaryMaskType::Pointer image, uint8_t fg = 1) {
+    return MaskSmoother::countForeground(image.GetPointer(), fg);
+}
+
+}  // anonymous namespace
+
+// =============================================================================
+// HollowTool tests
+// =============================================================================
+
+TEST(HollowToolTest, NullInputReturnsError) {
+    auto result = HollowTool::makeHollow(nullptr, 1.0);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+TEST(HollowToolTest, ZeroThicknessReturnsError) {
+    auto mask = createMask(10, 10, 10);
+    auto result = HollowTool::makeHollow(mask, 0.0);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidParameters);
+}
+
+TEST(HollowToolTest, NegativeThicknessReturnsError) {
+    auto mask = createMask(10, 10, 10);
+    auto result = HollowTool::makeHollow(mask, -1.0);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidParameters);
+}
+
+TEST(HollowToolTest, InsideHollowReducesVolume) {
+    auto mask = createMask(30, 30, 30);
+    drawSphere(mask, 15.0, 15.0, 15.0, 10.0);
+
+    size_t originalVolume = countVoxels(mask);
+    ASSERT_GT(originalVolume, 100u);
+
+    HollowTool::Config config;
+    config.thicknessMm = 2.0;
+    config.direction = HollowDirection::Inside;
+
+    auto result = HollowTool::makeHollow(mask, config);
+    ASSERT_TRUE(result.has_value());
+
+    size_t shellVolume = countVoxels(*result);
+    // Shell should be smaller than original (it's a subset)
+    EXPECT_LT(shellVolume, originalVolume);
+    // Shell should not be empty
+    EXPECT_GT(shellVolume, 0u);
+}
+
+TEST(HollowToolTest, OutsideHollowExcludesOriginalInterior) {
+    auto mask = createMask(30, 30, 30);
+    drawSphere(mask, 15.0, 15.0, 15.0, 8.0);
+
+    HollowTool::Config config;
+    config.thicknessMm = 2.0;
+    config.direction = HollowDirection::Outside;
+
+    auto result = HollowTool::makeHollow(mask, config);
+    ASSERT_TRUE(result.has_value());
+
+    auto shell = *result;
+    size_t shellVolume = countVoxels(shell);
+    EXPECT_GT(shellVolume, 0u);
+
+    // Center of original sphere should NOT be in the outside shell
+    BinaryMaskType::IndexType center = {{15, 15, 15}};
+    EXPECT_EQ(shell->GetPixel(center), 0);
+}
+
+TEST(HollowToolTest, BothDirectionShell) {
+    auto mask = createMask(30, 30, 30);
+    drawSphere(mask, 15.0, 15.0, 15.0, 10.0);
+
+    HollowTool::Config config;
+    config.thicknessMm = 2.0;
+    config.direction = HollowDirection::Both;
+
+    auto result = HollowTool::makeHollow(mask, config);
+    ASSERT_TRUE(result.has_value());
+
+    size_t shellVolume = countVoxels(*result);
+    EXPECT_GT(shellVolume, 0u);
+
+    // Center should be empty (deep interior)
+    BinaryMaskType::IndexType center = {{15, 15, 15}};
+    EXPECT_EQ((*result)->GetPixel(center), 0);
+}
+
+TEST(HollowToolTest, InsideShellIsSubsetOfOriginal) {
+    auto mask = createMask(30, 30, 30);
+    drawSphere(mask, 15.0, 15.0, 15.0, 10.0);
+
+    HollowTool::Config config;
+    config.thicknessMm = 2.0;
+    config.direction = HollowDirection::Inside;
+
+    auto result = HollowTool::makeHollow(mask, config);
+    ASSERT_TRUE(result.has_value());
+
+    // Every shell voxel should also be in the original mask
+    auto shell = *result;
+    auto region = shell->GetLargestPossibleRegion();
+    itk::ImageRegionConstIterator<BinaryMaskType> itS(shell, region);
+    itk::ImageRegionConstIterator<BinaryMaskType> itM(mask, region);
+    for (itS.GoToBegin(), itM.GoToBegin(); !itS.IsAtEnd(); ++itS, ++itM) {
+        if (itS.Get() == 1) {
+            EXPECT_EQ(itM.Get(), 1);
+        }
+    }
+}
+
+TEST(HollowToolTest, EmptyMaskReturnsEmptyShell) {
+    auto mask = createMask(10, 10, 10);
+    // No foreground voxels
+
+    auto result = HollowTool::makeHollow(mask, 1.0);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(countVoxels(*result), 0u);
+}
+
+TEST(HollowToolTest, MmToVoxelRadiusWithDefaultSpacing) {
+    auto mask = createMask(10, 10, 10, 1.0);  // 1mm spacing
+    EXPECT_EQ(HollowTool::mmToVoxelRadius(mask.GetPointer(), 2.0), 2);
+    EXPECT_EQ(HollowTool::mmToVoxelRadius(mask.GetPointer(), 0.3), 1);
+}
+
+TEST(HollowToolTest, MmToVoxelRadiusWithFineSpacing) {
+    auto mask = createMask(10, 10, 10, 0.5);  // 0.5mm spacing
+    // 2mm / 0.5mm = 4 voxels
+    EXPECT_EQ(HollowTool::mmToVoxelRadius(mask.GetPointer(), 2.0), 4);
+}
+
+TEST(HollowToolTest, MmToVoxelRadiusNullReturnsOne) {
+    EXPECT_EQ(HollowTool::mmToVoxelRadius(nullptr, 2.0), 1);
+}
+
+TEST(HollowToolTest, CubeInsideHollowHasNoInterior) {
+    auto mask = createMask(20, 20, 20);
+    drawCube(mask, 5, 5, 5, 14, 14, 14);
+
+    HollowTool::Config config;
+    config.thicknessMm = 2.0;
+    config.direction = HollowDirection::Inside;
+
+    auto result = HollowTool::makeHollow(mask, config);
+    ASSERT_TRUE(result.has_value());
+
+    // Deep interior should be empty
+    BinaryMaskType::IndexType interior = {{10, 10, 10}};
+    EXPECT_EQ((*result)->GetPixel(interior), 0);
+
+    // Surface should be filled
+    BinaryMaskType::IndexType surface = {{5, 10, 10}};
+    EXPECT_EQ((*result)->GetPixel(surface), 1);
+}
+
+// =============================================================================
+// MaskSmoother tests
+// =============================================================================
+
+TEST(MaskSmootherTest, NullInputReturnsError) {
+    auto result = MaskSmoother::smooth(nullptr, 1.0);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+TEST(MaskSmootherTest, ZeroSigmaReturnsError) {
+    auto mask = createMask(10, 10, 10);
+    auto result = MaskSmoother::smooth(mask, 0.0);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidParameters);
+}
+
+TEST(MaskSmootherTest, NegativeSigmaReturnsError) {
+    auto mask = createMask(10, 10, 10);
+    auto result = MaskSmoother::smooth(mask, -1.0);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidParameters);
+}
+
+TEST(MaskSmootherTest, EmptyMaskReturnsEmpty) {
+    auto mask = createMask(10, 10, 10);
+    auto result = MaskSmoother::smooth(mask, 1.0);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(countVoxels(*result), 0u);
+}
+
+TEST(MaskSmootherTest, VolumePreservation) {
+    auto mask = createMask(30, 30, 30);
+    drawSphere(mask, 15.0, 15.0, 15.0, 8.0);
+
+    size_t originalVolume = countVoxels(mask);
+    ASSERT_GT(originalVolume, 100u);
+
+    MaskSmoother::Config config;
+    config.sigmaMm = 1.0;
+    config.volumeTolerance = 0.02;  // 2% tolerance for test
+
+    auto result = MaskSmoother::smooth(mask, config);
+    ASSERT_TRUE(result.has_value());
+
+    size_t smoothedVolume = countVoxels(*result);
+    double ratio = std::abs(static_cast<double>(smoothedVolume) -
+                            static_cast<double>(originalVolume)) /
+                   static_cast<double>(originalVolume);
+
+    // Volume should be within tolerance
+    EXPECT_LE(ratio, config.volumeTolerance)
+        << "Original: " << originalVolume
+        << " Smoothed: " << smoothedVolume
+        << " Ratio: " << ratio;
+}
+
+TEST(MaskSmootherTest, SmoothedMaskIsNotIdentical) {
+    auto mask = createMask(30, 30, 30);
+    // Create a cube with sharp corners
+    drawCube(mask, 10, 10, 10, 19, 19, 19);
+
+    auto result = MaskSmoother::smooth(mask, 1.5);
+    ASSERT_TRUE(result.has_value());
+
+    // The smoothed mask should differ from original (corners smoothed)
+    auto smoothed = *result;
+    int diffCount = 0;
+    auto region = mask->GetLargestPossibleRegion();
+    itk::ImageRegionConstIterator<BinaryMaskType> itO(mask, region);
+    itk::ImageRegionConstIterator<BinaryMaskType> itS(smoothed, region);
+    for (itO.GoToBegin(), itS.GoToBegin(); !itO.IsAtEnd(); ++itO, ++itS) {
+        if (itO.Get() != itS.Get()) {
+            ++diffCount;
+        }
+    }
+    EXPECT_GT(diffCount, 0)
+        << "Smoothed mask should differ from original at corners";
+}
+
+TEST(MaskSmootherTest, LargeSigmaPreservesVolume) {
+    auto mask = createMask(40, 40, 40);
+    drawSphere(mask, 20.0, 20.0, 20.0, 10.0);
+
+    size_t originalVolume = countVoxels(mask);
+
+    MaskSmoother::Config config;
+    config.sigmaMm = 3.0;
+    config.volumeTolerance = 0.02;
+
+    auto result = MaskSmoother::smooth(mask, config);
+    ASSERT_TRUE(result.has_value());
+
+    size_t smoothedVolume = countVoxels(*result);
+    double ratio = std::abs(static_cast<double>(smoothedVolume) -
+                            static_cast<double>(originalVolume)) /
+                   static_cast<double>(originalVolume);
+
+    EXPECT_LE(ratio, config.volumeTolerance)
+        << "Original: " << originalVolume
+        << " Smoothed: " << smoothedVolume;
+}
+
+TEST(MaskSmootherTest, CountForegroundWorks) {
+    auto mask = createMask(10, 10, 10);
+    EXPECT_EQ(MaskSmoother::countForeground(mask.GetPointer()), 0u);
+
+    drawSphere(mask, 5.0, 5.0, 5.0, 3.0);
+    size_t count = MaskSmoother::countForeground(mask.GetPointer());
+    EXPECT_GT(count, 0u);
+    EXPECT_LT(count, 1000u);
+}
+
+TEST(MaskSmootherTest, CountForegroundNullReturnsZero) {
+    EXPECT_EQ(MaskSmoother::countForeground(nullptr), 0u);
+}
+
+TEST(MaskSmootherTest, CountAboveThresholdNullReturnsZero) {
+    EXPECT_EQ(MaskSmoother::countAboveThreshold(nullptr, 0.5f), 0u);
+}


### PR DESCRIPTION
Closes #298

## Summary
- Add HollowTool class for shell extraction from solid segmentation masks (Inside/Outside/Both modes)
- Add MaskSmoother class for volume-preserving Gaussian boundary smoothing
- Thickness specified in mm with automatic voxel conversion via image spacing
- MaskSmoother uses binary search to find threshold preserving original volume within 1% tolerance
- 22 unit tests covering all modes, edge cases, and error handling

Part of #255

## Test Plan
- [x] All 22 unit tests pass (hollow_smoother_test)
- [x] HollowTool Inside mode produces shell subset of original
- [x] HollowTool Outside mode excludes original interior
- [x] HollowTool Both mode creates symmetric shell
- [x] HollowTool handles empty masks and invalid parameters
- [x] MaskSmoother preserves volume within 2% tolerance
- [x] MaskSmoother produces different output (smoother boundaries)
- [x] MaskSmoother handles large sigma while preserving volume
- [x] Both tools handle null inputs with appropriate errors