### PR TITLE
feat(enhanced-dicom): integrate SeriesClassifier with DICOM loading pipeline

### DIFF
--- a/include/services/enhanced_dicom/series_classifier.hpp
+++ b/include/services/enhanced_dicom/series_classifier.hpp
@@ -5,6 +5,10 @@
 
 #include <itkMetaDataDictionary.h>
 
+namespace dicom_viewer::core {
+struct SeriesInfo;
+}  // namespace dicom_viewer::core
+
 namespace dicom_viewer::services {
 
 /**
@@ -111,6 +115,19 @@ public:
      */
     [[nodiscard]] static std::vector<ClassifiedSeries> classifyStudy(
         const std::vector<std::string>& seriesFiles);
+
+    /**
+     * @brief Classify series from scan results
+     *
+     * Bridge between SeriesBuilder::scanForSeries() and classification.
+     * Reads the first DICOM file from each series to classify its type.
+     * Series with no slices are classified as Unknown.
+     *
+     * @param scannedSeries Results from SeriesBuilder::scanForSeries()
+     * @return Classification for each series (same order and size)
+     */
+    [[nodiscard]] static std::vector<ClassifiedSeries> classifyScannedSeries(
+        const std::vector<core::SeriesInfo>& scannedSeries);
 
     /**
      * @brief Check if a SeriesType is a 4D Flow component

--- a/src/services/enhanced_dicom/series_classifier.cpp
+++ b/src/services/enhanced_dicom/series_classifier.cpp
@@ -1,5 +1,7 @@
 #include "services/enhanced_dicom/series_classifier.hpp"
 
+#include "core/series_builder.hpp"
+
 #include <algorithm>
 #include <string>
 
@@ -303,6 +305,27 @@ std::vector<ClassifiedSeries> SeriesClassifier::classifyStudy(
     results.reserve(seriesFiles.size());
     for (const auto& file : seriesFiles) {
         results.push_back(classifyFile(file));
+    }
+    return results;
+}
+
+std::vector<ClassifiedSeries> SeriesClassifier::classifyScannedSeries(
+    const std::vector<core::SeriesInfo>& scannedSeries) {
+    std::vector<ClassifiedSeries> results;
+    results.reserve(scannedSeries.size());
+    for (const auto& info : scannedSeries) {
+        if (info.slices.empty()) {
+            results.push_back(ClassifiedSeries{
+                SeriesType::Unknown,
+                info.seriesInstanceUid,
+                info.seriesDescription,
+                info.modality,
+                false
+            });
+        } else {
+            results.push_back(
+                classifyFile(info.slices.front().filePath.string()));
+        }
     }
     return results;
 }


### PR DESCRIPTION
Refs #247 (partial — Task: Integrate with existing DICOM loading pipeline)

## Summary
- Add `classifyScannedSeries()` static method to `SeriesClassifier` as a bridge between `SeriesBuilder::scanForSeries()` results and series type classification
- Maintains correct dependency direction: `services/enhanced_dicom` → `core/` (no circular dependency)
- Handles edge cases: empty series list, series with no slices (fallback to Unknown)
- Add 10 new tests: 7 vendor-specific edge cases + 3 integration tests (total: 30)

### Vendor edge case tests added
- Siemens "SI" (Superior-Inferior) direction → maps to `Flow4D_Phase_FH`
- GE "SI" direction → maps to `Flow4D_Phase_FH`
- StarVIBE underscore variant ("STAR_VIBE") detection
- Case-insensitive DIXON/CINE description matching
- PCMRA without hyphen ("PCMRA" vs "PC-MRA")
- Phase contrast detection via (0018,9014) DICOM tag

## Test Plan
- [x] All 30 series_classifier_test cases pass
- [x] Full build succeeds with no new warnings
- [x] `classifyScannedSeries()` handles empty input
- [x] `classifyScannedSeries()` handles series with no slices (Unknown fallback)
- [x] `classifyScannedSeries()` preserves input order
- [x] All vendor direction edge cases verified