### PR TITLE
fix(quality): suppress [[nodiscard]] warnings from discarded return values

### DIFF
--- a/src/services/measurement/area_measurement_tool.cpp
+++ b/src/services/measurement/area_measurement_tool.cpp
@@ -1205,7 +1205,8 @@ AreaMeasurementTool::copyRoiToSliceRange(int measurementId, int startSlice, int 
         if (!result) {
             // If one copy fails, delete all previously created copies and return error
             for (int id : newIds) {
-                deleteMeasurement(id);
+                // Best-effort cleanup; ignore errors since we're already in error path
+                (void)deleteMeasurement(id);
             }
             return std::unexpected(result.error());
         }

--- a/tests/unit/data_serializer_test.cpp
+++ b/tests/unit/data_serializer_test.cpp
@@ -380,7 +380,7 @@ TEST(DataSerializer, AnalysisResultsZipRoundtrip) {
 
     auto tmpPath = std::filesystem::temp_directory_path()
                    / "data_serializer_test_analysis.flo";
-    zip.writeTo(tmpPath);
+    (void)zip.writeTo(tmpPath);
 
     auto readResult = ZipArchive::readFrom(tmpPath);
     ASSERT_TRUE(readResult.has_value());
@@ -477,11 +477,11 @@ TEST(DataSerializer, ZipCompressionReducesSize) {
     std::vector<DataSerializer::LabelDefinition> labels = {{1, "ROI", {1,0,0}, 1}};
 
     ZipArchive zip;
-    DataSerializer::saveMask(zip, mask.GetPointer(), labels);
+    (void)DataSerializer::saveMask(zip, mask.GetPointer(), labels);
 
     auto tmpPath = std::filesystem::temp_directory_path()
                    / "data_serializer_compression.flo";
-    zip.writeTo(tmpPath);
+    (void)zip.writeTo(tmpPath);
 
     auto fileSize = std::filesystem::file_size(tmpPath);
     size_t rawSize = 64 * 64 * 64;  // 262144 bytes raw

--- a/tests/unit/project_manager_test.cpp
+++ b/tests/unit/project_manager_test.cpp
@@ -285,7 +285,7 @@ TEST(ProjectManagerTest, LoadMissingManifest) {
     // Write valid ZIP but without manifest.json
     ZipArchive zip;
     zip.addEntry("patient.json", "{}");
-    zip.writeTo(tmp.path());
+    (void)zip.writeTo(tmp.path());
 
     ProjectManager pm;
     auto result = pm.loadProject(tmp.path());
@@ -299,7 +299,7 @@ TEST(ProjectManagerTest, LoadInvalidManifestFormat) {
     // Write valid ZIP with wrong format identifier
     ZipArchive zip;
     zip.addEntry("manifest.json", R"({"format": "wrong_format", "version": 1})");
-    zip.writeTo(tmp.path());
+    (void)zip.writeTo(tmp.path());
 
     ProjectManager pm;
     auto result = pm.loadProject(tmp.path());
@@ -314,7 +314,7 @@ TEST(ProjectManagerTest, LoadIncompatibleVersion) {
     ZipArchive zip;
     zip.addEntry("manifest.json",
         R"({"format": "dicom_viewer_project", "version": 999})");
-    zip.writeTo(tmp.path());
+    (void)zip.writeTo(tmp.path());
 
     ProjectManager pm;
     auto result = pm.loadProject(tmp.path());

--- a/tests/unit/temporal_navigator_test.cpp
+++ b/tests/unit/temporal_navigator_test.cpp
@@ -92,7 +92,7 @@ TEST(PhaseCacheTest, CachesLoadedPhases) {
     cache.setPhaseLoader(createMockLoader(20));
 
     EXPECT_FALSE(cache.isCached(3));
-    cache.getPhase(3);
+    (void)cache.getPhase(3);
     EXPECT_TRUE(cache.isCached(3));
 }
 
@@ -100,15 +100,15 @@ TEST(PhaseCacheTest, LRUEviction) {
     PhaseCache cache(3);  // Max 3 phases
     cache.setPhaseLoader(createMockLoader(20));
 
-    cache.getPhase(0);
-    cache.getPhase(1);
-    cache.getPhase(2);
+    (void)cache.getPhase(0);
+    (void)cache.getPhase(1);
+    (void)cache.getPhase(2);
     EXPECT_TRUE(cache.isCached(0));
     EXPECT_TRUE(cache.isCached(1));
     EXPECT_TRUE(cache.isCached(2));
 
     // Loading phase 3 should evict phase 0 (oldest)
-    cache.getPhase(3);
+    (void)cache.getPhase(3);
     EXPECT_FALSE(cache.isCached(0));
     EXPECT_TRUE(cache.isCached(1));
     EXPECT_TRUE(cache.isCached(2));
@@ -119,15 +119,15 @@ TEST(PhaseCacheTest, LRUTouchReorders) {
     PhaseCache cache(3);
     cache.setPhaseLoader(createMockLoader(20));
 
-    cache.getPhase(0);
-    cache.getPhase(1);
-    cache.getPhase(2);
+    (void)cache.getPhase(0);
+    (void)cache.getPhase(1);
+    (void)cache.getPhase(2);
 
     // Touch phase 0 again — now 1 is the oldest
-    cache.getPhase(0);
+    (void)cache.getPhase(0);
 
     // Loading phase 3 should evict phase 1 (now oldest)
-    cache.getPhase(3);
+    (void)cache.getPhase(3);
     EXPECT_TRUE(cache.isCached(0));   // Recently touched
     EXPECT_FALSE(cache.isCached(1));  // Evicted
     EXPECT_TRUE(cache.isCached(2));
@@ -138,9 +138,9 @@ TEST(PhaseCacheTest, GetCachedPhases) {
     PhaseCache cache(5);
     cache.setPhaseLoader(createMockLoader(20));
 
-    cache.getPhase(5);
-    cache.getPhase(2);
-    cache.getPhase(8);
+    (void)cache.getPhase(5);
+    (void)cache.getPhase(2);
+    (void)cache.getPhase(8);
 
     auto phases = cache.getCachedPhases();
     ASSERT_EQ(phases.size(), 3);
@@ -153,8 +153,8 @@ TEST(PhaseCacheTest, Clear) {
     PhaseCache cache(5);
     cache.setPhaseLoader(createMockLoader(20));
 
-    cache.getPhase(0);
-    cache.getPhase(1);
+    (void)cache.getPhase(0);
+    (void)cache.getPhase(1);
     EXPECT_EQ(cache.getCachedPhases().size(), 2);
 
     cache.clear();
@@ -167,8 +167,8 @@ TEST(PhaseCacheTest, Status) {
     cache.setPhaseLoader(createMockLoader(20));
     cache.setTotalPhases(20);
 
-    cache.getPhase(0);
-    cache.getPhase(1);
+    (void)cache.getPhase(0);
+    (void)cache.getPhase(1);
 
     auto status = cache.getStatus();
     EXPECT_EQ(status.cachedCount, 2);
@@ -256,7 +256,7 @@ TEST(TemporalNavigatorTest, NextPhaseWraps) {
     nav.setPhaseLoader(createMockLoader(3));
     nav.setLooping(true);
 
-    nav.goToPhase(2);  // Last phase
+    (void)nav.goToPhase(2);  // Last phase
     auto result = nav.nextPhase();
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(nav.currentPhase(), 0);  // Wrapped to start
@@ -268,7 +268,7 @@ TEST(TemporalNavigatorTest, NextPhaseNoWrap) {
     nav.setPhaseLoader(createMockLoader(3));
     nav.setLooping(false);
 
-    nav.goToPhase(2);
+    (void)nav.goToPhase(2);
     auto result = nav.nextPhase();
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(nav.currentPhase(), 2);  // Stays at end
@@ -366,7 +366,7 @@ TEST(TemporalNavigatorTest, TickWrapsWithLooping) {
     nav.setPhaseLoader(createMockLoader(3));
     nav.setLooping(true);
 
-    nav.goToPhase(2);
+    (void)nav.goToPhase(2);
     nav.play();
     auto result = nav.tick();
     ASSERT_TRUE(result.has_value());
@@ -379,7 +379,7 @@ TEST(TemporalNavigatorTest, TickStopsWithoutLooping) {
     nav.setPhaseLoader(createMockLoader(3));
     nav.setLooping(false);
 
-    nav.goToPhase(2);
+    (void)nav.goToPhase(2);
     nav.play();
     auto result = nav.tick();
     ASSERT_FALSE(result.has_value());
@@ -407,7 +407,7 @@ TEST(TemporalNavigatorTest, PhaseChangedCallback) {
     int lastPhase = -1;
     nav.setPhaseChangedCallback([&](int p) { lastPhase = p; });
 
-    nav.goToPhase(7);
+    (void)nav.goToPhase(7);
     EXPECT_EQ(lastPhase, 7);
 }
 
@@ -438,7 +438,7 @@ TEST(TemporalNavigatorTest, CacheStatusCallback) {
         lastStatus = s;
     });
 
-    nav.goToPhase(3);
+    (void)nav.goToPhase(3);
     EXPECT_EQ(lastStatus.cachedCount, 1);
     EXPECT_EQ(lastStatus.totalPhases, 10);
 }


### PR DESCRIPTION
Closes #308

## Summary
- Add `(void)` casts to 29 instances of discarded `[[nodiscard]]` return values
- Fix 1 production code warning in `area_measurement_tool.cpp` (best-effort cleanup path)
- Fix 28 test code warnings across `project_manager_test.cpp`, `data_serializer_test.cpp`, and `temporal_navigator_test.cpp`

## Changes by File

| File | Instances | Functions |
|------|-----------|-----------|
| `area_measurement_tool.cpp` | 1 | `deleteMeasurement()` |
| `project_manager_test.cpp` | 3 | `zip.writeTo()` |
| `data_serializer_test.cpp` | 3 | `zip.writeTo()`, `DataSerializer::saveMask()` |
| `temporal_navigator_test.cpp` | 22 | `cache.getPhase()`, `nav.goToPhase()` |

## Test Plan
- [x] All 4 modified test suites pass (105 tests total)
- [x] Production build succeeds without `-Wunused-result` warnings
- [x] No behavioral changes — only explicit intent markers added