### PR TITLE
feat(segmentation): implement CenterlineTracer with Dijkstra path finding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,6 +424,7 @@ add_library(segmentation_service STATIC
     src/services/segmentation/phase_tracker.cpp
     src/services/segmentation/hollow_tool.cpp
     src/services/segmentation/mask_smoother.cpp
+    src/services/segmentation/centerline_tracer.cpp
 )
 
 target_link_libraries(segmentation_service PUBLIC

--- a/include/services/segmentation/centerline_tracer.hpp
+++ b/include/services/segmentation/centerline_tracer.hpp
@@ -1,0 +1,141 @@
+#pragma once
+
+#include "threshold_segmenter.hpp"
+
+#include <array>
+#include <expected>
+#include <vector>
+
+#include <itkImage.h>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief 3D point in physical (world) coordinates
+ */
+using Point3D = std::array<double, 3>;
+
+/**
+ * @brief Vessel centerline tracing using Dijkstra path finding
+ *
+ * Computes the optimal path between two user-specified points through
+ * a 3D image volume, following high-intensity (bright-blood) or
+ * low-intensity (dark-blood) vessel structures.
+ *
+ * Algorithm:
+ * 1. Convert intensity image to cost map
+ * 2. Dijkstra shortest path on 3D voxel grid (26-connectivity)
+ * 3. Catmull-Rom spline smoothing to remove staircase artifacts
+ * 4. Local radius estimation via radial gradient sampling
+ * 5. Tubular mask generation along the smoothed centerline
+ *
+ * @trace SRS-FR-025
+ */
+class CenterlineTracer {
+public:
+    using FloatImage3D = itk::Image<float, 3>;
+    using BinaryMaskType = itk::Image<uint8_t, 3>;
+
+    /**
+     * @brief Configuration for centerline tracing
+     */
+    struct TraceConfig {
+        double initialRadiusMm = 5.0;  ///< Initial radius estimate for radius search
+        bool brightVessels = true;      ///< True for bright-blood MRA, false for dark-blood
+        double costExponent = 1.0;      ///< Higher = stronger preference for vessel interior
+    };
+
+    /**
+     * @brief Result of centerline tracing
+     */
+    struct CenterlineResult {
+        std::vector<Point3D> points;    ///< Smoothed centerline points (physical coords)
+        std::vector<double> radii;      ///< Estimated vessel radius at each point (mm)
+        double totalLengthMm = 0.0;     ///< Total centerline length in mm
+    };
+
+    /**
+     * @brief Trace centerline between two physical points
+     *
+     * Uses Dijkstra shortest path on an intensity-derived cost map,
+     * followed by spline smoothing and radius estimation.
+     *
+     * @param image Input magnitude/MRA image
+     * @param startPoint Start point in physical coordinates
+     * @param endPoint End point in physical coordinates
+     * @param config Tracing configuration
+     * @return Centerline result or error
+     */
+    [[nodiscard]] static std::expected<CenterlineResult, SegmentationError>
+    traceCenterline(const FloatImage3D* image,
+                    const Point3D& startPoint,
+                    const Point3D& endPoint,
+                    const TraceConfig& config);
+
+    /// @overload Uses default TraceConfig
+    [[nodiscard]] static std::expected<CenterlineResult, SegmentationError>
+    traceCenterline(const FloatImage3D* image,
+                    const Point3D& startPoint,
+                    const Point3D& endPoint);
+
+    /**
+     * @brief Generate a tubular binary mask along a centerline
+     *
+     * For each voxel in the reference image, computes the minimum
+     * distance to the centerline. Voxels within the radius are marked
+     * as foreground.
+     *
+     * @param centerline Centerline with radius information
+     * @param radiusOverrideMm Override radius (< 0 for per-point auto radius)
+     * @param referenceImage Image defining output geometry (spacing, size, origin)
+     * @return Binary mask or error
+     */
+    [[nodiscard]] static std::expected<BinaryMaskType::Pointer, SegmentationError>
+    generateMask(const CenterlineResult& centerline,
+                 double radiusOverrideMm,
+                 const FloatImage3D* referenceImage);
+
+    /**
+     * @brief Estimate local vessel radius at a point
+     *
+     * Samples radially in multiple directions perpendicular to the
+     * local tangent, detecting where intensity drops below a threshold
+     * (vessel boundary).
+     *
+     * @param image Input intensity image
+     * @param center Point on centerline (physical coords)
+     * @param tangent Local tangent direction (unit vector)
+     * @param maxRadiusMm Maximum search radius in mm
+     * @return Estimated radius in mm
+     */
+    [[nodiscard]] static double estimateLocalRadius(
+        const FloatImage3D* image,
+        const Point3D& center,
+        const Point3D& tangent,
+        double maxRadiusMm = 20.0);
+
+    /**
+     * @brief Smooth a voxel-grid path using Catmull-Rom splines
+     *
+     * @param rawPoints Path points from Dijkstra (physical coords)
+     * @param subdivisions Number of interpolated points between each pair
+     * @return Smoothed path
+     */
+    [[nodiscard]] static std::vector<Point3D>
+    smoothPath(const std::vector<Point3D>& rawPoints, int subdivisions = 3);
+
+    /**
+     * @brief Convert physical point to nearest voxel index
+     *
+     * @param image Reference image for coordinate transform
+     * @param point Physical point
+     * @param[out] index Output voxel index
+     * @return True if the point is inside the image bounds
+     */
+    [[nodiscard]] static bool physicalToIndex(
+        const FloatImage3D* image,
+        const Point3D& point,
+        FloatImage3D::IndexType& index);
+};
+
+}  // namespace dicom_viewer::services

