### PR TITLE
feat(segmentation): implement LevelTracingTool with flood-fill and Moore contour tracing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,6 +425,7 @@ add_library(segmentation_service STATIC
     src/services/segmentation/hollow_tool.cpp
     src/services/segmentation/mask_smoother.cpp
     src/services/segmentation/centerline_tracer.cpp
+    src/services/segmentation/level_tracing_tool.cpp
 )
 
 target_link_libraries(segmentation_service PUBLIC

--- a/include/services/segmentation/level_tracing_tool.hpp
+++ b/include/services/segmentation/level_tracing_tool.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "threshold_segmenter.hpp"
+
+#include <array>
+#include <expected>
+#include <vector>
+
+#include <itkImage.h>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Edge-following contour tool using flood-fill and Moore boundary tracing
+ *
+ * Automatically traces intensity boundaries on 2D slices. Given a seed point,
+ * the algorithm:
+ * 1. Samples intensity at the seed and defines a tolerance band
+ * 2. Flood-fills connected pixels within the band from the seed
+ * 3. Extracts the ordered boundary contour using Moore neighborhood tracing
+ * 4. Optionally fills the enclosed region to produce a binary mask
+ *
+ * @trace SRS-FR-025
+ */
+class LevelTracingTool {
+public:
+    using FloatSlice2D = itk::Image<float, 2>;
+    using BinarySlice2D = itk::Image<uint8_t, 2>;
+    using Point2D = std::array<double, 2>;
+    using IndexPoint = std::array<int, 2>;
+
+    /**
+     * @brief Configuration for level tracing
+     */
+    struct Config {
+        double tolerancePct = 5.0;      ///< Intensity tolerance as % of image range
+        uint8_t foregroundValue = 1;
+    };
+
+    /**
+     * @brief Trace the boundary contour at the intensity level of the seed point
+     *
+     * Performs flood-fill within the tolerance band, then extracts the
+     * ordered boundary using Moore neighborhood contour tracing.
+     *
+     * @param slice Input 2D float slice
+     * @param seedPoint Seed pixel index [x, y]
+     * @param config Tracing configuration
+     * @return Ordered contour points (pixel coordinates) or error
+     */
+    [[nodiscard]] static std::expected<std::vector<IndexPoint>, SegmentationError>
+    traceContour(const FloatSlice2D* slice,
+                 const IndexPoint& seedPoint,
+                 const Config& config);
+
+    /// @overload Uses default Config
+    [[nodiscard]] static std::expected<std::vector<IndexPoint>, SegmentationError>
+    traceContour(const FloatSlice2D* slice,
+                 const IndexPoint& seedPoint);
+
+    /**
+     * @brief Convert a closed contour to a filled binary mask
+     *
+     * Uses scanline ray-casting to fill the interior of the contour.
+     *
+     * @param contour Ordered boundary points
+     * @param referenceSlice Image defining output geometry
+     * @return Filled binary mask or error
+     */
+    [[nodiscard]] static std::expected<BinarySlice2D::Pointer, SegmentationError>
+    contourToMask(const std::vector<IndexPoint>& contour,
+                  const FloatSlice2D* referenceSlice);
+
+    /**
+     * @brief Trace contour and fill in one step
+     *
+     * Combines traceContour and contourToMask. More efficient than
+     * calling them separately because the flood-fill result is reused
+     * directly as the mask.
+     *
+     * @param slice Input 2D float slice
+     * @param seedPoint Seed pixel index [x, y]
+     * @param config Tracing configuration
+     * @return Filled binary mask or error
+     */
+    [[nodiscard]] static std::expected<BinarySlice2D::Pointer, SegmentationError>
+    traceAndFill(const FloatSlice2D* slice,
+                 const IndexPoint& seedPoint,
+                 const Config& config);
+
+    /// @overload Uses default Config
+    [[nodiscard]] static std::expected<BinarySlice2D::Pointer, SegmentationError>
+    traceAndFill(const FloatSlice2D* slice,
+                 const IndexPoint& seedPoint);
+};
+
+}  // namespace dicom_viewer::services

