### PR TITLE
feat(ui): wire Ctrl+Z/Ctrl+Y undo/redo for segmentation command stack

### DIFF
--- a/include/ui/panels/segmentation_panel.hpp
+++ b/include/ui/panels/segmentation_panel.hpp
@@ -68,6 +68,13 @@ public:
      */
     void resetToDefaults();
 
+    /**
+     * @brief Update enabled state of undo/redo buttons
+     * @param canUndo Whether undo is available
+     * @param canRedo Whether redo is available
+     */
+    void setUndoRedoEnabled(bool canUndo, bool canRedo);
+
 signals:
     /**
      * @brief Emitted when segmentation tool changes
@@ -113,6 +120,16 @@ signals:
      * @brief Emitted when complete is requested for polygon/smart scissors
      */
     void completeRequested();
+
+    /**
+     * @brief Emitted when command stack undo is requested (Ctrl+Z)
+     */
+    void undoCommandRequested();
+
+    /**
+     * @brief Emitted when command stack redo is requested (Ctrl+Y)
+     */
+    void redoCommandRequested();
 
 private slots:
     void onToolButtonClicked(int toolId);

--- a/include/ui/viewport_widget.hpp
+++ b/include/ui/viewport_widget.hpp
@@ -187,6 +187,18 @@ public:
     void undoSegmentationOperation();
 
     /**
+     * @brief Undo last segmentation command (command stack undo)
+     * @return true if an undo was performed
+     */
+    bool undoSegmentationCommand();
+
+    /**
+     * @brief Redo last undone segmentation command (command stack redo)
+     * @return true if a redo was performed
+     */
+    bool redoSegmentationCommand();
+
+    /**
      * @brief Complete current segmentation operation (polygon/smart scissors)
      */
     void completeSegmentationOperation();
@@ -235,6 +247,9 @@ signals:
 
     /// Emitted when scroll wheel is used in Phase mode
     void phaseScrollRequested(int delta);
+
+    /// Emitted when undo/redo availability changes for segmentation command stack
+    void segmentationUndoRedoChanged(bool canUndo, bool canRedo);
 
 public slots:
     /// Set crosshair position from external source

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -78,6 +78,10 @@ public:
     services::TemporalNavigator temporalNavigator;
     QTimer* cineTimer = nullptr;
 
+    // Edit menu actions
+    QAction* undoAction = nullptr;
+    QAction* redoAction = nullptr;
+
     // Measurement actions
     QAction* distanceAction = nullptr;
     QAction* angleAction = nullptr;
@@ -172,13 +176,17 @@ void MainWindow::setupMenuBar()
     // Edit menu
     auto editMenu = menuBar()->addMenu(tr("&Edit"));
 
-    auto undoAction = editMenu->addAction(tr("&Undo"));
-    undoAction->setShortcut(QKeySequence::Undo);
-    undoAction->setEnabled(false);
+    impl_->undoAction = editMenu->addAction(tr("&Undo"));
+    impl_->undoAction->setShortcut(QKeySequence::Undo);
+    impl_->undoAction->setEnabled(false);
+    connect(impl_->undoAction, &QAction::triggered,
+            this, [this]() { impl_->viewport->undoSegmentationCommand(); });
 
-    auto redoAction = editMenu->addAction(tr("&Redo"));
-    redoAction->setShortcut(QKeySequence::Redo);
-    redoAction->setEnabled(false);
+    impl_->redoAction = editMenu->addAction(tr("&Redo"));
+    impl_->redoAction->setShortcut(QKeySequence::Redo);
+    impl_->redoAction->setEnabled(false);
+    connect(impl_->redoAction, &QAction::triggered,
+            this, [this]() { impl_->viewport->redoSegmentationCommand(); });
 
     editMenu->addSeparator();
 
@@ -623,11 +631,23 @@ void MainWindow::setupConnections()
             impl_->viewport, &ViewportWidget::completeSegmentationOperation);
     connect(impl_->segmentationPanel, &SegmentationPanel::clearAllRequested,
             impl_->viewport, &ViewportWidget::clearAllSegmentation);
+    connect(impl_->segmentationPanel, &SegmentationPanel::undoCommandRequested,
+            impl_->viewport, &ViewportWidget::undoSegmentationCommand);
+    connect(impl_->segmentationPanel, &SegmentationPanel::redoCommandRequested,
+            impl_->viewport, &ViewportWidget::redoSegmentationCommand);
 
     // Segmentation status updates
     connect(impl_->viewport, &ViewportWidget::segmentationModified,
             this, [this](int /*sliceIndex*/) {
                 impl_->statusLabel->setText(tr("Segmentation modified"));
+            });
+
+    // Segmentation undo/redo availability → Edit menu + panel buttons
+    connect(impl_->viewport, &ViewportWidget::segmentationUndoRedoChanged,
+            this, [this](bool canUndo, bool canRedo) {
+                impl_->undoAction->setEnabled(canUndo);
+                impl_->redoAction->setEnabled(canRedo);
+                impl_->segmentationPanel->setUndoRedoEnabled(canUndo, canRedo);
             });
 
     // Measurement completed -> Status bar

--- a/src/ui/panels/segmentation_panel.cpp
+++ b/src/ui/panels/segmentation_panel.cpp
@@ -45,6 +45,10 @@ public:
     QPushButton* clearAllButton = nullptr;
     QWidget* polygonActionsWidget = nullptr;
 
