### PR TITLE
feat(rendering): add vorticity and energy loss 2D overlay types

### DIFF
--- a/include/services/render/hemodynamic_overlay_renderer.hpp
+++ b/include/services/render/hemodynamic_overlay_renderer.hpp
@@ -34,7 +34,9 @@ enum class OverlayType {
     VelocityMagnitude,  ///< Speed = sqrt(Vx^2 + Vy^2 + Vz^2) in cm/s
     VelocityX,          ///< X component of velocity
     VelocityY,          ///< Y component of velocity
-    VelocityZ           ///< Z component of velocity
+    VelocityZ,          ///< Z component of velocity
+    Vorticity,          ///< |curl(V)| vorticity magnitude in 1/s
+    EnergyLoss          ///< Viscous dissipation rate in W/m^3
 };
 
 /**
@@ -214,6 +216,20 @@ public:
      */
     [[nodiscard]] static std::expected<vtkSmartPointer<vtkImageData>, OverlayError>
     extractComponent(vtkSmartPointer<vtkImageData> velocityField, int component);
+
+    /**
+     * @brief Get the default colormap preset for an overlay type
+     *
+     * Default mappings:
+     * - VelocityMagnitude → Jet
+     * - VelocityX/Y/Z → CoolWarm (diverging, signed data)
+     * - Vorticity → CoolWarm
+     * - EnergyLoss → HotMetal
+     *
+     * @param type Overlay type
+     * @return Recommended colormap preset
+     */
+    [[nodiscard]] static ColormapPreset defaultColormapForType(OverlayType type) noexcept;
 
 private:
     class Impl;

--- a/src/services/render/hemodynamic_overlay_renderer.cpp
+++ b/src/services/render/hemodynamic_overlay_renderer.cpp
@@ -293,6 +293,8 @@ bool HemodynamicOverlayRenderer::hasScalarField() const noexcept {
 
 void HemodynamicOverlayRenderer::setOverlayType(OverlayType type) {
     impl_->overlayType = type;
+    // Automatically apply default colormap for the new overlay type
+    setColormapPreset(defaultColormapForType(type));
 }
 
 OverlayType HemodynamicOverlayRenderer::overlayType() const noexcept {
@@ -473,6 +475,21 @@ HemodynamicOverlayRenderer::extractComponent(
     }
 
     return result;
+}
+
+ColormapPreset HemodynamicOverlayRenderer::defaultColormapForType(OverlayType type) noexcept {
+    switch (type) {
+        case OverlayType::VelocityMagnitude:
+            return ColormapPreset::Jet;
+        case OverlayType::VelocityX:
+        case OverlayType::VelocityY:
+        case OverlayType::VelocityZ:
+        case OverlayType::Vorticity:
+            return ColormapPreset::CoolWarm;
+        case OverlayType::EnergyLoss:
+            return ColormapPreset::HotMetal;
+    }
+    return ColormapPreset::Jet;
 }
 
 } // namespace dicom_viewer::services


### PR DESCRIPTION
## Summary
- Add Vorticity and EnergyLoss values to OverlayType enum for 2D hemodynamic overlay rendering
- Add defaultColormapForType() static method mapping overlay types to recommended colormap presets (Vorticity->CoolWarm, EnergyLoss->HotMetal)
- Auto-apply default colormap when setOverlayType() is called
- ITK-to-VTK conversion already available via ImageConverter::itkToVtk(FloatImageType::Pointer)

## Changes
- `hemodynamic_overlay_renderer.hpp`: Extended OverlayType enum, added defaultColormapForType() declaration
- `hemodynamic_overlay_renderer.cpp`: Implemented defaultColormapForType(), enhanced setOverlayType() to auto-apply colormap
- `hemodynamic_overlay_renderer_test.cpp`: Added 18 new tests (37 total, all passing)

## Test Plan
- [x] All 37 hemodynamic overlay renderer tests pass
- [x] All 34 flow visualizer tests pass (no regression)
- [x] Vorticity end-to-end pipeline test with CoolWarm colormap
- [x] Energy Loss end-to-end pipeline test with HotMetal colormap
- [x] Colormap override after setOverlayType() verified

Closes #323