### PR TITLE
feat(ui): add ViewportLayoutManager with 1/2/4-split layout modes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -581,6 +581,7 @@ target_link_libraries(cardiac_service PUBLIC
 add_library(dicom_viewer_ui STATIC
     src/ui/main_window.cpp
     src/ui/widgets/viewport_widget.cpp
+    src/ui/widgets/viewport_layout_manager.cpp
     src/ui/widgets/mpr_widget.cpp
     src/ui/widgets/mpr_view_widget.cpp
     src/ui/widgets/dr_viewer.cpp
@@ -595,6 +596,7 @@ add_library(dicom_viewer_ui STATIC
     # Headers with Q_OBJECT for AUTOMOC
     include/ui/main_window.hpp
     include/ui/viewport_widget.hpp
+    include/ui/viewport_layout_manager.hpp
     include/ui/mpr_view_widget.hpp
     include/ui/dr_viewer.hpp
     include/ui/widgets/phase_slider_widget.hpp

--- a/include/ui/viewport_layout_manager.hpp
+++ b/include/ui/viewport_layout_manager.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <memory>
+#include <QWidget>
+
+namespace dicom_viewer::ui {
+
+class ViewportWidget;
+
+/**
+ * @brief Layout mode for viewport arrangement
+ */
+enum class LayoutMode {
+    Single,     ///< Single viewport (default)
+    DualSplit,  ///< Side-by-side: 2D slice | 3D rendering
+    QuadSplit   ///< 2x2 grid: Axial | Sagittal | Coronal | 3D
+};
+
+/**
+ * @brief Manages viewport layout with 1/2/4-split modes
+ *
+ * Uses QStackedWidget to switch between layout containers.
+ * Each layout mode creates the required ViewportWidgets and
+ * arranges them with splitters or grid layouts.
+ *
+ * @trace SRS-FR-005
+ */
+class ViewportLayoutManager : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ViewportLayoutManager(QWidget* parent = nullptr);
+    ~ViewportLayoutManager() override;
+
+    // Non-copyable
+    ViewportLayoutManager(const ViewportLayoutManager&) = delete;
+    ViewportLayoutManager& operator=(const ViewportLayoutManager&) = delete;
+
+    /**
+     * @brief Get current layout mode
+     */
+    [[nodiscard]] LayoutMode layoutMode() const;
+
+    /**
+     * @brief Get the primary (always-available) viewport
+     *
+     * In Single mode this is the only viewport.
+     * In DualSplit this is the left (2D) viewport.
+     * In QuadSplit this is the top-left (Axial) viewport.
+     */
+    [[nodiscard]] ViewportWidget* primaryViewport() const;
+
+    /**
+     * @brief Get a viewport by index
+     * @param index 0-based viewport index
+     * @return ViewportWidget pointer, or nullptr if index is out of range
+     *
+     * Index mapping per mode:
+     *   Single:    0 = primary
+     *   DualSplit: 0 = 2D, 1 = 3D
+     *   QuadSplit: 0 = Axial, 1 = Sagittal, 2 = Coronal, 3 = 3D
+     */
+    [[nodiscard]] ViewportWidget* viewport(int index) const;
+
+    /**
+     * @brief Get the number of active viewports in current mode
+     */
+    [[nodiscard]] int viewportCount() const;
+
+public slots:
+    /**
+     * @brief Switch layout mode
+     * @param mode New layout mode
+     */
+    void setLayoutMode(LayoutMode mode);
+
+signals:
+    /**
+     * @brief Emitted when layout mode changes
+     * @param mode New layout mode
+     */
+    void layoutModeChanged(LayoutMode mode);
+
+private:
+    void buildSingleLayout();
+    void buildDualLayout();
+    void buildQuadLayout();
+
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::ui

--- a/include/ui/viewport_widget.hpp
+++ b/include/ui/viewport_widget.hpp
@@ -28,6 +28,15 @@ enum class ViewportMode {
 };
 
 /**
+ * @brief Slice orientation for 2D views
+ */
+enum class SliceOrientation {
+    Axial,      // XY plane (Z-axis slicing, default)
+    Coronal,    // XZ plane (Y-axis slicing)
+    Sagittal    // YZ plane (X-axis slicing)
+};
+
+/**
  * @brief VTK viewport widget for medical image visualization
  *
  * Wraps QVTKOpenGLNativeWidget and provides high-level interface
@@ -62,6 +71,17 @@ public:
      * @brief Get current viewport mode
      */
     ViewportMode getMode() const;
+
+    /**
+     * @brief Set slice orientation for 2D views
+     * @param orientation Axial, Coronal, or Sagittal
+     */
+    void setSliceOrientation(SliceOrientation orientation);
+
+    /**
+     * @brief Get current slice orientation
+     */
+    SliceOrientation getSliceOrientation() const;
 
     /**
      * @brief Set window/level for 2D views

--- a/src/ui/widgets/viewport_layout_manager.cpp
+++ b/src/ui/widgets/viewport_layout_manager.cpp
@@ -1,0 +1,189 @@
+#include "ui/viewport_layout_manager.hpp"
+#include "ui/viewport_widget.hpp"
+
+#include <QGridLayout>
+#include <QLabel>
+#include <QSplitter>
+#include <QStackedWidget>
+#include <QVBoxLayout>
+
+namespace dicom_viewer::ui {
+
+class ViewportLayoutManager::Impl {
+public:
+    LayoutMode mode = LayoutMode::Single;
+    QStackedWidget* stack = nullptr;
+
+    // Layout containers (one per mode)
+    QWidget* singleContainer = nullptr;
+    QSplitter* dualContainer = nullptr;
+    QWidget* quadContainer = nullptr;
+
+    // Viewports: max 4 (Axial, Sagittal, Coronal, 3D)
+    // Index 0 is always the "primary" viewport.
+    ViewportWidget* viewports[4] = {};
+    bool layoutBuilt[3] = {};  // Track which layouts have been built
+};
+
+ViewportLayoutManager::ViewportLayoutManager(QWidget* parent)
+    : QWidget(parent)
+    , impl_(std::make_unique<Impl>())
+{
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(0);
+
+    impl_->stack = new QStackedWidget(this);
+    layout->addWidget(impl_->stack);
+
+    // Build the default (Single) layout immediately
+    buildSingleLayout();
+    impl_->stack->setCurrentIndex(0);
+}
+
+ViewportLayoutManager::~ViewportLayoutManager() = default;
+
+LayoutMode ViewportLayoutManager::layoutMode() const
+{
+    return impl_->mode;
+}
+
+ViewportWidget* ViewportLayoutManager::primaryViewport() const
+{
+    return impl_->viewports[0];
+}
+
+ViewportWidget* ViewportLayoutManager::viewport(int index) const
+{
+    if (index < 0 || index >= viewportCount()) return nullptr;
+    return impl_->viewports[index];
+}
+
+int ViewportLayoutManager::viewportCount() const
+{
+    switch (impl_->mode) {
+        case LayoutMode::Single:    return 1;
+        case LayoutMode::DualSplit: return 2;
+        case LayoutMode::QuadSplit: return 4;
+    }
+    return 1;
+}
+
+void ViewportLayoutManager::setLayoutMode(LayoutMode mode)
+{
+    if (impl_->mode == mode) return;
+    impl_->mode = mode;
+
+    switch (mode) {
+        case LayoutMode::Single:
+            if (!impl_->layoutBuilt[0]) buildSingleLayout();
+            impl_->stack->setCurrentIndex(0);
+            break;
+        case LayoutMode::DualSplit:
+            if (!impl_->layoutBuilt[1]) buildDualLayout();
+            impl_->stack->setCurrentIndex(1);
+            break;
+        case LayoutMode::QuadSplit:
+            if (!impl_->layoutBuilt[2]) buildQuadLayout();
+            impl_->stack->setCurrentIndex(2);
+            break;
+    }
+
+    emit layoutModeChanged(mode);
+}
+
+void ViewportLayoutManager::buildSingleLayout()
+{
+    impl_->singleContainer = new QWidget(impl_->stack);
+    auto* layout = new QVBoxLayout(impl_->singleContainer);
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    // Viewport 0 is always the primary, shared across all modes
+    if (!impl_->viewports[0]) {
+        impl_->viewports[0] = new ViewportWidget(impl_->singleContainer);
+    }
+    impl_->viewports[0]->setParent(impl_->singleContainer);
+    layout->addWidget(impl_->viewports[0]);
+
+    impl_->stack->addWidget(impl_->singleContainer);
+    impl_->layoutBuilt[0] = true;
+}
+
+void ViewportLayoutManager::buildDualLayout()
+{
+    impl_->dualContainer = new QSplitter(Qt::Horizontal, impl_->stack);
+    impl_->dualContainer->setHandleWidth(3);
+
+    // Left: 2D slice (reuse or create viewport 0)
+    if (!impl_->viewports[0]) {
+        impl_->viewports[0] = new ViewportWidget(impl_->dualContainer);
+    }
+    impl_->viewports[0]->setParent(impl_->dualContainer);
+    impl_->dualContainer->addWidget(impl_->viewports[0]);
+
+    // Right: 3D view
+    if (!impl_->viewports[1]) {
+        impl_->viewports[1] = new ViewportWidget(impl_->dualContainer);
+        impl_->viewports[1]->setMode(ViewportMode::VolumeRendering);
+    }
+    impl_->dualContainer->addWidget(impl_->viewports[1]);
+
+    // Equal split by default
+    impl_->dualContainer->setSizes({1, 1});
+
+    impl_->stack->addWidget(impl_->dualContainer);
+    impl_->layoutBuilt[1] = true;
+}
+
+void ViewportLayoutManager::buildQuadLayout()
+{
+    impl_->quadContainer = new QWidget(impl_->stack);
+    auto* grid = new QGridLayout(impl_->quadContainer);
+    grid->setContentsMargins(0, 0, 0, 0);
+    grid->setSpacing(2);
+
+    // Create viewports for each quadrant if not already present
+    // 0: Axial (top-left)
+    if (!impl_->viewports[0]) {
+        impl_->viewports[0] = new ViewportWidget(impl_->quadContainer);
+    }
+    impl_->viewports[0]->setParent(impl_->quadContainer);
+    impl_->viewports[0]->setSliceOrientation(SliceOrientation::Axial);
+
+    // 1: Sagittal (top-right)
+    if (!impl_->viewports[1]) {
+        impl_->viewports[1] = new ViewportWidget(impl_->quadContainer);
+    }
+    impl_->viewports[1]->setParent(impl_->quadContainer);
+    impl_->viewports[1]->setSliceOrientation(SliceOrientation::Sagittal);
+
+    // 2: Coronal (bottom-left)
+    if (!impl_->viewports[2]) {
+        impl_->viewports[2] = new ViewportWidget(impl_->quadContainer);
+    }
+    impl_->viewports[2]->setParent(impl_->quadContainer);
+    impl_->viewports[2]->setSliceOrientation(SliceOrientation::Coronal);
+
+    // 3: 3D (bottom-right)
+    if (!impl_->viewports[3]) {
+        impl_->viewports[3] = new ViewportWidget(impl_->quadContainer);
+        impl_->viewports[3]->setMode(ViewportMode::VolumeRendering);
+    }
+    impl_->viewports[3]->setParent(impl_->quadContainer);
+
+    grid->addWidget(impl_->viewports[0], 0, 0);
+    grid->addWidget(impl_->viewports[1], 0, 1);
+    grid->addWidget(impl_->viewports[2], 1, 0);
+    grid->addWidget(impl_->viewports[3], 1, 1);
+
+    // Equal stretch
+    grid->setRowStretch(0, 1);
+    grid->setRowStretch(1, 1);
+    grid->setColumnStretch(0, 1);
+    grid->setColumnStretch(1, 1);
+
+    impl_->stack->addWidget(impl_->quadContainer);
+    impl_->layoutBuilt[2] = true;
+}
+
+} // namespace dicom_viewer::ui

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1351,6 +1351,24 @@ target_include_directories(phase_slider_widget_test PRIVATE
 
 gtest_discover_tests(phase_slider_widget_test DISCOVERY_TIMEOUT 60)
 
+# Viewport layout manager tests
+add_executable(viewport_layout_manager_test
+    unit/viewport_layout_manager_test.cpp
+)
+
+target_link_libraries(viewport_layout_manager_test PRIVATE
+    dicom_viewer_ui
+    Qt6::Test
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(viewport_layout_manager_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(viewport_layout_manager_test DISCOVERY_TIMEOUT 60)
+
 # Unit tests for Segmentation Command Stack and BrushStrokeCommand
 add_executable(segmentation_command_test
     unit/segmentation_command_test.cpp

--- a/tests/unit/viewport_layout_manager_test.cpp
+++ b/tests/unit/viewport_layout_manager_test.cpp
@@ -1,0 +1,159 @@
+#include <gtest/gtest.h>
+
+#include <QApplication>
+
+#include "ui/viewport_layout_manager.hpp"
+#include "ui/viewport_widget.hpp"
+
+using namespace dicom_viewer::ui;
+
+namespace {
+
+// QApplication must exist for QWidget instantiation
+int argc = 0;
+char* argv[] = {nullptr};
+QApplication app(argc, argv);
+
+}  // anonymous namespace
+
+// =============================================================================
+// Construction and defaults
+// =============================================================================
+
+TEST(ViewportLayoutManagerTest, DefaultConstruction) {
+    ViewportLayoutManager manager;
+    EXPECT_EQ(manager.layoutMode(), LayoutMode::Single);
+    EXPECT_EQ(manager.viewportCount(), 1);
+    EXPECT_NE(manager.primaryViewport(), nullptr);
+}
+
+TEST(ViewportLayoutManagerTest, PrimaryViewportAlwaysValid) {
+    ViewportLayoutManager manager;
+    auto* primary = manager.primaryViewport();
+    ASSERT_NE(primary, nullptr);
+    EXPECT_EQ(manager.viewport(0), primary);
+}
+
+// =============================================================================
+// Layout mode switching
+// =============================================================================
+
+TEST(ViewportLayoutManagerTest, SetLayoutModeDual) {
+    ViewportLayoutManager manager;
+    manager.setLayoutMode(LayoutMode::DualSplit);
+
+    EXPECT_EQ(manager.layoutMode(), LayoutMode::DualSplit);
+    EXPECT_EQ(manager.viewportCount(), 2);
+    EXPECT_NE(manager.viewport(0), nullptr);
+    EXPECT_NE(manager.viewport(1), nullptr);
+}
+
+TEST(ViewportLayoutManagerTest, SetLayoutModeQuad) {
+    ViewportLayoutManager manager;
+    manager.setLayoutMode(LayoutMode::QuadSplit);
+
+    EXPECT_EQ(manager.layoutMode(), LayoutMode::QuadSplit);
+    EXPECT_EQ(manager.viewportCount(), 4);
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_NE(manager.viewport(i), nullptr) << "viewport " << i;
+    }
+}
+
+TEST(ViewportLayoutManagerTest, SetLayoutModeSingleFromQuad) {
+    ViewportLayoutManager manager;
+    manager.setLayoutMode(LayoutMode::QuadSplit);
+    manager.setLayoutMode(LayoutMode::Single);
+
+    EXPECT_EQ(manager.layoutMode(), LayoutMode::Single);
+    EXPECT_EQ(manager.viewportCount(), 1);
+}
+
+TEST(ViewportLayoutManagerTest, ViewportOutOfRange_ReturnsNull) {
+    ViewportLayoutManager manager;
+    EXPECT_EQ(manager.viewport(1), nullptr);
+    EXPECT_EQ(manager.viewport(-1), nullptr);
+}
+
+// =============================================================================
+// Signal emission
+// =============================================================================
+
+TEST(ViewportLayoutManagerTest, LayoutModeChangedSignal) {
+    ViewportLayoutManager manager;
+    bool signalReceived = false;
+    LayoutMode receivedMode = LayoutMode::Single;
+
+    QObject::connect(&manager, &ViewportLayoutManager::layoutModeChanged,
+                     [&](LayoutMode mode) {
+        signalReceived = true;
+        receivedMode = mode;
+    });
+
+    manager.setLayoutMode(LayoutMode::DualSplit);
+    EXPECT_TRUE(signalReceived);
+    EXPECT_EQ(receivedMode, LayoutMode::DualSplit);
+}
+
+TEST(ViewportLayoutManagerTest, SameMode_NoSignal) {
+    ViewportLayoutManager manager;
+    bool signalReceived = false;
+
+    QObject::connect(&manager, &ViewportLayoutManager::layoutModeChanged,
+                     [&](LayoutMode) { signalReceived = true; });
+
+    manager.setLayoutMode(LayoutMode::Single);  // already Single
+    EXPECT_FALSE(signalReceived);
+}
+
+// =============================================================================
+// Quad split orientation tests
+// =============================================================================
+
+TEST(ViewportLayoutManagerTest, QuadSplit_Orientations) {
+    ViewportLayoutManager manager;
+    manager.setLayoutMode(LayoutMode::QuadSplit);
+
+    EXPECT_EQ(manager.viewport(0)->getSliceOrientation(), SliceOrientation::Axial);
+    EXPECT_EQ(manager.viewport(1)->getSliceOrientation(), SliceOrientation::Sagittal);
+    EXPECT_EQ(manager.viewport(2)->getSliceOrientation(), SliceOrientation::Coronal);
+}
+
+TEST(ViewportLayoutManagerTest, QuadSplit_3DViewport) {
+    ViewportLayoutManager manager;
+    manager.setLayoutMode(LayoutMode::QuadSplit);
+
+    EXPECT_EQ(manager.viewport(3)->getMode(), ViewportMode::VolumeRendering);
+}
+
+// =============================================================================
+// DualSplit mode configuration
+// =============================================================================
+
+TEST(ViewportLayoutManagerTest, DualSplit_3DViewport) {
+    ViewportLayoutManager manager;
+    manager.setLayoutMode(LayoutMode::DualSplit);
+
+    EXPECT_EQ(manager.viewport(1)->getMode(), ViewportMode::VolumeRendering);
+}
+
+// =============================================================================
+// SliceOrientation tests (on ViewportWidget directly)
+// =============================================================================
+
+TEST(ViewportWidgetOrientationTest, DefaultOrientation) {
+    ViewportWidget widget;
+    EXPECT_EQ(widget.getSliceOrientation(), SliceOrientation::Axial);
+}
+
+TEST(ViewportWidgetOrientationTest, SetOrientation) {
+    ViewportWidget widget;
+
+    widget.setSliceOrientation(SliceOrientation::Coronal);
+    EXPECT_EQ(widget.getSliceOrientation(), SliceOrientation::Coronal);
+
+    widget.setSliceOrientation(SliceOrientation::Sagittal);
+    EXPECT_EQ(widget.getSliceOrientation(), SliceOrientation::Sagittal);
+
+    widget.setSliceOrientation(SliceOrientation::Axial);
+    EXPECT_EQ(widget.getSliceOrientation(), SliceOrientation::Axial);
+}


### PR DESCRIPTION
Closes #319
Part of #244

## Summary
- Add `ViewportLayoutManager` class with `LayoutMode` enum (Single, DualSplit, QuadSplit)
- Add `SliceOrientation` enum and `setSliceOrientation()` to `ViewportWidget` (Axial/Coronal/Sagittal via `vtkImageSliceMapper::SetOrientation()`)
- Add 1x1/1x2/2x2 toggle buttons to the MainWindow toolbar
- Replace single `ViewportWidget` central widget with `ViewportLayoutManager`
- Lazy layout construction: only build layout containers when first accessed

## Layout Modes

| Mode | Arrangement | Description |
|------|-------------|-------------|
| Single | 1x1 | Full-size viewport (default, current behavior) |
| DualSplit | 1x2 | QSplitter: 2D slice \| 3D volume rendering |
| QuadSplit | 2x2 | QGridLayout: Axial \| Sagittal \| Coronal \| 3D |

## Files Changed

| File | Description |
|------|-------------|
| `viewport_layout_manager.hpp/cpp` | New: LayoutMode enum, QStackedWidget-based layout manager |
| `viewport_widget.hpp/cpp` | Add SliceOrientation enum and setSliceOrientation() |
| `main_window.cpp` | Add ViewportLayoutManager as central widget, toolbar buttons |
| `CMakeLists.txt` | Register new source and header files |
| `tests/CMakeLists.txt` | Register new test target |
| `viewport_layout_manager_test.cpp` | 13 unit tests |

## Test Plan
- [x] All 13 ViewportLayoutManager tests pass
- [x] All 16 PhaseSliderWidget tests still pass
- [x] Build succeeds with no new compiler errors
- [ ] Manual: verify toolbar 1x1/1x2/2x2 buttons switch layout
- [ ] Manual: verify 4-split shows correct orientations per quadrant