+    // Command stack undo/redo buttons
+    QPushButton* undoCommandButton = nullptr;
+    QPushButton* redoCommandButton = nullptr;
+
     // State
     services::SegmentationTool currentTool = services::SegmentationTool::None;
     int currentBrushSize = 5;
@@ -217,6 +221,19 @@ void SegmentationPanel::setupUI()
     actionsLayout->addWidget(impl_->completeButton);
     mainLayout->addWidget(impl_->polygonActionsWidget);
 
+    // History actions (Undo/Redo for command stack)
+    auto historyGroup = new QGroupBox(tr("History"));
+    auto historyLayout = new QHBoxLayout(historyGroup);
+    impl_->undoCommandButton = new QPushButton(tr("Undo"));
+    impl_->undoCommandButton->setToolTip(tr("Undo last segmentation operation (Ctrl+Z)"));
+    impl_->undoCommandButton->setEnabled(false);
+    impl_->redoCommandButton = new QPushButton(tr("Redo"));
+    impl_->redoCommandButton->setToolTip(tr("Redo last undone operation (Ctrl+Y)"));
+    impl_->redoCommandButton->setEnabled(false);
+    historyLayout->addWidget(impl_->undoCommandButton);
+    historyLayout->addWidget(impl_->redoCommandButton);
+    mainLayout->addWidget(historyGroup);
+
     // Clear all
     auto clearGroup = new QGroupBox(tr("Actions"));
     auto clearLayout = new QVBoxLayout(clearGroup);
@@ -268,6 +285,12 @@ void SegmentationPanel::setupConnections()
             this, &SegmentationPanel::onCompleteClicked);
     connect(impl_->clearAllButton, &QPushButton::clicked,
             this, &SegmentationPanel::onClearAllClicked);
+
+    // Command stack undo/redo
+    connect(impl_->undoCommandButton, &QPushButton::clicked,
+            this, &SegmentationPanel::undoCommandRequested);
+    connect(impl_->redoCommandButton, &QPushButton::clicked,
+            this, &SegmentationPanel::redoCommandRequested);
 }
 
 void SegmentationPanel::createToolSection() {}
@@ -395,6 +418,12 @@ void SegmentationPanel::onColorButtonClicked()
         impl_->updateColorButtonStyle(impl_->colorButton, impl_->currentColor);
         emit labelColorChanged(impl_->currentColor);
     }
+}
+
+void SegmentationPanel::setUndoRedoEnabled(bool canUndo, bool canRedo)
+{
+    impl_->undoCommandButton->setEnabled(canUndo);
+    impl_->redoCommandButton->setEnabled(canRedo);
 }
 
 void SegmentationPanel::onClearAllClicked()

--- a/src/ui/widgets/viewport_widget.cpp
+++ b/src/ui/widgets/viewport_widget.cpp
@@ -169,6 +169,12 @@ ViewportWidget::ViewportWidget(QWidget* parent)
             emit areaMeasurementCompleted(m.areaMm2, m.areaCm2, m.id);
         });
 
+    // Wire segmentation undo/redo availability signal
+    impl_->segmentationController->setUndoRedoCallback(
+        [this](bool canUndo, bool canRedo) {
+            emit segmentationUndoRedoChanged(canUndo, canRedo);
+        });
+
     setLayout(layout);
 }
 
@@ -468,6 +474,24 @@ void ViewportWidget::clearAllSegmentation()
 {
     impl_->segmentationController->clearAll();
     emit segmentationModified(impl_->currentSlice);
+}
+
+bool ViewportWidget::undoSegmentationCommand()
+{
+    bool result = impl_->segmentationController->undo();
+    if (result) {
+        emit segmentationModified(impl_->currentSlice);
+    }
+    return result;
+}
+
+bool ViewportWidget::redoSegmentationCommand()
+{
+    bool result = impl_->segmentationController->redo();
+    if (result) {
+        emit segmentationModified(impl_->currentSlice);
+    }
+    return result;
 }
 
 bool ViewportWidget::isSegmentationModeActive() const


### PR DESCRIPTION
Closes #236

## Summary
- Wire Edit menu Undo (Ctrl+Z) and Redo (Ctrl+Y) actions to existing `SegmentationCommandStack`
- Add `undoSegmentationCommand()`/`redoSegmentationCommand()` slots and `segmentationUndoRedoChanged` signal to `ViewportWidget`
- Add dedicated History (Undo/Redo) buttons to `SegmentationPanel` with real-time enabled state tracking
- All segmentation tools (Brush, Eraser, Fill, Polygon, Freehand, Smart Scissors) now support keyboard undo/redo

## Context
The core undo/redo infrastructure (`ISegmentationCommand`, `SegmentationCommandStack`, `BrushStrokeCommand`, `SnapshotCommand`) was already fully implemented with comprehensive tests (20+14+73 = 107 passing tests). The only missing piece was the UI wiring:
1. Edit menu Undo/Redo actions were placeholders (`setEnabled(false)`, no `connect()`)
2. No command stack undo/redo buttons in the SegmentationPanel

## Test Plan
- [x] `segmentation_command_test` — 20/20 passed (undo/redo cycles, history limits, callbacks)
- [x] `snapshot_command_test` — 14/14 passed (RLE compression, undo/redo, memory budget)
- [x] `manual_segmentation_controller_test` — 73/73 passed (tool undo/redo, clear undo)
- [x] Build succeeds with no new warnings