--- a/src/services/segmentation/level_tracing_tool.cpp
+++ b/src/services/segmentation/level_tracing_tool.cpp
@@ -1,0 +1,415 @@
+#include "services/segmentation/level_tracing_tool.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <queue>
+#include <set>
+#include <vector>
+
+#include <itkImageRegionConstIterator.h>
+#include <itkImageRegionIterator.h>
+
+namespace dicom_viewer::services {
+
+// =========================================================================
+// Internal helpers
+// =========================================================================
+
+namespace {
+
+/// Check if an index is within image bounds
+bool isInBounds(int x, int y, int width, int height) {
+    return x >= 0 && x < width && y >= 0 && y < height;
+}
+
+/// Compute image intensity range
+std::pair<float, float> computeIntensityRange(const LevelTracingTool::FloatSlice2D* slice) {
+    float minVal = std::numeric_limits<float>::max();
+    float maxVal = std::numeric_limits<float>::lowest();
+
+    auto region = slice->GetLargestPossibleRegion();
+    itk::ImageRegionConstIterator<LevelTracingTool::FloatSlice2D> it(slice, region);
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        float v = it.Get();
+        if (v < minVal) minVal = v;
+        if (v > maxVal) maxVal = v;
+    }
+    return {minVal, maxVal};
+}
+
+/// BFS flood-fill from seed within intensity tolerance band.
+/// Returns a binary visited mask (1 = within-band connected to seed).
+LevelTracingTool::BinarySlice2D::Pointer
+floodFill(const LevelTracingTool::FloatSlice2D* slice,
+          const LevelTracingTool::IndexPoint& seed,
+          float lowerBound, float upperBound) {
+    auto region = slice->GetLargestPossibleRegion();
+    auto size = region.GetSize();
+    int width = static_cast<int>(size[0]);
+    int height = static_cast<int>(size[1]);
+
+    auto mask = LevelTracingTool::BinarySlice2D::New();
+    mask->SetRegions(region);
+    mask->SetSpacing(slice->GetSpacing());
+    mask->SetOrigin(slice->GetOrigin());
+    mask->SetDirection(slice->GetDirection());
+    mask->Allocate();
+    mask->FillBuffer(0);
+
+    // 4-connectivity BFS
+    std::queue<LevelTracingTool::IndexPoint> queue;
+    queue.push(seed);
+
+    LevelTracingTool::BinarySlice2D::IndexType idx = {{seed[0], seed[1]}};
+    mask->SetPixel(idx, 1);
+
+    constexpr int dx4[] = {1, -1, 0, 0};
+    constexpr int dy4[] = {0, 0, 1, -1};
+
+    while (!queue.empty()) {
+        auto [cx, cy] = queue.front();
+        queue.pop();
+
+        for (int d = 0; d < 4; ++d) {
+            int nx = cx + dx4[d];
+            int ny = cy + dy4[d];
+
+            if (!isInBounds(nx, ny, width, height)) continue;
+
+            LevelTracingTool::BinarySlice2D::IndexType nIdx = {{nx, ny}};
+            if (mask->GetPixel(nIdx) != 0) continue;
+
+            LevelTracingTool::FloatSlice2D::IndexType srcIdx = {{nx, ny}};
+            float val = slice->GetPixel(srcIdx);
+            if (val >= lowerBound && val <= upperBound) {
+                mask->SetPixel(nIdx, 1);
+                queue.push({nx, ny});
+            }
+        }
+    }
+
+    return mask;
+}
+
+/// Moore neighborhood contour tracing.
+/// Extracts the ordered boundary of the foreground region in the mask,
+/// starting from the topmost-leftmost boundary pixel.
+std::vector<LevelTracingTool::IndexPoint>
+mooreContourTrace(const LevelTracingTool::BinarySlice2D* mask) {
+    auto size = mask->GetLargestPossibleRegion().GetSize();
+    int width = static_cast<int>(size[0]);
+    int height = static_cast<int>(size[1]);
+
+    // Find the starting boundary pixel: scan top-to-bottom, left-to-right
+    LevelTracingTool::IndexPoint start = {-1, -1};
+    for (int y = 0; y < height && start[0] < 0; ++y) {
+        for (int x = 0; x < width; ++x) {
+            LevelTracingTool::BinarySlice2D::IndexType idx = {{x, y}};
+            if (mask->GetPixel(idx) > 0) {
+                start = {x, y};
+                break;
+            }
+        }
+    }
+
+    if (start[0] < 0) {
+        return {};  // No foreground pixels
+    }
+
+    // Moore neighborhood: 8 directions (clockwise from right)
+    // Direction index: 0=right, 1=bottom-right, 2=down, 3=bottom-left,
+    //                  4=left, 5=top-left, 6=up, 7=top-right
+    constexpr int mx[] = {1, 1, 0, -1, -1, -1, 0, 1};
+    constexpr int my[] = {0, 1, 1, 1, 0, -1, -1, -1};
+
+    auto getPixel = [&](int x, int y) -> bool {
+        if (!isInBounds(x, y, width, height)) return false;
+        LevelTracingTool::BinarySlice2D::IndexType idx = {{x, y}};
+        return mask->GetPixel(idx) > 0;
+    };
+
+    std::vector<LevelTracingTool::IndexPoint> contour;
+    contour.push_back(start);
+
+    // The backtrack direction: we entered the start pixel from the left
+    int backDir = 4;  // Came from the left (entered from west)
+
+    LevelTracingTool::IndexPoint current = start;
+    bool firstStep = true;
+
+    // Jacob's stopping criterion: stop when we return to start AND
+    // the next boundary pixel matches the second pixel in the contour
+    while (true) {
+        // Start scanning from (backDir + 1) mod 8 clockwise
+        int startDir = (backDir + 1) % 8;
+        bool found = false;
+
+        for (int i = 0; i < 8; ++i) {
+            int dir = (startDir + i) % 8;
+            int nx = current[0] + mx[dir];
+            int ny = current[1] + my[dir];
+
+            if (getPixel(nx, ny)) {
+                LevelTracingTool::IndexPoint next = {nx, ny};
+
+                // Jacob's stopping criterion
+                if (!firstStep && next[0] == start[0] && next[1] == start[1]) {
+                    // Check if this completes the contour
+                    if (contour.size() > 2) {
+                        return contour;
+                    }
+                }
+
+                contour.push_back(next);
+                // Backtrack direction is opposite of the direction we moved
+                backDir = (dir + 4) % 8;
+                current = next;
+                found = true;
+                firstStep = false;
+                break;
+            }
+        }
+
+        if (!found) {
+            // Isolated pixel or dead end
+            break;
+        }
+
+        // Safety: prevent infinite loops for pathological cases
+        if (contour.size() > static_cast<size_t>(2 * width * height)) {
+            break;
+        }
+    }
+
+    return contour;
+}
+
+}  // anonymous namespace
+
+// =========================================================================
+// traceContour
+// =========================================================================
+
+std::expected<std::vector<LevelTracingTool::IndexPoint>, SegmentationError>
+LevelTracingTool::traceContour(const FloatSlice2D* slice,
+                                const IndexPoint& seedPoint,
+                                const Config& config) {
+    if (!slice) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Input slice is null"});
+    }
+
+    auto region = slice->GetLargestPossibleRegion();
+    auto size = region.GetSize();
+    int width = static_cast<int>(size[0]);
+    int height = static_cast<int>(size[1]);
+
+    if (!isInBounds(seedPoint[0], seedPoint[1], width, height)) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Seed point is outside image bounds"});
+    }
+
+    // Get seed intensity
+    FloatSlice2D::IndexType seedIdx = {{seedPoint[0], seedPoint[1]}};
+    float seedIntensity = slice->GetPixel(seedIdx);
+
+    // Compute tolerance band
+    auto [minVal, maxVal] = computeIntensityRange(slice);
+    float range = maxVal - minVal;
+    if (range < 1e-6f) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Image has uniform intensity"});
+    }
+
+    float tolerance = range * static_cast<float>(config.tolerancePct / 100.0);
+    float lowerBound = seedIntensity - tolerance;
+    float upperBound = seedIntensity + tolerance;
+
+    // Flood-fill from seed within tolerance band
+    auto filledMask = floodFill(slice, seedPoint, lowerBound, upperBound);
+
+    // Extract boundary contour using Moore neighborhood tracing
+    auto contour = mooreContourTrace(filledMask.GetPointer());
+
+    if (contour.empty()) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::ProcessingFailed,
+            "No contour found at seed intensity level"});
+    }
+
+    return contour;
+}
+
+std::expected<std::vector<LevelTracingTool::IndexPoint>, SegmentationError>
+LevelTracingTool::traceContour(const FloatSlice2D* slice,
+                                const IndexPoint& seedPoint) {
+    return traceContour(slice, seedPoint, Config{});
+}
+
+// =========================================================================
+// contourToMask
+// =========================================================================
+
+std::expected<LevelTracingTool::BinarySlice2D::Pointer, SegmentationError>
+LevelTracingTool::contourToMask(const std::vector<IndexPoint>& contour,
+                                 const FloatSlice2D* referenceSlice) {
+    if (!referenceSlice) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Reference slice is null"});
+    }
+
+    if (contour.size() < 3) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Contour has fewer than 3 points"});
+    }
+
+    auto region = referenceSlice->GetLargestPossibleRegion();
+    auto size = region.GetSize();
+    int width = static_cast<int>(size[0]);
+    int height = static_cast<int>(size[1]);
+
+    auto mask = BinarySlice2D::New();
+    mask->SetRegions(region);
+    mask->SetSpacing(referenceSlice->GetSpacing());
+    mask->SetOrigin(referenceSlice->GetOrigin());
+    mask->SetDirection(referenceSlice->GetDirection());
+    mask->Allocate();
+    mask->FillBuffer(0);
+
+    // Scanline ray-casting: for each row, count contour crossings
+    // A pixel is inside if the number of crossings to its left is odd
+    for (int y = 0; y < height; ++y) {
+        // Collect X-coordinates where contour edges cross this scanline
+        std::vector<int> crossings;
+        size_t n = contour.size();
+
+        for (size_t i = 0; i < n; ++i) {
+            size_t j = (i + 1) % n;
+            int y0 = contour[i][1];
+            int y1 = contour[j][1];
+
+            // Skip horizontal edges
+            if (y0 == y1) continue;
+
+            // Check if scanline y crosses this edge
+            int yMin = std::min(y0, y1);
+            int yMax = std::max(y0, y1);
+
+            if (y < yMin || y >= yMax) continue;
+
+            // Linear interpolation for crossing x-coordinate
+            double t = static_cast<double>(y - y0) / (y1 - y0);
+            double crossX = contour[i][0] + t * (contour[j][0] - contour[i][0]);
+            crossings.push_back(static_cast<int>(std::round(crossX)));
+        }
+
+        // Sort crossings and fill between pairs
+        std::sort(crossings.begin(), crossings.end());
+
+        for (size_t k = 0; k + 1 < crossings.size(); k += 2) {
+            int xStart = std::max(0, crossings[k]);
+            int xEnd = std::min(width - 1, crossings[k + 1]);
+            for (int x = xStart; x <= xEnd; ++x) {
+                BinarySlice2D::IndexType idx = {{x, y}};
+                mask->SetPixel(idx, 1);
+            }
+        }
+    }
+
+    // Also mark contour pixels themselves
+    for (const auto& pt : contour) {
+        if (isInBounds(pt[0], pt[1], width, height)) {
+            BinarySlice2D::IndexType idx = {{pt[0], pt[1]}};
+            mask->SetPixel(idx, 1);
+        }
+    }
+
+    return mask;
+}
+
+// =========================================================================
+// traceAndFill
+// =========================================================================
+
+std::expected<LevelTracingTool::BinarySlice2D::Pointer, SegmentationError>
+LevelTracingTool::traceAndFill(const FloatSlice2D* slice,
+                                const IndexPoint& seedPoint,
+                                const Config& config) {
+    if (!slice) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Input slice is null"});
+    }
+
+    auto region = slice->GetLargestPossibleRegion();
+    auto size = region.GetSize();
+    int width = static_cast<int>(size[0]);
+    int height = static_cast<int>(size[1]);
+
+    if (!isInBounds(seedPoint[0], seedPoint[1], width, height)) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Seed point is outside image bounds"});
+    }
+
+    // Get seed intensity and compute tolerance band
+    FloatSlice2D::IndexType seedIdx = {{seedPoint[0], seedPoint[1]}};
+    float seedIntensity = slice->GetPixel(seedIdx);
+
+    auto [minVal, maxVal] = computeIntensityRange(slice);
+    float range = maxVal - minVal;
+    if (range < 1e-6f) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::InvalidInput,
+            "Image has uniform intensity"});
+    }
+
+    float tolerance = range * static_cast<float>(config.tolerancePct / 100.0);
+    float lowerBound = seedIntensity - tolerance;
+    float upperBound = seedIntensity + tolerance;
+
+    // Flood-fill directly produces the filled mask
+    auto mask = floodFill(slice, seedPoint, lowerBound, upperBound);
+
+    // Verify non-empty result
+    bool hasPixels = false;
+    itk::ImageRegionConstIterator<BinarySlice2D> it(mask, region);
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        if (it.Get() > 0) {
+            hasPixels = true;
+            break;
+        }
+    }
+
+    if (!hasPixels) {
+        return std::unexpected(SegmentationError{
+            SegmentationError::Code::ProcessingFailed,
+            "No region found at seed intensity level"});
+    }
+
+    // Set foreground value if different from default (1)
+    if (config.foregroundValue != 1) {
+        itk::ImageRegionIterator<BinarySlice2D> fillIt(mask, region);
+        for (fillIt.GoToBegin(); !fillIt.IsAtEnd(); ++fillIt) {
+            if (fillIt.Get() > 0) {
+                fillIt.Set(config.foregroundValue);
+            }
+        }
+    }
+
+    return mask;
+}
+
+std::expected<LevelTracingTool::BinarySlice2D::Pointer, SegmentationError>
+LevelTracingTool::traceAndFill(const FloatSlice2D* slice,
+                                const IndexPoint& seedPoint) {
+    return traceAndFill(slice, seedPoint, Config{});
+}
+
+}  // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1603,6 +1603,24 @@ target_include_directories(centerline_tracer_test PRIVATE
 
 gtest_discover_tests(centerline_tracer_test DISCOVERY_TIMEOUT 120)
 
