### PR TITLE
feat(core): add recent projects management to ProjectManager

### DIFF
--- a/include/core/project_manager.hpp
+++ b/include/core/project_manager.hpp
@@ -162,6 +162,41 @@ public:
     void setViewState(const ViewState& state);
     [[nodiscard]] const ViewState& viewState() const noexcept;
 
+    // -- Recent projects --
+
+    /**
+     * @brief Add a project path to the recent projects list
+     *
+     * If the path already exists, it is moved to the front.
+     * The list is capped at kMaxRecentProjects entries.
+     * Persists to disk if a recent projects path is configured.
+     *
+     * @param path Project file path
+     * @param name Display name (defaults to filename stem)
+     */
+    void addToRecent(const std::filesystem::path& path,
+                     const std::string& name = "");
+
+    /**
+     * @brief Get the list of recent projects (newest first)
+     */
+    [[nodiscard]] std::vector<RecentProject> recentProjects() const;
+
+    /**
+     * @brief Clear the recent projects list and persist
+     */
+    void clearRecentProjects();
+
+    /**
+     * @brief Set the file path used to persist recent projects
+     *
+     * If not set, recent projects are stored in memory only.
+     * The file uses JSON format.
+     *
+     * @param path Path to the recent projects JSON file
+     */
+    void setRecentProjectsPath(const std::filesystem::path& path);
+
     // -- State change notification --
 
     void setStateChangeCallback(StateChangeCallback callback);


### PR DESCRIPTION
Closes #237 (partial — Task 7: recent projects list)

## Summary
- Add `addToRecent()`, `recentProjects()`, `clearRecentProjects()`, and `setRecentProjectsPath()` to `ProjectManager`
- LRU-style deduplication: re-adding a path moves it to the front of the list
- Capped at `kMaxRecentProjects` (10) entries, oldest automatically dropped
- JSON-based disk persistence when `setRecentProjectsPath()` is configured
- Auto-registers projects on `saveProject()` and `loadProject()` success
- Gracefully handles missing or corrupt persistence files

## Test Plan
- [x] `AddToRecentBasic` — basic add and name derivation
- [x] `AddToRecentCustomName` — custom display name
- [x] `AddToRecentDeduplication` — re-add moves to front
- [x] `AddToRecentMaxLimit` — enforces max 10 entries
- [x] `ClearRecentProjects` — clears in-memory list
- [x] `RecentProjectsPersistence` — save/load roundtrip via JSON file
- [x] `RecentProjectsPersistenceCorruptFile` — graceful recovery
- [x] `SaveAutoAddsToRecent` — auto-add on save
- [x] `LoadAutoAddsToRecent` — auto-add on load
- [x] `ClearRecentPersists` — clear persists to disk
- [x] `NewProjectDoesNotClearRecent` — newProject preserves recent list
- [x] All 30 project_manager_test cases pass (6 ZipArchive + 24 ProjectManager)