--- a/src/services/segmentation/centerline_tracer.cpp
+++ b/src/services/segmentation/centerline_tracer.cpp
@@ -1,0 +1,529 @@
+#include "services/segmentation/centerline_tracer.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <numeric>
+#include <queue>
+#include <vector>
+
+#include <itkImageRegionConstIterator.h>
+#include <itkImageRegionIterator.h>
+#include <itkLinearInterpolateImageFunction.h>
+
+namespace dicom_viewer::services {
+
+// =========================================================================
+// Helper utilities
+// =========================================================================
+
+namespace {
+
+/// Compute Euclidean distance between two 3D points
+double distance3D(const Point3D& a, const Point3D& b) {
+    double dx = a[0] - b[0];
+    double dy = a[1] - b[1];
+    double dz = a[2] - b[2];
+    return std::sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+/// Normalize a 3D vector in-place; returns magnitude
+double normalize3D(Point3D& v) {
+    double mag = std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+    if (mag > 1e-12) {
+        v[0] /= mag;
+        v[1] /= mag;
+        v[2] /= mag;
+    }
+    return mag;
+}
+
+/// Cross product of two 3D vectors
+Point3D cross3D(const Point3D& a, const Point3D& b) {
+    return {
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0]
+    };
+}
+
+/// 26-connectivity neighbor offsets
+struct Neighbor {
+    int dx, dy, dz;
+    double dist;  // physical distance factor (1, sqrt(2), sqrt(3))
+};
+
+std::vector<Neighbor> buildNeighbors() {
+    std::vector<Neighbor> neighbors;
+    for (int dz = -1; dz <= 1; ++dz) {
+        for (int dy = -1; dy <= 1; ++dy) {
+            for (int dx = -1; dx <= 1; ++dx) {
+                if (dx == 0 && dy == 0 && dz == 0) continue;
+                double dist = std::sqrt(dx * dx + dy * dy + dz * dz);
+                neighbors.push_back({dx, dy, dz, dist});
+            }
+        }
+    }
+    return neighbors;
+}
+
+/// Convert flat index to 3D index
+inline void flatToIndex(size_t flat, int nx, int ny,
+                         int& x, int& y, int& z) {
+    z = static_cast<int>(flat / (nx * ny));
+    size_t rem = flat % (nx * ny);
+    y = static_cast<int>(rem / nx);
+    x = static_cast<int>(rem % nx);
+}
+
+/// Convert 3D index to flat index
+inline size_t indexToFlat(int x, int y, int z, int nx, int ny) {
+    return static_cast<size_t>(z) * nx * ny +
+           static_cast<size_t>(y) * nx +
+           static_cast<size_t>(x);
+}
+
+}  // anonymous namespace
+
+// =========================================================================
+// Physical ↔ voxel coordinate conversion
+// =========================================================================
+
+bool CenterlineTracer::physicalToIndex(const FloatImage3D* image,
+                                        const Point3D& point,
+                                        FloatImage3D::IndexType& index) {
+    if (!image) return false;
+
+    FloatImage3D::PointType pt;
+    pt[0] = point[0];
+    pt[1] = point[1];
+    pt[2] = point[2];
+
+    using ContinuousIndexType = itk::ContinuousIndex<double, 3>;
+    ContinuousIndexType cidx;
+    if (!image->TransformPhysicalPointToContinuousIndex(pt, cidx)) {
+        return false;
+    }
+
+    auto region = image->GetLargestPossibleRegion();
+    auto size = region.GetSize();
+    for (int i = 0; i < 3; ++i) {
+        index[i] = static_cast<long>(std::round(cidx[i]));
+        if (index[i] < 0 || index[i] >= static_cast<long>(size[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// =========================================================================
+// Dijkstra 3D shortest path
+// =========================================================================
+
+std::expected<CenterlineTracer::CenterlineResult, SegmentationError>
+CenterlineTracer::traceCenterline(const FloatImage3D* image,
+                                   const Point3D& startPoint,
+                                   const Point3D& endPoint,
+                                   const TraceConfig& config) {
+    if (!image) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Input image is null"});
+    }
+
+    // Convert physical points to voxel indices
+    FloatImage3D::IndexType startIdx, endIdx;
+    if (!physicalToIndex(image, startPoint, startIdx)) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Start point is outside image bounds"});
+    }
+    if (!physicalToIndex(image, endPoint, endIdx)) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "End point is outside image bounds"});
+    }
+
+    auto region = image->GetLargestPossibleRegion();
+    auto size = region.GetSize();
+    const int nx = static_cast<int>(size[0]);
+    const int ny = static_cast<int>(size[1]);
+    const int nz = static_cast<int>(size[2]);
+    const size_t totalVoxels = static_cast<size_t>(nx) * ny * nz;
+
+    auto spacing = image->GetSpacing();
+
+    // Build cost map: lower cost = preferred path
+    // Find intensity range for normalization
+    float minVal = std::numeric_limits<float>::max();
+    float maxVal = std::numeric_limits<float>::lowest();
+    itk::ImageRegionConstIterator<FloatImage3D> rangeIt(image, region);
+    for (rangeIt.GoToBegin(); !rangeIt.IsAtEnd(); ++rangeIt) {
+        float v = rangeIt.Get();
+        if (v < minVal) minVal = v;
+        if (v > maxVal) maxVal = v;
+    }
+
+    float intensityRange = maxVal - minVal;
+    if (intensityRange < 1e-6f) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Image has uniform intensity"});
+    }
+
+    // Compute cost for each voxel
+    std::vector<float> costMap(totalVoxels);
+    itk::ImageRegionConstIterator<FloatImage3D> costIt(image, region);
+    size_t vi = 0;
+    for (costIt.GoToBegin(); !costIt.IsAtEnd(); ++costIt, ++vi) {
+        // Normalize to [0, 1]
+        float normalized = (costIt.Get() - minVal) / intensityRange;
+        if (config.brightVessels) {
+            // Bright vessels → low cost
+            costMap[vi] = std::pow(1.0f - normalized + 0.01f,
+                                   static_cast<float>(config.costExponent));
+        } else {
+            // Dark vessels → low cost
+            costMap[vi] = std::pow(normalized + 0.01f,
+                                   static_cast<float>(config.costExponent));
+        }
+    }
+
+    // Dijkstra shortest path
+    size_t startFlat = indexToFlat(startIdx[0], startIdx[1], startIdx[2],
+                                    nx, ny);
+    size_t endFlat = indexToFlat(endIdx[0], endIdx[1], endIdx[2], nx, ny);
+
+    std::vector<float> dist(totalVoxels, std::numeric_limits<float>::max());
+    std::vector<size_t> prev(totalVoxels, totalVoxels);  // invalid sentinel
+
+    dist[startFlat] = 0.0f;
+
+    // Min-heap: (distance, flat_index)
+    using PQElement = std::pair<float, size_t>;
+    std::priority_queue<PQElement, std::vector<PQElement>,
+                        std::greater<PQElement>> pq;
+    pq.push({0.0f, startFlat});
+
+    auto neighbors = buildNeighbors();
+    bool found = false;
+
+    while (!pq.empty()) {
+        auto [d, u] = pq.top();
+        pq.pop();
+
+        if (u == endFlat) {
+            found = true;
+            break;
+        }
+
+        if (d > dist[u]) continue;  // stale entry
+
+        int ux, uy, uz;
+        flatToIndex(u, nx, ny, ux, uy, uz);
+
+        for (const auto& nb : neighbors) {
+            int vx = ux + nb.dx;
+            int vy = uy + nb.dy;
+            int vz = uz + nb.dz;
+
+            if (vx < 0 || vx >= nx || vy < 0 || vy >= ny ||
+                vz < 0 || vz >= nz) {
+                continue;
+            }
+
+            size_t v = indexToFlat(vx, vy, vz, nx, ny);
+
+            // Physical distance between neighbors
+            double physDist = std::sqrt(
+                (nb.dx * spacing[0]) * (nb.dx * spacing[0]) +
+                (nb.dy * spacing[1]) * (nb.dy * spacing[1]) +
+                (nb.dz * spacing[2]) * (nb.dz * spacing[2]));
+
+            // Edge weight = average cost * physical distance
+            float edgeCost = (costMap[u] + costMap[v]) * 0.5f *
+                             static_cast<float>(physDist);
+
+            float newDist = dist[u] + edgeCost;
+            if (newDist < dist[v]) {
+                dist[v] = newDist;
+                prev[v] = u;
+                pq.push({newDist, v});
+            }
+        }
+    }
+
+    if (!found) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::ProcessingFailed,
+            "No path found between start and end points"});
+    }
+
+    // Backtrack path
+    std::vector<Point3D> rawPath;
+    for (size_t cur = endFlat; cur != totalVoxels; cur = prev[cur]) {
+        int cx, cy, cz;
+        flatToIndex(cur, nx, ny, cx, cy, cz);
+
+        // Convert voxel index to physical coordinate
+        FloatImage3D::IndexType idx = {{cx, cy, cz}};
+        FloatImage3D::PointType pt;
+        image->TransformIndexToPhysicalPoint(idx, pt);
+        rawPath.push_back({pt[0], pt[1], pt[2]});
+    }
+    std::reverse(rawPath.begin(), rawPath.end());
+
+    // Smooth path
+    auto smoothedPath = smoothPath(rawPath, 3);
+
+    // Estimate radius at each smoothed point
+    std::vector<double> radii(smoothedPath.size());
+    for (size_t i = 0; i < smoothedPath.size(); ++i) {
+        // Compute local tangent
+        Point3D tangent = {0.0, 0.0, 1.0};
+        if (i > 0 && i < smoothedPath.size() - 1) {
+            tangent[0] = smoothedPath[i + 1][0] - smoothedPath[i - 1][0];
+            tangent[1] = smoothedPath[i + 1][1] - smoothedPath[i - 1][1];
+            tangent[2] = smoothedPath[i + 1][2] - smoothedPath[i - 1][2];
+        } else if (i == 0 && smoothedPath.size() > 1) {
+            tangent[0] = smoothedPath[1][0] - smoothedPath[0][0];
+            tangent[1] = smoothedPath[1][1] - smoothedPath[0][1];
+            tangent[2] = smoothedPath[1][2] - smoothedPath[0][2];
+        }
+        normalize3D(tangent);
+
+        radii[i] = estimateLocalRadius(image, smoothedPath[i], tangent,
+                                        config.initialRadiusMm);
+    }
+
+    // Compute total length
+    double totalLength = 0.0;
+    for (size_t i = 1; i < smoothedPath.size(); ++i) {
+        totalLength += distance3D(smoothedPath[i - 1], smoothedPath[i]);
+    }
+
+    CenterlineResult result;
+    result.points = std::move(smoothedPath);
+    result.radii = std::move(radii);
+    result.totalLengthMm = totalLength;
+    return result;
+}
+
+// =========================================================================
+// Catmull-Rom spline smoothing
+// =========================================================================
+
+std::vector<Point3D>
+CenterlineTracer::smoothPath(const std::vector<Point3D>& rawPoints,
+                              int subdivisions) {
+    if (rawPoints.size() < 3) {
+        return rawPoints;
+    }
+
+    if (subdivisions < 1) {
+        subdivisions = 1;
+    }
+
+    std::vector<Point3D> result;
+    result.reserve(rawPoints.size() * subdivisions);
+
+    for (size_t i = 0; i < rawPoints.size() - 1; ++i) {
+        // Catmull-Rom requires 4 control points: P_{i-1}, P_i, P_{i+1}, P_{i+2}
+        const auto& p0 = (i == 0) ? rawPoints[0] : rawPoints[i - 1];
+        const auto& p1 = rawPoints[i];
+        const auto& p2 = rawPoints[i + 1];
+        const auto& p3 = (i + 2 < rawPoints.size())
+                              ? rawPoints[i + 2]
+                              : rawPoints[rawPoints.size() - 1];
+
+        for (int s = 0; s < subdivisions; ++s) {
+            double t = static_cast<double>(s) / subdivisions;
+            double t2 = t * t;
+            double t3 = t2 * t;
+
+            // Catmull-Rom basis
+            Point3D pt;
+            for (int d = 0; d < 3; ++d) {
+                pt[d] = 0.5 * ((2.0 * p1[d]) +
+                                (-p0[d] + p2[d]) * t +
+                                (2.0 * p0[d] - 5.0 * p1[d] + 4.0 * p2[d] - p3[d]) * t2 +
+                                (-p0[d] + 3.0 * p1[d] - 3.0 * p2[d] + p3[d]) * t3);
+            }
+            result.push_back(pt);
+        }
+    }
+
+    // Add the last point
+    result.push_back(rawPoints.back());
+    return result;
+}
+
+// =========================================================================
+// Local radius estimation
+// =========================================================================
+
+double CenterlineTracer::estimateLocalRadius(const FloatImage3D* image,
+                                              const Point3D& center,
+                                              const Point3D& tangent,
+                                              double maxRadiusMm) {
+    if (!image || maxRadiusMm <= 0.0) {
+        return 1.0;
+    }
+
+    // Create two orthogonal vectors perpendicular to tangent
+    Point3D arbitrary = {0.0, 0.0, 1.0};
+    if (std::abs(tangent[2]) > 0.9) {
+        arbitrary = {1.0, 0.0, 0.0};
+    }
+
+    Point3D perp1 = cross3D(tangent, arbitrary);
+    normalize3D(perp1);
+    Point3D perp2 = cross3D(tangent, perp1);
+    normalize3D(perp2);
+
+    // Set up interpolator
+    using InterpolatorType =
+        itk::LinearInterpolateImageFunction<FloatImage3D, double>;
+    auto interp = InterpolatorType::New();
+    interp->SetInputImage(image);
+
+    // Get center intensity
+    FloatImage3D::PointType centerPt;
+    centerPt[0] = center[0];
+    centerPt[1] = center[1];
+    centerPt[2] = center[2];
+
+    if (!interp->IsInsideBuffer(centerPt)) {
+        return 1.0;
+    }
+
+    double centerIntensity = interp->Evaluate(centerPt);
+
+    // Half-max threshold for vessel boundary
+    auto spacing = image->GetSpacing();
+    double minSpacing = std::min({spacing[0], spacing[1], spacing[2]});
+    double stepMm = minSpacing * 0.5;
+    double threshold = centerIntensity * 0.5;
+
+    // Sample in 8 radial directions
+    constexpr int numDirections = 8;
+    double totalRadius = 0.0;
+    int validCount = 0;
+
+    for (int dir = 0; dir < numDirections; ++dir) {
+        double angle = dir * (2.0 * M_PI / numDirections);
+        double dx = perp1[0] * std::cos(angle) + perp2[0] * std::sin(angle);
+        double dy = perp1[1] * std::cos(angle) + perp2[1] * std::sin(angle);
+        double dz = perp1[2] * std::cos(angle) + perp2[2] * std::sin(angle);
+
+        double foundRadius = maxRadiusMm;
+        for (double r = stepMm; r <= maxRadiusMm; r += stepMm) {
+            FloatImage3D::PointType samplePt;
+            samplePt[0] = center[0] + dx * r;
+            samplePt[1] = center[1] + dy * r;
+            samplePt[2] = center[2] + dz * r;
+
+            if (!interp->IsInsideBuffer(samplePt)) {
+                foundRadius = r;
+                break;
+            }
+
+            double val = interp->Evaluate(samplePt);
+            if (val < threshold) {
+                foundRadius = r;
+                break;
+            }
+        }
+
+        totalRadius += foundRadius;
+        ++validCount;
+    }
+
+    if (validCount == 0) {
+        return 1.0;
+    }
+
+    return totalRadius / validCount;
+}
+
+// =========================================================================
+// Tubular mask generation
+// =========================================================================
+
+std::expected<CenterlineTracer::BinaryMaskType::Pointer, SegmentationError>
+CenterlineTracer::generateMask(const CenterlineResult& centerline,
+                                double radiusOverrideMm,
+                                const FloatImage3D* referenceImage) {
+    if (!referenceImage) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Reference image is null"});
+    }
+
+    if (centerline.points.empty()) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Centerline has no points"});
+    }
+
+    // Create output mask with same geometry as reference
+    auto mask = BinaryMaskType::New();
+    mask->SetRegions(referenceImage->GetLargestPossibleRegion());
+    mask->SetSpacing(referenceImage->GetSpacing());
+    mask->SetOrigin(referenceImage->GetOrigin());
+    mask->SetDirection(referenceImage->GetDirection());
+    mask->Allocate();
+    mask->FillBuffer(0);
+
+    auto region = mask->GetLargestPossibleRegion();
+
+    // For each voxel, compute minimum distance to centerline
+    itk::ImageRegionIterator<BinaryMaskType> it(mask, region);
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        auto idx = it.GetIndex();
+        FloatImage3D::PointType pt;
+        referenceImage->TransformIndexToPhysicalPoint(idx, pt);
+
+        Point3D voxelPos = {pt[0], pt[1], pt[2]};
+
+        // Find minimum distance to any centerline segment
+        double minDist = std::numeric_limits<double>::max();
+        size_t nearestIdx = 0;
+
+        for (size_t i = 0; i < centerline.points.size(); ++i) {
+            double d = distance3D(voxelPos, centerline.points[i]);
+            if (d < minDist) {
+                minDist = d;
+                nearestIdx = i;
+            }
+        }
+
+        // Determine radius at nearest point
+        double radius = radiusOverrideMm;
+        if (radius < 0.0 && nearestIdx < centerline.radii.size()) {
+            radius = centerline.radii[nearestIdx];
+        }
+        if (radius <= 0.0) {
+            radius = 1.0;
+        }
+
+        if (minDist <= radius) {
+            it.Set(1);
+        }
+    }
+
+    return mask;
+}
+
+// =========================================================================
+// Overload: traceCenterline without config (uses default)
+// =========================================================================
+
+std::expected<CenterlineTracer::CenterlineResult, SegmentationError>
+CenterlineTracer::traceCenterline(const FloatImage3D* image,
+                                   const Point3D& startPoint,
+                                   const Point3D& endPoint) {
+    return traceCenterline(image, startPoint, endPoint, TraceConfig{});
+}
+
+}  // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1585,6 +1585,24 @@ target_include_directories(hollow_smoother_test PRIVATE
 
 gtest_discover_tests(hollow_smoother_test DISCOVERY_TIMEOUT 120)
 