+# Unit tests for Level Tracing contour tool
+add_executable(level_tracing_test
+    unit/level_tracing_test.cpp
+)
+
+target_link_libraries(level_tracing_test PRIVATE
+    segmentation_service
+    ${ITK_LIBRARIES}
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(level_tracing_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(level_tracing_test)
+
 # Unit tests for Ensight Gold format exporter
 add_executable(ensight_exporter_test
     unit/ensight_exporter_test.cpp

--- a/tests/unit/level_tracing_test.cpp
+++ b/tests/unit/level_tracing_test.cpp
@@ -1,0 +1,375 @@
+#include "services/segmentation/level_tracing_tool.hpp"
+
+#include <cmath>
+
+#include <gtest/gtest.h>
+#include <itkImageRegionIterator.h>
+
+using namespace dicom_viewer::services;
+using FloatSlice2D = LevelTracingTool::FloatSlice2D;
+using BinarySlice2D = LevelTracingTool::BinarySlice2D;
+using IndexPoint = LevelTracingTool::IndexPoint;
+
+namespace {
+
+/// Create a 2D float image with uniform value
+FloatSlice2D::Pointer createSlice(int width, int height,
+                                   float value = 0.0f) {
+    auto image = FloatSlice2D::New();
+    FloatSlice2D::SizeType size = {{
+        static_cast<unsigned long>(width),
+        static_cast<unsigned long>(height)
+    }};
+    FloatSlice2D::IndexType start = {{0, 0}};
+    FloatSlice2D::RegionType region{start, size};
+    image->SetRegions(region);
+
+    FloatSlice2D::SpacingType spacing;
+    spacing.Fill(1.0);
+    image->SetSpacing(spacing);
+
+    FloatSlice2D::PointType origin;
+    origin.Fill(0.0);
+    image->SetOrigin(origin);
+
+    image->Allocate();
+    image->FillBuffer(value);
+    return image;
+}
+
+/// Draw a filled rectangle on the slice
+void drawRect(FloatSlice2D::Pointer image,
+              int x0, int y0, int x1, int y1,
+              float intensity) {
+    for (int y = y0; y <= y1; ++y) {
+        for (int x = x0; x <= x1; ++x) {
+            FloatSlice2D::IndexType idx = {{x, y}};
+            image->SetPixel(idx, intensity);
+        }
+    }
+}
+
+/// Draw a filled circle on the slice
+void drawCircle(FloatSlice2D::Pointer image,
+                int cx, int cy, int radius,
+                float intensity) {
+    auto size = image->GetLargestPossibleRegion().GetSize();
+    int w = static_cast<int>(size[0]);
+    int h = static_cast<int>(size[1]);
+
+    for (int y = 0; y < h; ++y) {
+        for (int x = 0; x < w; ++x) {
+            int dx = x - cx;
+            int dy = y - cy;
+            if (dx * dx + dy * dy <= radius * radius) {
+                FloatSlice2D::IndexType idx = {{x, y}};
+                image->SetPixel(idx, intensity);
+            }
+        }
+    }
+}
+
+/// Count foreground pixels in a binary slice
+size_t countForeground(BinarySlice2D::Pointer mask) {
+    size_t count = 0;
+    itk::ImageRegionConstIterator<BinarySlice2D> it(
+        mask, mask->GetLargestPossibleRegion());
+    for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+        if (it.Get() > 0) ++count;
+    }
+    return count;
+}
+
+}  // anonymous namespace
+
+// =============================================================================
+// Input validation tests
+// =============================================================================
+
+TEST(LevelTracingToolTest, NullSliceReturnsError) {
+    IndexPoint seed = {5, 5};
+    auto result = LevelTracingTool::traceContour(nullptr, seed);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+TEST(LevelTracingToolTest, OutOfBoundsSeedReturnsError) {
+    auto slice = createSlice(20, 20, 100.0f);
+    IndexPoint seed = {-5, 10};
+    auto result = LevelTracingTool::traceContour(slice.GetPointer(), seed);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+TEST(LevelTracingToolTest, OutOfBoundsSeedHighReturnsError) {
+    auto slice = createSlice(20, 20, 100.0f);
+    IndexPoint seed = {25, 10};
+    auto result = LevelTracingTool::traceContour(slice.GetPointer(), seed);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(LevelTracingToolTest, UniformImageReturnsError) {
+    auto slice = createSlice(20, 20, 100.0f);  // uniform
+    IndexPoint seed = {10, 10};
+    auto result = LevelTracingTool::traceContour(slice.GetPointer(), seed);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+TEST(LevelTracingToolTest, TraceAndFillNullSliceReturnsError) {
+    IndexPoint seed = {5, 5};
+    auto result = LevelTracingTool::traceAndFill(nullptr, seed);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, SegmentationError::Code::InvalidInput);
+}
+
+TEST(LevelTracingToolTest, ContourToMaskNullReferenceReturnsError) {
+    std::vector<IndexPoint> contour = {{0, 0}, {10, 0}, {10, 10}};
+    auto result = LevelTracingTool::contourToMask(contour, nullptr);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(LevelTracingToolTest, ContourToMaskTooFewPointsReturnsError) {
+    auto ref = createSlice(20, 20);
+    std::vector<IndexPoint> contour = {{5, 5}, {10, 5}};
+    auto result = LevelTracingTool::contourToMask(contour, ref.GetPointer());
+    EXPECT_FALSE(result.has_value());
+}
+
+// =============================================================================
+// Rectangle tracing tests
+// =============================================================================
+
+TEST(LevelTracingToolTest, TraceContourOnBrightRectangle) {
+    // Background = 0, bright rectangle = 200
+    auto slice = createSlice(30, 30, 0.0f);
+    drawRect(slice, 5, 5, 20, 20, 200.0f);
+
+    // Seed inside the rectangle
+    IndexPoint seed = {12, 12};
+    LevelTracingTool::Config config;
+    config.tolerancePct = 5.0;
+
+    auto result = LevelTracingTool::traceContour(
+        slice.GetPointer(), seed, config);
+    ASSERT_TRUE(result.has_value())
+        << "Error: " << result.error().message;
+
+    auto& contour = result.value();
+    // Rectangle boundary should have multiple points
+    EXPECT_GT(contour.size(), 10u);
+
+    // All contour points should be within or on the rectangle boundary
+    for (const auto& pt : contour) {
+        EXPECT_GE(pt[0], 4) << "Contour point too far left";
+        EXPECT_LE(pt[0], 21) << "Contour point too far right";
+        EXPECT_GE(pt[1], 4) << "Contour point too far up";
+        EXPECT_LE(pt[1], 21) << "Contour point too far down";
+    }
+}
+
+TEST(LevelTracingToolTest, TraceAndFillBrightRectangle) {
+    auto slice = createSlice(30, 30, 0.0f);
+    drawRect(slice, 5, 5, 20, 20, 200.0f);
+
+    IndexPoint seed = {12, 12};
+    auto result = LevelTracingTool::traceAndFill(slice.GetPointer(), seed);
+    ASSERT_TRUE(result.has_value())
+        << "Error: " << result.error().message;
+
+    size_t filledCount = countForeground(*result);
+    // Expected area: 16 * 16 = 256 pixels (5..20 inclusive = 16 wide)
+    size_t expectedArea = 16u * 16u;
+    EXPECT_NEAR(static_cast<double>(filledCount),
+                static_cast<double>(expectedArea), expectedArea * 0.1);
+}
+
+// =============================================================================
+// Circle tracing tests
+// =============================================================================
+
+TEST(LevelTracingToolTest, TraceContourOnCircle) {
+    auto slice = createSlice(40, 40, 0.0f);
+    drawCircle(slice, 20, 20, 8, 150.0f);
+
+    IndexPoint seed = {20, 20};
+    auto result = LevelTracingTool::traceContour(slice.GetPointer(), seed);
+    ASSERT_TRUE(result.has_value());
+
+    auto& contour = result.value();
+    EXPECT_GT(contour.size(), 15u);
+
+    // Contour points should be near the circle boundary
+    for (const auto& pt : contour) {
+        double dist = std::sqrt((pt[0] - 20) * (pt[0] - 20) +
+                                (pt[1] - 20) * (pt[1] - 20));
+        EXPECT_LE(dist, 10.0) << "Contour point too far from center";
+    }
+}
+
+TEST(LevelTracingToolTest, TraceAndFillCircle) {
+    auto slice = createSlice(40, 40, 0.0f);
+    drawCircle(slice, 20, 20, 8, 150.0f);
+
+    IndexPoint seed = {20, 20};
+    auto result = LevelTracingTool::traceAndFill(slice.GetPointer(), seed);
+    ASSERT_TRUE(result.has_value());
+
+    size_t filledCount = countForeground(*result);
+    // Approximate area of circle with r=8: π*64 ≈ 201
+    double expectedArea = M_PI * 8 * 8;
+    EXPECT_NEAR(static_cast<double>(filledCount), expectedArea,
+                expectedArea * 0.15);
+}
+
+// =============================================================================
+// Tolerance band tests
+// =============================================================================
+
+TEST(LevelTracingToolTest, NarrowToleranceTracesLess) {
+    auto slice = createSlice(30, 30, 50.0f);
+    // Gradient region: intensity varies from 100 to 200
+    for (int y = 5; y <= 25; ++y) {
+        for (int x = 5; x <= 25; ++x) {
+            float intensity = 100.0f + (x - 5) * 5.0f;
+            FloatSlice2D::IndexType idx = {{x, y}};
+            slice->SetPixel(idx, intensity);
+        }
+    }
+
+    IndexPoint seed = {15, 15};  // ~150
+
+    // Wide tolerance should capture more
+    LevelTracingTool::Config wideConfig;
+    wideConfig.tolerancePct = 30.0;
+    auto wideResult = LevelTracingTool::traceAndFill(
+        slice.GetPointer(), seed, wideConfig);
+    ASSERT_TRUE(wideResult.has_value());
+    size_t wideCount = countForeground(*wideResult);
+
+    // Narrow tolerance should capture less
+    LevelTracingTool::Config narrowConfig;
+    narrowConfig.tolerancePct = 5.0;
+    auto narrowResult = LevelTracingTool::traceAndFill(
+        slice.GetPointer(), seed, narrowConfig);
+    ASSERT_TRUE(narrowResult.has_value());
+    size_t narrowCount = countForeground(*narrowResult);
+
+    EXPECT_GT(wideCount, narrowCount)
+        << "Wider tolerance should capture more pixels";
+}
+
+TEST(LevelTracingToolTest, ToleranceBandRespectsSeedIntensity) {
+    auto slice = createSlice(30, 30, 0.0f);
+    // Two separate bright regions with different intensities
+    drawRect(slice, 2, 2, 10, 10, 100.0f);
+    drawRect(slice, 15, 15, 25, 25, 200.0f);
+
+    // Seed in the first region (intensity=100)
+    IndexPoint seed = {6, 6};
+    LevelTracingTool::Config config;
+    config.tolerancePct = 10.0;  // tolerance = 0.1 * 200 = 20
+
+    auto result = LevelTracingTool::traceAndFill(
+        slice.GetPointer(), seed, config);
+    ASSERT_TRUE(result.has_value());
+
+    // Should only fill the first rectangle, not the second
+    // Check a pixel in the second rectangle
+    BinarySlice2D::IndexType checkIdx = {{20, 20}};
+    EXPECT_EQ(result.value()->GetPixel(checkIdx), 0)
+        << "Second rectangle should not be filled";
+
+    // Check a pixel in the first rectangle
+    BinarySlice2D::IndexType firstIdx = {{6, 6}};
+    EXPECT_EQ(result.value()->GetPixel(firstIdx), 1)
+        << "Seed region should be filled";
+}
+
+// =============================================================================
+// contourToMask tests
+// =============================================================================
+
+TEST(LevelTracingToolTest, ContourToMaskSimpleTriangle) {
+    auto ref = createSlice(20, 20);
+    std::vector<IndexPoint> contour = {
+        {5, 5}, {15, 5}, {10, 15}
+    };
+
+    auto result = LevelTracingTool::contourToMask(contour, ref.GetPointer());
+    ASSERT_TRUE(result.has_value());
+
+    size_t filledCount = countForeground(*result);
+    // Triangle area ≈ 0.5 * 10 * 10 = 50
+    EXPECT_GT(filledCount, 20u) << "Triangle should have significant area";
+    EXPECT_LT(filledCount, 120u) << "Filled area should not exceed bounding box";
+}
+
+TEST(LevelTracingToolTest, ContourToMaskSquare) {
+    auto ref = createSlice(30, 30);
+    std::vector<IndexPoint> contour;
+
+    // Build a square contour: bottom edge, right edge, top edge, left edge
+    for (int x = 5; x <= 15; ++x) contour.push_back({x, 5});
+    for (int y = 6; y <= 15; ++y) contour.push_back({15, y});
+    for (int x = 14; x >= 5; --x) contour.push_back({x, 15});
+    for (int y = 14; y >= 6; --y) contour.push_back({5, y});
+
+    auto result = LevelTracingTool::contourToMask(contour, ref.GetPointer());
+    ASSERT_TRUE(result.has_value());
+
+    size_t filledCount = countForeground(*result);
+    // Square area: 11 * 11 = 121
+    EXPECT_GT(filledCount, 80u);
+}
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+TEST(LevelTracingToolTest, SinglePixelRegion) {
+    auto slice = createSlice(10, 10, 0.0f);
+    // Single bright pixel
+    FloatSlice2D::IndexType idx = {{5, 5}};
+    slice->SetPixel(idx, 200.0f);
+
+    IndexPoint seed = {5, 5};
+    auto result = LevelTracingTool::traceAndFill(slice.GetPointer(), seed);
+    ASSERT_TRUE(result.has_value());
+
+    size_t count = countForeground(*result);
+    EXPECT_EQ(count, 1u) << "Single pixel should produce single-pixel mask";
+}
+
+TEST(LevelTracingToolTest, SeedOnBackgroundWithDefaultTolerance) {
+    auto slice = createSlice(20, 20, 0.0f);
+    drawRect(slice, 8, 8, 12, 12, 200.0f);
+
+    // Seed on background (intensity=0), default tolerance=5% of 200=10
+    // Band: [-10, 10] — doesn't overlap with 200, so only background floods
+    IndexPoint seed = {2, 2};
+    auto result = LevelTracingTool::traceAndFill(slice.GetPointer(), seed);
+    ASSERT_TRUE(result.has_value());
+
+    // The filled region should be the background, not the rectangle
+    BinarySlice2D::IndexType rectCenter = {{10, 10}};
+    EXPECT_EQ(result.value()->GetPixel(rectCenter), 0)
+        << "Rectangle should not be in background flood fill";
+}
+
+TEST(LevelTracingToolTest, CustomForegroundValue) {
+    auto slice = createSlice(20, 20, 0.0f);
+    drawRect(slice, 5, 5, 15, 15, 200.0f);
+
+    IndexPoint seed = {10, 10};
+    LevelTracingTool::Config config;
+    config.tolerancePct = 5.0;
+    config.foregroundValue = 255;
+
+    auto result = LevelTracingTool::traceAndFill(
+        slice.GetPointer(), seed, config);
+    ASSERT_TRUE(result.has_value());
+
+    BinarySlice2D::IndexType centerIdx = {{10, 10}};
+    EXPECT_EQ(result.value()->GetPixel(centerIdx), 255);
+}


### PR DESCRIPTION
Closes #302

## Summary
- Implement edge-following contour tool using BFS flood-fill within intensity tolerance band from seed point
- Add Moore neighborhood boundary tracing for extracting ordered contour points
- Add scanline ray-casting for contour-to-mask polygon fill conversion
- Provide traceAndFill convenience method that reuses flood-fill result directly as the mask
- Support configurable tolerance band as percentage of image intensity range

Part of #255 (completes all three tools: HollowTool #298, MaskSmoother #298, LevelTracingTool #302)

## Test Plan
- [x] 18 unit tests all passing (input validation, rectangle/circle tracing, tolerance band handling, contour-to-mask conversion, edge cases)
- [x] Synthetic edge images validate contour accuracy and flood-fill correctness
- [x] Build verified with cmake + clang on macOS