+# Unit tests for CenterlineTracer (vessel centerline tracing)
+add_executable(centerline_tracer_test
+    unit/centerline_tracer_test.cpp
+)
+
+target_link_libraries(centerline_tracer_test PRIVATE
+    segmentation_service
+    ${ITK_LIBRARIES}
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(centerline_tracer_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(centerline_tracer_test DISCOVERY_TIMEOUT 120)
+
 # Unit tests for Ensight Gold format exporter
 add_executable(ensight_exporter_test
     unit/ensight_exporter_test.cpp

--- a/tests/unit/centerline_tracer_test.cpp
+++ b/tests/unit/centerline_tracer_test.cpp
@@ -1,0 +1,380 @@
+#include "services/segmentation/centerline_tracer.hpp"
+
+#include <cmath>
+
+#include <gtest/gtest.h>
+#include <itkImageRegionIterator.h>
+
+using namespace dicom_viewer::services;
+using FloatImage3D = CenterlineTracer::FloatImage3D;
+using BinaryMaskType = CenterlineTracer::BinaryMaskType;
+
+namespace {
+
+/// Create a float 3D image of given size with uniform value
+FloatImage3D::Pointer createImage(int sx, int sy, int sz,
+                                   double spacingMm = 1.0,
+                                   float value = 0.0f) {
+    auto image = FloatImage3D::New();
+    FloatImage3D::SizeType size = {{
+        static_cast<unsigned long>(sx),
+        static_cast<unsigned long>(sy),
+        static_cast<unsigned long>(sz)
+    }};
+    FloatImage3D::IndexType start = {{0, 0, 0}};
+    FloatImage3D::RegionType region{start, size};
+    image->SetRegions(region);
+
+    FloatImage3D::SpacingType spacing;
+    spacing.Fill(spacingMm);
+    image->SetSpacing(spacing);
+
+    FloatImage3D::PointType origin;
+    origin.Fill(0.0);
+    image->SetOrigin(origin);
+
+    image->Allocate();
+    image->FillBuffer(value);
+    return image;
+}
+
+/// Draw a straight tube (cylinder) along the X axis in a float image
+/// Center of tube is at (any_x, cy, cz), radius in mm
+void drawStraightTube(FloatImage3D::Pointer image,
+                       double cy, double cz, double radiusMm,
+                       float intensity = 200.0f) {
+    auto region = image->GetLargestPossibleRegion();
+    auto spacing = image->GetSpacing();
+    itk::ImageRegionIterator<FloatImage3D> it(image, region);
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        auto idx = it.GetIndex();
+        // Physical coordinates
+        double py = idx[1] * spacing[1];
+        double pz = idx[2] * spacing[2];
+        double dy = py - cy;
+        double dz = pz - cz;
+        double dist = std::sqrt(dy * dy + dz * dz);
+        if (dist <= radiusMm) {
+            it.Set(intensity);
+        }
+    }
+}
+
+/// Draw a curved tube (quarter circle) in the XY plane
+/// Center of curvature at (cx, cy, cz), bend radius in mm, tube radius in mm
+void drawCurvedTube(FloatImage3D::Pointer image,
+                     double cx, double cy, double cz,
+                     double bendRadiusMm, double tubeRadiusMm,
+                     float intensity = 200.0f) {
+    auto region = image->GetLargestPossibleRegion();
+    auto spacing = image->GetSpacing();
+    itk::ImageRegionIterator<FloatImage3D> it(image, region);
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        auto idx = it.GetIndex();
+        double px = idx[0] * spacing[0];
+        double py = idx[1] * spacing[1];
+        double pz = idx[2] * spacing[2];
+
+        // Distance from center of curvature in XY plane
+        double dxy = std::sqrt((px - cx) * (px - cx) +
+                               (py - cy) * (py - cy));
+        // Distance from the circular arc
+        double distFromArc = std::abs(dxy - bendRadiusMm);
+        double distFromZ = std::abs(pz - cz);
+        double totalDist = std::sqrt(distFromArc * distFromArc +
+                                     distFromZ * distFromZ);
+
+        if (totalDist <= tubeRadiusMm) {
+            it.Set(intensity);
+        }
+    }
+}
+
+/// Count foreground voxels in mask
+size_t countMaskVoxels(BinaryMaskType::Pointer mask) {
+    size_t count = 0;
+    itk::ImageRegionConstIterator<BinaryMaskType> it(
+        mask, mask->GetLargestPossibleRegion());
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        if (it.Get() > 0) ++count;
+    }
+    return count;
+}
+
+}  // anonymous namespace
+
+// =============================================================================
+// Input validation tests
+// =============================================================================
+
+TEST(CenterlineTracerTest, NullImageReturnsError) {
+    Point3D start = {0.0, 0.0, 0.0};
+    Point3D end = {10.0, 0.0, 0.0};
+    auto result = CenterlineTracer::traceCenterline(nullptr, start, end);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+TEST(CenterlineTracerTest, OutOfBoundsStartReturnsError) {
+    auto image = createImage(20, 20, 20);
+    drawStraightTube(image, 10.0, 10.0, 3.0);
+
+    Point3D start = {-100.0, 0.0, 0.0};  // way outside
+    Point3D end = {10.0, 10.0, 10.0};
+    auto result = CenterlineTracer::traceCenterline(image, start, end);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+TEST(CenterlineTracerTest, OutOfBoundsEndReturnsError) {
+    auto image = createImage(20, 20, 20);
+    drawStraightTube(image, 10.0, 10.0, 3.0);
+
+    Point3D start = {10.0, 10.0, 10.0};
+    Point3D end = {-100.0, 0.0, 0.0};
+    auto result = CenterlineTracer::traceCenterline(image, start, end);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CenterlineTracerTest, UniformImageReturnsError) {
+    auto image = createImage(20, 20, 20, 1.0, 100.0f);  // uniform intensity
+    Point3D start = {5.0, 5.0, 5.0};
+    Point3D end = {15.0, 5.0, 5.0};
+    auto result = CenterlineTracer::traceCenterline(image, start, end);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+// =============================================================================
+// Straight tube path finding
+// =============================================================================
+
+TEST(CenterlineTracerTest, StraightTubePathFollowsVessel) {
+    // Create 40x40x40 image with 1mm spacing, background = 10
+    auto image = createImage(40, 40, 40, 1.0, 10.0f);
+    // Draw bright tube along X axis centered at Y=20, Z=20, radius=4mm
+    drawStraightTube(image, 20.0, 20.0, 4.0, 200.0f);
+
+    Point3D start = {5.0, 20.0, 20.0};
+    Point3D end = {35.0, 20.0, 20.0};
+
+    CenterlineTracer::TraceConfig config;
+    config.brightVessels = true;
+    config.initialRadiusMm = 5.0;
+
+    auto result = CenterlineTracer::traceCenterline(
+        image.GetPointer(), start, end, config);
+    ASSERT_TRUE(result.has_value())
+        << "Error: " << result.error().message;
+
+    auto& centerline = result.value();
+
+    // Path should have multiple points
+    EXPECT_GT(centerline.points.size(), 5u);
+
+    // All points should stay close to the tube center (Y≈20, Z≈20)
+    for (const auto& pt : centerline.points) {
+        EXPECT_NEAR(pt[1], 20.0, 5.0)
+            << "Y coordinate deviated from tube center";
+        EXPECT_NEAR(pt[2], 20.0, 5.0)
+            << "Z coordinate deviated from tube center";
+    }
+
+    // Total length should approximate the straight distance
+    double expectedLength = 30.0;  // 35 - 5 = 30mm
+    EXPECT_NEAR(centerline.totalLengthMm, expectedLength, 10.0);
+}
+
+TEST(CenterlineTracerTest, PathRadiiAreReasonable) {
+    auto image = createImage(40, 40, 40, 1.0, 10.0f);
+    drawStraightTube(image, 20.0, 20.0, 4.0, 200.0f);
+
+    Point3D start = {5.0, 20.0, 20.0};
+    Point3D end = {35.0, 20.0, 20.0};
+
+    auto result = CenterlineTracer::traceCenterline(image.GetPointer(),
+                                                     start, end);
+    ASSERT_TRUE(result.has_value());
+
+    // Radii should be roughly around the tube radius (4mm)
+    for (double r : result->radii) {
+        EXPECT_GT(r, 1.0) << "Radius too small";
+        EXPECT_LT(r, 10.0) << "Radius too large";
+    }
+}
+
+// =============================================================================
+// Spline smoothing tests
+// =============================================================================
+
+TEST(CenterlineTracerTest, SmoothPathTooFewPointsReturnsOriginal) {
+    std::vector<Point3D> twoPoints = {{0.0, 0.0, 0.0}, {10.0, 0.0, 0.0}};
+    auto result = CenterlineTracer::smoothPath(twoPoints, 3);
+    EXPECT_EQ(result.size(), twoPoints.size());
+}
+
+TEST(CenterlineTracerTest, SmoothPathIncreasesPointCount) {
+    std::vector<Point3D> points = {
+        {0.0, 0.0, 0.0},
+        {5.0, 1.0, 0.0},
+        {10.0, 0.0, 0.0},
+        {15.0, -1.0, 0.0},
+        {20.0, 0.0, 0.0}
+    };
+
+    auto smoothed = CenterlineTracer::smoothPath(points, 3);
+    EXPECT_GT(smoothed.size(), points.size());
+}
+
+TEST(CenterlineTracerTest, SmoothPathPreservesEndpoints) {
+    std::vector<Point3D> points = {
+        {0.0, 0.0, 0.0},
+        {5.0, 1.0, 0.0},
+        {10.0, 0.0, 0.0},
+        {15.0, 1.0, 0.0}
+    };
+
+    auto smoothed = CenterlineTracer::smoothPath(points, 3);
+    ASSERT_GE(smoothed.size(), 2u);
+
+    // First point should be close to original start
+    EXPECT_NEAR(smoothed.front()[0], points.front()[0], 0.5);
+    EXPECT_NEAR(smoothed.front()[1], points.front()[1], 0.5);
+
+    // Last point should be original end
+    EXPECT_NEAR(smoothed.back()[0], points.back()[0], 0.01);
+    EXPECT_NEAR(smoothed.back()[1], points.back()[1], 0.01);
+}
+
+// =============================================================================
+// Radius estimation tests
+// =============================================================================
+
+TEST(CenterlineTracerTest, EstimateRadiusNullImage) {
+    Point3D center = {10.0, 10.0, 10.0};
+    Point3D tangent = {1.0, 0.0, 0.0};
+    double r = CenterlineTracer::estimateLocalRadius(nullptr, center, tangent);
+    EXPECT_EQ(r, 1.0);  // default fallback
+}
+
+TEST(CenterlineTracerTest, EstimateRadiusOnStraightTube) {
+    auto image = createImage(40, 40, 40, 1.0, 10.0f);
+    drawStraightTube(image, 20.0, 20.0, 5.0, 200.0f);
+
+    Point3D center = {20.0, 20.0, 20.0};
+    Point3D tangent = {1.0, 0.0, 0.0};  // tube along X
+
+    double r = CenterlineTracer::estimateLocalRadius(
+        image.GetPointer(), center, tangent, 15.0);
+
+    // Should be close to tube radius of 5mm
+    EXPECT_NEAR(r, 5.0, 2.0);
+}
+
+// =============================================================================
+// Mask generation tests
+// =============================================================================
+
+TEST(CenterlineTracerTest, GenerateMaskNullImage) {
+    CenterlineTracer::CenterlineResult cl;
+    cl.points = {{0.0, 0.0, 0.0}, {10.0, 0.0, 0.0}};
+    cl.radii = {3.0, 3.0};
+
+    auto result = CenterlineTracer::generateMask(cl, 3.0, nullptr);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CenterlineTracerTest, GenerateMaskEmptyCenterline) {
+    auto ref = createImage(20, 20, 20);
+    CenterlineTracer::CenterlineResult cl;  // empty
+
+    auto result = CenterlineTracer::generateMask(cl, 3.0, ref.GetPointer());
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CenterlineTracerTest, GenerateMaskProducesNonEmptyMask) {
+    auto ref = createImage(30, 30, 30, 1.0, 0.0f);
+
+    CenterlineTracer::CenterlineResult cl;
+    // Straight centerline along X from (5,15,15) to (25,15,15)
+    for (int x = 5; x <= 25; ++x) {
+        cl.points.push_back({static_cast<double>(x), 15.0, 15.0});
+        cl.radii.push_back(3.0);
+    }
+
+    auto result = CenterlineTracer::generateMask(cl, 3.0, ref.GetPointer());
+    ASSERT_TRUE(result.has_value());
+
+    size_t voxelCount = countMaskVoxels(*result);
+    EXPECT_GT(voxelCount, 100u) << "Mask should contain tube voxels";
+}
+
+TEST(CenterlineTracerTest, GenerateMaskWithOverrideRadius) {
+    auto ref = createImage(30, 30, 30, 1.0, 0.0f);
+
+    CenterlineTracer::CenterlineResult cl;
+    for (int x = 10; x <= 20; ++x) {
+        cl.points.push_back({static_cast<double>(x), 15.0, 15.0});
+        cl.radii.push_back(2.0);  // auto radius
+    }
+
+    // With small override radius
+    auto small = CenterlineTracer::generateMask(cl, 1.0, ref.GetPointer());
+    ASSERT_TRUE(small.has_value());
+    size_t smallCount = countMaskVoxels(*small);
+
+    // With large override radius
+    auto large = CenterlineTracer::generateMask(cl, 5.0, ref.GetPointer());
+    ASSERT_TRUE(large.has_value());
+    size_t largeCount = countMaskVoxels(*large);
+
+    // Larger radius → more voxels
+    EXPECT_GT(largeCount, smallCount);
+}
+
+TEST(CenterlineTracerTest, GenerateMaskAutoRadius) {
+    auto ref = createImage(30, 30, 30, 1.0, 0.0f);
+
+    CenterlineTracer::CenterlineResult cl;
+    for (int x = 10; x <= 20; ++x) {
+        cl.points.push_back({static_cast<double>(x), 15.0, 15.0});
+        cl.radii.push_back(3.0);
+    }
+
+    // Negative override → use per-point auto radius
+    auto result = CenterlineTracer::generateMask(cl, -1.0, ref.GetPointer());
+    ASSERT_TRUE(result.has_value());
+
+    size_t voxelCount = countMaskVoxels(*result);
+    EXPECT_GT(voxelCount, 50u);
+}
+
+// =============================================================================
+// Physical ↔ voxel conversion tests
+// =============================================================================
+
+TEST(CenterlineTracerTest, PhysicalToIndexValidPoint) {
+    auto image = createImage(20, 20, 20, 1.0);
+    Point3D pt = {10.0, 10.0, 10.0};
+    FloatImage3D::IndexType idx;
+
+    EXPECT_TRUE(CenterlineTracer::physicalToIndex(image.GetPointer(), pt, idx));
+    EXPECT_EQ(idx[0], 10);
+    EXPECT_EQ(idx[1], 10);
+    EXPECT_EQ(idx[2], 10);
+}
+
+TEST(CenterlineTracerTest, PhysicalToIndexOutOfBounds) {
+    auto image = createImage(20, 20, 20, 1.0);
+    Point3D pt = {-5.0, 10.0, 10.0};
+    FloatImage3D::IndexType idx;
+
+    EXPECT_FALSE(CenterlineTracer::physicalToIndex(image.GetPointer(), pt, idx));
+}
+
+TEST(CenterlineTracerTest, PhysicalToIndexNullImage) {
+    Point3D pt = {10.0, 10.0, 10.0};
+    FloatImage3D::IndexType idx;
+
+    EXPECT_FALSE(CenterlineTracer::physicalToIndex(nullptr, pt, idx));
+}


### PR DESCRIPTION
Closes #300

## Summary
- Implement Dijkstra 3D shortest path on intensity-derived cost map with 26-connectivity for vessel centerline tracing
- Add Catmull-Rom spline smoothing to eliminate staircase artifacts from voxel-grid paths
- Add local radius estimation via 8-direction radial sampling with half-max threshold
- Add tubular binary mask generation along smoothed centerline for segmentation output
- Support both bright-blood (MRA) and dark-blood vessel protocols via configurable cost function

Part of #254

## Test Plan
- [x] 19 unit tests all passing (input validation, straight tube path, spline smoothing, radius estimation, mask generation, coordinate conversion)
- [x] Synthetic tube phantom data validates path accuracy and radius estimation
- [x] Build verified with cmake + clang on macOS