### PR TITLE
feat(rendering): implement 2D streamline and LIC overlay renderer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,6 +371,7 @@ add_library(render_service STATIC
     src/services/render/transfer_function.cpp
     src/services/render/oblique_reslice_renderer.cpp
     src/services/render/hemodynamic_overlay_renderer.cpp
+    src/services/render/streamline_overlay_renderer.cpp
 )
 
 target_link_libraries(render_service PUBLIC

--- a/include/services/render/hemodynamic_overlay_renderer.hpp
+++ b/include/services/render/hemodynamic_overlay_renderer.hpp
@@ -36,7 +36,9 @@ enum class OverlayType {
     VelocityY,          ///< Y component of velocity
     VelocityZ,          ///< Z component of velocity
     Vorticity,          ///< |curl(V)| vorticity magnitude in 1/s
-    EnergyLoss          ///< Viscous dissipation rate in W/m^3
+    EnergyLoss,         ///< Viscous dissipation rate in W/m^3
+    Streamline,         ///< 2D flow streamlines on slice plane
+    VelocityTexture     ///< Line Integral Convolution (LIC) texture
 };
 
 /**

--- a/include/services/render/streamline_overlay_renderer.hpp
+++ b/include/services/render/streamline_overlay_renderer.hpp
@@ -1,0 +1,215 @@
+#pragma once
+
+#include <array>
+#include <expected>
+#include <memory>
+
+#include <vtkSmartPointer.h>
+
+class vtkImageData;
+class vtkRenderer;
+class vtkPolyData;
+
+namespace dicom_viewer::services {
+
+enum class MPRPlane;
+enum class OverlayError;
+
+/**
+ * @brief Parameters for 2D streamline generation on a slice plane
+ */
+struct Streamline2DParams {
+    int numSeedPoints = 200;          ///< Number of seed points on the slice
+    double stepLength = 0.5;          ///< Integration step in mm
+    int maxSteps = 500;               ///< Maximum integration steps per streamline
+    double terminalSpeed = 0.01;      ///< Stop when velocity drops below this (cm/s)
+    double lineWidth = 1.5;           ///< Rendered line width in pixels
+};
+
+/**
+ * @brief Parameters for LIC (Line Integral Convolution) texture generation
+ */
+struct LICParams {
+    int kernelLength = 20;            ///< Number of steps forward+backward for convolution
+    double stepSize = 0.5;            ///< Euler integration step in pixels
+    unsigned int noiseSeed = 42;      ///< Random seed for reproducible noise texture
+};
+
+/**
+ * @brief 2D streamline and LIC overlay renderer for MPR views
+ *
+ * Renders velocity vector fields as 2D streamlines or Line Integral
+ * Convolution (LIC) textures on MPR slice planes. Unlike the scalar
+ * HemodynamicOverlayRenderer, this processes vector data to produce
+ * flow visualization overlays.
+ *
+ * Pipeline (Streamlines):
+ * @code
+ *   3D velocity field (vtkImageData, 3-component)
+ *     → extract 2D in-plane velocity at slice position
+ *     → vtkStreamTracer (2D integration)
+ *     → vtkPolyDataMapper (velocity-coded colors)
+ *     → vtkActor (line overlay)
+ * @endcode
+ *
+ * Pipeline (LIC):
+ * @code
+ *   3D velocity field (vtkImageData, 3-component)
+ *     → extract 2D in-plane velocity at slice position
+ *     → Line Integral Convolution (noise texture + streamline averaging)
+ *     → vtkImageActor (grayscale overlay)
+ * @endcode
+ *
+ * @trace SRS-FR-046
+ */
+class StreamlineOverlayRenderer {
+public:
+    /**
+     * @brief Rendering mode for the overlay
+     */
+    enum class Mode {
+        Streamline,      ///< 2D streamlines colored by velocity
+        LIC              ///< Line Integral Convolution texture
+    };
+
+    StreamlineOverlayRenderer();
+    ~StreamlineOverlayRenderer();
+
+    // Non-copyable, movable
+    StreamlineOverlayRenderer(const StreamlineOverlayRenderer&) = delete;
+    StreamlineOverlayRenderer& operator=(const StreamlineOverlayRenderer&) = delete;
+    StreamlineOverlayRenderer(StreamlineOverlayRenderer&&) noexcept;
+    StreamlineOverlayRenderer& operator=(StreamlineOverlayRenderer&&) noexcept;
+
+    // ==================== Input Data ====================
+
+    /**
+     * @brief Set the 3D velocity field for streamline/LIC rendering
+     * @param velocityField 3D vtkImageData with 3-component vectors
+     */
+    void setVelocityField(vtkSmartPointer<vtkImageData> velocityField);
+
+    /**
+     * @brief Check if a velocity field has been set
+     */
+    [[nodiscard]] bool hasVelocityField() const noexcept;
+
+    // ==================== Settings ====================
+
+    /**
+     * @brief Set rendering mode (Streamline or LIC)
+     */
+    void setMode(Mode mode);
+
+    /**
+     * @brief Get current mode
+     */
+    [[nodiscard]] Mode mode() const noexcept;
+
+    /**
+     * @brief Set overlay visibility
+     */
+    void setVisible(bool visible);
+
+    /**
+     * @brief Get visibility state
+     */
+    [[nodiscard]] bool isVisible() const noexcept;
+
+    /**
+     * @brief Set overlay opacity (0.0 = transparent, 1.0 = opaque)
+     */
+    void setOpacity(double opacity);
+
+    /**
+     * @brief Get opacity
+     */
+    [[nodiscard]] double opacity() const noexcept;
+
+    /**
+     * @brief Set streamline generation parameters
+     */
+    void setStreamlineParams(const Streamline2DParams& params);
+
+    /**
+     * @brief Set LIC parameters
+     */
+    void setLICParams(const LICParams& params);
+
+    // ==================== Rendering ====================
+
+    /**
+     * @brief Set VTK renderers for the three MPR planes
+     */
+    void setRenderers(vtkSmartPointer<vtkRenderer> axial,
+                      vtkSmartPointer<vtkRenderer> coronal,
+                      vtkSmartPointer<vtkRenderer> sagittal);
+
+    /**
+     * @brief Set slice position for a specific plane
+     * @return Success or OverlayError
+     */
+    [[nodiscard]] std::expected<void, OverlayError>
+    setSlicePosition(MPRPlane plane, double worldPosition);
+
+    /**
+     * @brief Regenerate and update all planes
+     */
+    void update();
+
+    /**
+     * @brief Regenerate and update a specific plane
+     */
+    void updatePlane(MPRPlane plane);
+
+    // ==================== Static Utilities ====================
+
+    /**
+     * @brief Extract 2D in-plane velocity from a 3D velocity field at a slice
+     *
+     * For Axial: extracts (Vx, Vy) at given Z position
+     * For Coronal: extracts (Vx, Vz) at given Y position
+     * For Sagittal: extracts (Vy, Vz) at given X position
+     *
+     * @param velocityField 3D velocity field (3-component)
+     * @param plane MPR plane
+     * @param worldPosition Slice position in world coordinates
+     * @return 2D vtkImageData with 3-component vectors (in-plane + zero)
+     */
+    [[nodiscard]] static std::expected<vtkSmartPointer<vtkImageData>, OverlayError>
+    extractSliceVelocity(vtkSmartPointer<vtkImageData> velocityField,
+                         MPRPlane plane, double worldPosition);
+
+    /**
+     * @brief Generate 2D streamlines from a 2D velocity field
+     *
+     * Uses uniform grid seeding and vtkStreamTracer for integration.
+     *
+     * @param velocitySlice 2D velocity field from extractSliceVelocity()
+     * @param params Streamline parameters
+     * @return PolyData with streamline geometry, or error
+     */
+    [[nodiscard]] static std::expected<vtkSmartPointer<vtkPolyData>, OverlayError>
+    generateStreamlines2D(vtkSmartPointer<vtkImageData> velocitySlice,
+                          const Streamline2DParams& params = {});
+
+    /**
+     * @brief Compute Line Integral Convolution texture from a 2D velocity field
+     *
+     * Creates a grayscale texture showing flow direction patterns by
+     * convolving a white noise image along streamlines.
+     *
+     * @param velocitySlice 2D velocity field from extractSliceVelocity()
+     * @param params LIC parameters
+     * @return Grayscale vtkImageData texture, or error
+     */
+    [[nodiscard]] static std::expected<vtkSmartPointer<vtkImageData>, OverlayError>
+    computeLIC(vtkSmartPointer<vtkImageData> velocitySlice,
+               const LICParams& params = {});
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::services

--- a/src/services/render/hemodynamic_overlay_renderer.cpp
+++ b/src/services/render/hemodynamic_overlay_renderer.cpp
@@ -488,6 +488,10 @@ ColormapPreset HemodynamicOverlayRenderer::defaultColormapForType(OverlayType ty
             return ColormapPreset::CoolWarm;
         case OverlayType::EnergyLoss:
             return ColormapPreset::HotMetal;
+        case OverlayType::Streamline:
+            return ColormapPreset::Jet;
+        case OverlayType::VelocityTexture:
+            return ColormapPreset::Viridis;
     }
     return ColormapPreset::Jet;
 }

--- a/src/services/render/streamline_overlay_renderer.cpp
+++ b/src/services/render/streamline_overlay_renderer.cpp
@@ -1,0 +1,580 @@
+#include "services/render/streamline_overlay_renderer.hpp"
+#include "services/render/hemodynamic_overlay_renderer.hpp"
+#include "services/mpr_renderer.hpp"
+
+#include <vtkActor.h>
+#include <vtkFloatArray.h>
+#include <vtkImageActor.h>
+#include <vtkImageData.h>
+#include <vtkImageMapper3D.h>
+#include <vtkImageMapToColors.h>
+#include <vtkLookupTable.h>
+#include <vtkPointData.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+#include <vtkPolyDataMapper.h>
+#include <vtkProperty.h>
+#include <vtkRenderer.h>
+#include <vtkRungeKutta45.h>
+#include <vtkStreamTracer.h>
+
+#include <algorithm>
+#include <cmath>
+#include <random>
+#include <vector>
+
+namespace dicom_viewer::services {
+
+// =============================================================================
+// Implementation
+// =============================================================================
+
+class StreamlineOverlayRenderer::Impl {
+public:
+    // Input data
+    vtkSmartPointer<vtkImageData> velocityField;
+
+    // Settings
+    Mode mode = Mode::Streamline;
+    bool visible = true;
+    double overlayOpacity = 0.6;
+    Streamline2DParams streamlineParams;
+    LICParams licParams;
+
+    // Per-plane rendering state
+    std::array<vtkSmartPointer<vtkRenderer>, 3> renderers;
+    std::array<double, 3> slicePositions = {0.0, 0.0, 0.0};
+
+    // Streamline mode: polydata actors
+    std::array<vtkSmartPointer<vtkActor>, 3> streamlineActors;
+
+    // LIC mode: image actors
+    std::array<vtkSmartPointer<vtkImageActor>, 3> licActors;
+
+    Impl() {
+        for (int i = 0; i < 3; ++i) {
+            streamlineActors[i] = vtkSmartPointer<vtkActor>::New();
+            streamlineActors[i]->SetVisibility(false);
+            streamlineActors[i]->GetProperty()->SetOpacity(overlayOpacity);
+
+            licActors[i] = vtkSmartPointer<vtkImageActor>::New();
+            licActors[i]->SetVisibility(false);
+            licActors[i]->SetOpacity(overlayOpacity);
+        }
+    }
+
+    void applyVisibility() {
+        bool hasData = velocityField != nullptr;
+        for (int i = 0; i < 3; ++i) {
+            if (mode == Mode::Streamline) {
+                streamlineActors[i]->SetVisibility(visible && hasData);
+                licActors[i]->SetVisibility(false);
+            } else {
+                streamlineActors[i]->SetVisibility(false);
+                licActors[i]->SetVisibility(visible && hasData);
+            }
+        }
+    }
+
+    void attachToRenderers() {
+        for (int i = 0; i < 3; ++i) {
+            if (renderers[i]) {
+                renderers[i]->AddViewProp(streamlineActors[i]);
+                renderers[i]->AddViewProp(licActors[i]);
+            }
+        }
+    }
+
+    void detachFromRenderers() {
+        for (int i = 0; i < 3; ++i) {
+            if (renderers[i]) {
+                renderers[i]->RemoveViewProp(streamlineActors[i]);
+                renderers[i]->RemoveViewProp(licActors[i]);
+            }
+        }
+    }
+
+    void regeneratePlane(int planeIndex) {
+        if (!velocityField) {
+            return;
+        }
+
+        auto mprPlane = static_cast<MPRPlane>(planeIndex);
+        double position = slicePositions[planeIndex];
+
+        auto sliceResult = StreamlineOverlayRenderer::extractSliceVelocity(
+            velocityField, mprPlane, position);
+        if (!sliceResult.has_value()) {
+            return;
+        }
+
+        auto& velocitySlice = *sliceResult;
+
+        if (mode == Mode::Streamline) {
+            auto polyResult = StreamlineOverlayRenderer::generateStreamlines2D(
+                velocitySlice, streamlineParams);
+            if (polyResult.has_value()) {
+                auto mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+                mapper->SetInputData(*polyResult);
+                mapper->SetScalarModeToUsePointData();
+                mapper->SetColorModeToMapScalars();
+
+                // Build a Jet LUT for velocity magnitude coloring
+                auto lut = vtkSmartPointer<vtkLookupTable>::New();
+                lut->SetNumberOfTableValues(256);
+                lut->SetHueRange(0.667, 0.0);
+                lut->SetSaturationRange(1.0, 1.0);
+                lut->SetValueRange(1.0, 1.0);
+                lut->Build();
+
+                double range[2];
+                if ((*polyResult)->GetPointData()->GetScalars()) {
+                    (*polyResult)->GetPointData()->GetScalars()->GetRange(range);
+                    lut->SetTableRange(range);
+                }
+                mapper->SetLookupTable(lut);
+                mapper->ScalarVisibilityOn();
+
+                streamlineActors[planeIndex]->SetMapper(mapper);
+                streamlineActors[planeIndex]->GetProperty()->SetLineWidth(
+                    static_cast<float>(streamlineParams.lineWidth));
+            }
+        } else {
+            auto licResult = StreamlineOverlayRenderer::computeLIC(
+                velocitySlice, licParams);
+            if (licResult.has_value()) {
+                licActors[planeIndex]->GetMapper()->SetInputData(*licResult);
+            }
+        }
+
+        applyVisibility();
+    }
+};
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+StreamlineOverlayRenderer::StreamlineOverlayRenderer()
+    : impl_(std::make_unique<Impl>()) {}
+
+StreamlineOverlayRenderer::~StreamlineOverlayRenderer() {
+    if (impl_) {
+        impl_->detachFromRenderers();
+    }
+}
+
+StreamlineOverlayRenderer::StreamlineOverlayRenderer(StreamlineOverlayRenderer&&) noexcept = default;
+StreamlineOverlayRenderer& StreamlineOverlayRenderer::operator=(StreamlineOverlayRenderer&&) noexcept = default;
+
+void StreamlineOverlayRenderer::setVelocityField(vtkSmartPointer<vtkImageData> velocityField) {
+    impl_->velocityField = velocityField;
+    impl_->applyVisibility();
+}
+
+bool StreamlineOverlayRenderer::hasVelocityField() const noexcept {
+    return impl_->velocityField != nullptr;
+}
+
+void StreamlineOverlayRenderer::setMode(Mode mode) {
+    impl_->mode = mode;
+    impl_->applyVisibility();
+}
+
+StreamlineOverlayRenderer::Mode StreamlineOverlayRenderer::mode() const noexcept {
+    return impl_->mode;
+}
+
+void StreamlineOverlayRenderer::setVisible(bool visible) {
+    impl_->visible = visible;
+    impl_->applyVisibility();
+}
+
+bool StreamlineOverlayRenderer::isVisible() const noexcept {
+    return impl_->visible;
+}
+
+void StreamlineOverlayRenderer::setOpacity(double opacity) {
+    impl_->overlayOpacity = std::clamp(opacity, 0.0, 1.0);
+    for (int i = 0; i < 3; ++i) {
+        impl_->streamlineActors[i]->GetProperty()->SetOpacity(impl_->overlayOpacity);
+        impl_->licActors[i]->SetOpacity(impl_->overlayOpacity);
+    }
+}
+
+double StreamlineOverlayRenderer::opacity() const noexcept {
+    return impl_->overlayOpacity;
+}
+
+void StreamlineOverlayRenderer::setStreamlineParams(const Streamline2DParams& params) {
+    impl_->streamlineParams = params;
+}
+
+void StreamlineOverlayRenderer::setLICParams(const LICParams& params) {
+    impl_->licParams = params;
+}
+
+void StreamlineOverlayRenderer::setRenderers(
+    vtkSmartPointer<vtkRenderer> axial,
+    vtkSmartPointer<vtkRenderer> coronal,
+    vtkSmartPointer<vtkRenderer> sagittal) {
+
+    impl_->detachFromRenderers();
+
+    impl_->renderers[0] = axial;
+    impl_->renderers[1] = coronal;
+    impl_->renderers[2] = sagittal;
+
+    impl_->attachToRenderers();
+    impl_->applyVisibility();
+}
+
+std::expected<void, OverlayError>
+StreamlineOverlayRenderer::setSlicePosition(MPRPlane plane, double worldPosition) {
+    if (!impl_->velocityField) {
+        return std::unexpected(OverlayError::NoScalarField);
+    }
+
+    int planeIndex = static_cast<int>(plane);
+    if (planeIndex < 0 || planeIndex > 2) {
+        return std::unexpected(OverlayError::InvalidPlane);
+    }
+
+    impl_->slicePositions[planeIndex] = worldPosition;
+    return {};
+}
+
+void StreamlineOverlayRenderer::update() {
+    for (int i = 0; i < 3; ++i) {
+        impl_->regeneratePlane(i);
+    }
+}
+
+void StreamlineOverlayRenderer::updatePlane(MPRPlane plane) {
+    int idx = static_cast<int>(plane);
+    if (idx >= 0 && idx <= 2) {
+        impl_->regeneratePlane(idx);
+    }
+}
+
+// =============================================================================
+// Static: Extract 2D slice velocity
+// =============================================================================
+
+std::expected<vtkSmartPointer<vtkImageData>, OverlayError>
+StreamlineOverlayRenderer::extractSliceVelocity(
+    vtkSmartPointer<vtkImageData> velocityField,
+    MPRPlane plane, double worldPosition) {
+
+    if (!velocityField) {
+        return std::unexpected(OverlayError::NoScalarField);
+    }
+
+    if (velocityField->GetNumberOfScalarComponents() < 3) {
+        return std::unexpected(OverlayError::NoScalarField);
+    }
+
+    int* dims = velocityField->GetDimensions();
+    double* spacing = velocityField->GetSpacing();
+    double* origin = velocityField->GetOrigin();
+
+    // Determine which axis to slice and extract in-plane velocity components
+    // Axial (XY plane): slice along Z, extract (Vx, Vy)
+    // Coronal (XZ plane): slice along Y, extract (Vx, Vz)
+    // Sagittal (YZ plane): slice along X, extract (Vy, Vz)
+
+    int sliceAxis = -1;
+    int comp0 = -1, comp1 = -1;
+    int outDimX = 0, outDimY = 0;
+    double outSpacingX = 0.0, outSpacingY = 0.0;
+    double outOriginX = 0.0, outOriginY = 0.0;
+
+    switch (plane) {
+        case MPRPlane::Axial:
+            sliceAxis = 2;  // Z
+            comp0 = 0; comp1 = 1;  // Vx, Vy
+            outDimX = dims[0]; outDimY = dims[1];
+            outSpacingX = spacing[0]; outSpacingY = spacing[1];
+            outOriginX = origin[0]; outOriginY = origin[1];
+            break;
+        case MPRPlane::Coronal:
+            sliceAxis = 1;  // Y
+            comp0 = 0; comp1 = 2;  // Vx, Vz
+            outDimX = dims[0]; outDimY = dims[2];
+            outSpacingX = spacing[0]; outSpacingY = spacing[2];
+            outOriginX = origin[0]; outOriginY = origin[2];
+            break;
+        case MPRPlane::Sagittal:
+            sliceAxis = 0;  // X
+            comp0 = 1; comp1 = 2;  // Vy, Vz
+            outDimX = dims[1]; outDimY = dims[2];
+            outSpacingX = spacing[1]; outSpacingY = spacing[2];
+            outOriginX = origin[1]; outOriginY = origin[2];
+            break;
+    }
+
+    // Find the slice index closest to worldPosition
+    int sliceDim = dims[sliceAxis];
+    double sliceOrigin = origin[sliceAxis];
+    double sliceSpacing = spacing[sliceAxis];
+
+    int sliceIndex = static_cast<int>(
+        std::round((worldPosition - sliceOrigin) / sliceSpacing));
+    sliceIndex = std::clamp(sliceIndex, 0, sliceDim - 1);
+
+    // Create 2D output with 3-component vectors (in-plane velocity + 0 for z)
+    auto output = vtkSmartPointer<vtkImageData>::New();
+    output->SetDimensions(outDimX, outDimY, 1);
+    output->SetSpacing(outSpacingX, outSpacingY, 1.0);
+    output->SetOrigin(outOriginX, outOriginY, 0.0);
+    output->AllocateScalars(VTK_FLOAT, 3);
+
+    // Also create a velocity magnitude array for scalar coloring
+    auto magnitudeArray = vtkSmartPointer<vtkFloatArray>::New();
+    magnitudeArray->SetName("VelocityMagnitude");
+    magnitudeArray->SetNumberOfTuples(
+        static_cast<vtkIdType>(outDimX) * outDimY);
+
+    auto* inData = velocityField->GetPointData()->GetScalars();
+    auto* outPtr = static_cast<float*>(output->GetScalarPointer());
+
+    vtkIdType outIdx = 0;
+    for (int j = 0; j < outDimY; ++j) {
+        for (int i = 0; i < outDimX; ++i) {
+            // Map (i, j) back to 3D indices depending on plane
+            vtkIdType inIdx = 0;
+            switch (plane) {
+                case MPRPlane::Axial:
+                    inIdx = static_cast<vtkIdType>(sliceIndex) * dims[1] * dims[0]
+                          + static_cast<vtkIdType>(j) * dims[0] + i;
+                    break;
+                case MPRPlane::Coronal:
+                    inIdx = static_cast<vtkIdType>(j) * dims[1] * dims[0]
+                          + static_cast<vtkIdType>(sliceIndex) * dims[0] + i;
+                    break;
+                case MPRPlane::Sagittal:
+                    inIdx = static_cast<vtkIdType>(j) * dims[1] * dims[0]
+                          + static_cast<vtkIdType>(i) * dims[0] + sliceIndex;
+                    break;
+            }
+
+            double v0 = inData->GetComponent(inIdx, comp0);
+            double v1 = inData->GetComponent(inIdx, comp1);
+
+            outPtr[outIdx * 3 + 0] = static_cast<float>(v0);
+            outPtr[outIdx * 3 + 1] = static_cast<float>(v1);
+            outPtr[outIdx * 3 + 2] = 0.0f;
+
+            double mag = std::sqrt(v0 * v0 + v1 * v1);
+            magnitudeArray->SetValue(outIdx, static_cast<float>(mag));
+
+            ++outIdx;
+        }
+    }
+
+    // Set vectors for vtkStreamTracer (needs active vectors)
+    auto vectors = vtkSmartPointer<vtkFloatArray>::New();
+    vectors->SetName("Velocity");
+    vectors->SetNumberOfComponents(3);
+    vectors->SetNumberOfTuples(static_cast<vtkIdType>(outDimX) * outDimY);
+
+    outPtr = static_cast<float*>(output->GetScalarPointer());
+    for (vtkIdType k = 0; k < static_cast<vtkIdType>(outDimX) * outDimY; ++k) {
+        vectors->SetTuple3(k, outPtr[k * 3], outPtr[k * 3 + 1], outPtr[k * 3 + 2]);
+    }
+
+    output->GetPointData()->SetVectors(vectors);
+    output->GetPointData()->AddArray(magnitudeArray);
+
+    return output;
+}
+
+// =============================================================================
+// Static: Generate 2D streamlines
+// =============================================================================
+
+std::expected<vtkSmartPointer<vtkPolyData>, OverlayError>
+StreamlineOverlayRenderer::generateStreamlines2D(
+    vtkSmartPointer<vtkImageData> velocitySlice,
+    const Streamline2DParams& params) {
+
+    if (!velocitySlice) {
+        return std::unexpected(OverlayError::NoScalarField);
+    }
+
+    if (!velocitySlice->GetPointData()->GetVectors()) {
+        return std::unexpected(OverlayError::NoScalarField);
+    }
+
+    int* dims = velocitySlice->GetDimensions();
+    double* spacing = velocitySlice->GetSpacing();
+    double* origin = velocitySlice->GetOrigin();
+
+    // Create uniform grid seed points across the 2D slice
+    auto seedPoints = vtkSmartPointer<vtkPoints>::New();
+    int nx = static_cast<int>(std::sqrt(static_cast<double>(params.numSeedPoints)));
+    int ny = (nx > 0) ? params.numSeedPoints / nx : 1;
+    nx = std::max(nx, 1);
+    ny = std::max(ny, 1);
+
+    double dx = (dims[0] > 1) ? (dims[0] - 1) * spacing[0] / static_cast<double>(nx) : spacing[0];
+    double dy = (dims[1] > 1) ? (dims[1] - 1) * spacing[1] / static_cast<double>(ny) : spacing[1];
+
+    for (int j = 0; j < ny; ++j) {
+        for (int i = 0; i < nx; ++i) {
+            double x = origin[0] + (i + 0.5) * dx;
+            double y = origin[1] + (j + 0.5) * dy;
+            seedPoints->InsertNextPoint(x, y, 0.0);
+        }
+    }
+
+    auto seedPolyData = vtkSmartPointer<vtkPolyData>::New();
+    seedPolyData->SetPoints(seedPoints);
+
+    // Run stream tracer
+    auto tracer = vtkSmartPointer<vtkStreamTracer>::New();
+    tracer->SetInputData(velocitySlice);
+    tracer->SetSourceData(seedPolyData);
+
+    auto integrator = vtkSmartPointer<vtkRungeKutta45>::New();
+    tracer->SetIntegrator(integrator);
+
+    tracer->SetMaximumPropagation(params.maxSteps * params.stepLength);
+    tracer->SetInitialIntegrationStep(params.stepLength);
+    tracer->SetIntegrationDirectionToBoth();
+    tracer->SetTerminalSpeed(params.terminalSpeed);
+    tracer->SetMaximumNumberOfSteps(params.maxSteps);
+
+    tracer->Update();
+
+    auto output = vtkSmartPointer<vtkPolyData>::New();
+    output->DeepCopy(tracer->GetOutput());
+
+    // Add velocity magnitude as scalars for color-coding
+    if (output->GetNumberOfPoints() > 0) {
+        auto magArray = vtkSmartPointer<vtkFloatArray>::New();
+        magArray->SetName("VelocityMagnitude");
+        magArray->SetNumberOfTuples(output->GetNumberOfPoints());
+
+        auto* vectors = output->GetPointData()->GetVectors();
+        if (vectors) {
+            for (vtkIdType i = 0; i < output->GetNumberOfPoints(); ++i) {
+                double v[3];
+                vectors->GetTuple(i, v);
+                magArray->SetValue(i, static_cast<float>(
+                    std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2])));
+            }
+        } else {
+            magArray->FillComponent(0, 0.0);
+        }
+
+        output->GetPointData()->SetScalars(magArray);
+    }
+
+    return output;
+}
+
+// =============================================================================
+// Static: Compute LIC texture
+// =============================================================================
+
+std::expected<vtkSmartPointer<vtkImageData>, OverlayError>
+StreamlineOverlayRenderer::computeLIC(
+    vtkSmartPointer<vtkImageData> velocitySlice,
+    const LICParams& params) {
+
+    if (!velocitySlice) {
+        return std::unexpected(OverlayError::NoScalarField);
+    }
+
+    int* dims = velocitySlice->GetDimensions();
+    double* spacing = velocitySlice->GetSpacing();
+    double* origin = velocitySlice->GetOrigin();
+
+    int width = dims[0];
+    int height = dims[1];
+
+    if (width < 2 || height < 2) {
+        return std::unexpected(OverlayError::InternalError);
+    }
+
+    // Generate white noise texture
+    std::mt19937 rng(params.noiseSeed);
+    std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+    std::vector<float> noise(static_cast<size_t>(width) * height);
+    for (auto& n : noise) {
+        n = dist(rng);
+    }
+
+    // Get velocity data pointer
+    auto* velPtr = static_cast<float*>(velocitySlice->GetScalarPointer());
+    int numComponents = velocitySlice->GetNumberOfScalarComponents();
+
+    // LIC output
+    std::vector<float> licOutput(static_cast<size_t>(width) * height, 0.0f);
+
+    // For each pixel, trace streamline forward and backward,
+    // average noise values along the path
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            double sum = 0.0;
+            int count = 0;
+
+            // Trace forward and backward
+            for (int dir = -1; dir <= 1; dir += 2) {
+                double px = static_cast<double>(x);
+                double py = static_cast<double>(y);
+
+                for (int step = 0; step < params.kernelLength; ++step) {
+                    int ix = static_cast<int>(std::round(px));
+                    int iy = static_cast<int>(std::round(py));
+
+                    if (ix < 0 || ix >= width || iy < 0 || iy >= height) {
+                        break;
+                    }
+
+                    size_t idx = static_cast<size_t>(iy) * width + ix;
+                    sum += noise[idx];
+                    ++count;
+
+                    // Get velocity at current position (bilinear would be better,
+                    // but nearest-neighbor is sufficient for visualization)
+                    size_t velIdx = idx * numComponents;
+                    double vx = velPtr[velIdx];
+                    double vy = velPtr[velIdx + 1];
+
+                    double mag = std::sqrt(vx * vx + vy * vy);
+                    if (mag < 1e-10) {
+                        break;
+                    }
+
+                    // Normalize and advance
+                    px += dir * params.stepSize * vx / mag;
+                    py += dir * params.stepSize * vy / mag;
+                }
+            }
+
+            size_t outIdx = static_cast<size_t>(y) * width + x;
+            licOutput[outIdx] = (count > 0)
+                ? static_cast<float>(sum / count)
+                : noise[outIdx];
+        }
+    }
+
+    // Create output vtkImageData
+    auto output = vtkSmartPointer<vtkImageData>::New();
+    output->SetDimensions(width, height, 1);
+    output->SetSpacing(spacing[0], spacing[1], 1.0);
+    output->SetOrigin(origin[0], origin[1], 0.0);
+    output->AllocateScalars(VTK_UNSIGNED_CHAR, 1);
+
+    auto* outPtr = static_cast<unsigned char*>(output->GetScalarPointer());
+    for (size_t i = 0; i < licOutput.size(); ++i) {
+        outPtr[i] = static_cast<unsigned char>(
+            std::clamp(licOutput[i] * 255.0f, 0.0f, 255.0f));
+    }
+
+    return output;
+}
+
+} // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1483,6 +1483,33 @@ vtk_module_autoinit(
 
 gtest_discover_tests(hemodynamic_overlay_renderer_test DISCOVERY_TIMEOUT 60)
 
+# Unit tests for Streamline Overlay Renderer
+add_executable(streamline_overlay_renderer_test
+    unit/streamline_overlay_renderer_test.cpp
+)
+
+target_link_directories(streamline_overlay_renderer_test PRIVATE
+    /opt/homebrew/lib
+)
+
+target_link_libraries(streamline_overlay_renderer_test PRIVATE
+    render_service
+    ${VTK_LIBRARIES}
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(streamline_overlay_renderer_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+vtk_module_autoinit(
+    TARGETS streamline_overlay_renderer_test
+    MODULES ${VTK_LIBRARIES}
+)
+
+gtest_discover_tests(streamline_overlay_renderer_test DISCOVERY_TIMEOUT 60)
+
 # Volume Renderer Overlay Tests
 add_executable(volume_renderer_overlay_test
     unit/volume_renderer_overlay_test.cpp

--- a/tests/unit/streamline_overlay_renderer_test.cpp
+++ b/tests/unit/streamline_overlay_renderer_test.cpp
@@ -1,0 +1,513 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include <vtkFloatArray.h>
+#include <vtkImageData.h>
+#include <vtkPointData.h>
+#include <vtkPolyData.h>
+#include <vtkRenderer.h>
+#include <vtkSmartPointer.h>
+
+#include "services/render/streamline_overlay_renderer.hpp"
+#include "services/render/hemodynamic_overlay_renderer.hpp"
+#include "services/mpr_renderer.hpp"
+
+using namespace dicom_viewer::services;
+
+namespace {
+
+/// Create a 3D uniform velocity field (Vx, Vy, Vz) at each voxel
+vtkSmartPointer<vtkImageData> createUniformVelocityField(
+    int dimX, int dimY, int dimZ,
+    double vx, double vy, double vz,
+    double spacing = 1.0) {
+    auto image = vtkSmartPointer<vtkImageData>::New();
+    image->SetDimensions(dimX, dimY, dimZ);
+    image->SetSpacing(spacing, spacing, spacing);
+    image->SetOrigin(0.0, 0.0, 0.0);
+    image->AllocateScalars(VTK_FLOAT, 3);
+
+    auto* ptr = static_cast<float*>(image->GetScalarPointer());
+    int total = dimX * dimY * dimZ;
+    for (int i = 0; i < total; ++i) {
+        ptr[i * 3 + 0] = static_cast<float>(vx);
+        ptr[i * 3 + 1] = static_cast<float>(vy);
+        ptr[i * 3 + 2] = static_cast<float>(vz);
+    }
+    return image;
+}
+
+/// Create a 3D velocity field with a circular vortex pattern in the XY plane
+vtkSmartPointer<vtkImageData> createVortexVelocityField(
+    int dim, double spacing = 1.0) {
+    auto image = vtkSmartPointer<vtkImageData>::New();
+    image->SetDimensions(dim, dim, dim);
+    image->SetSpacing(spacing, spacing, spacing);
+    image->SetOrigin(0.0, 0.0, 0.0);
+    image->AllocateScalars(VTK_FLOAT, 3);
+
+    auto* ptr = static_cast<float*>(image->GetScalarPointer());
+    double center = (dim - 1) * spacing / 2.0;
+
+    int idx = 0;
+    for (int z = 0; z < dim; ++z) {
+        for (int y = 0; y < dim; ++y) {
+            for (int x = 0; x < dim; ++x) {
+                double dx = x * spacing - center;
+                double dy = y * spacing - center;
+                double r = std::sqrt(dx * dx + dy * dy);
+                double speed = (r > 0.1) ? 10.0 / (1.0 + r) : 0.0;
+                // Tangential velocity: (-dy, dx) / r
+                ptr[idx * 3 + 0] = static_cast<float>((r > 0.1) ? -dy / r * speed : 0.0);
+                ptr[idx * 3 + 1] = static_cast<float>((r > 0.1) ? dx / r * speed : 0.0);
+                ptr[idx * 3 + 2] = 0.0f;
+                ++idx;
+            }
+        }
+    }
+    return image;
+}
+
+} // anonymous namespace
+
+// =============================================================================
+// Construction and Default State
+// =============================================================================
+
+TEST(StreamlineOverlayRendererTest, DefaultState) {
+    StreamlineOverlayRenderer renderer;
+    EXPECT_FALSE(renderer.hasVelocityField());
+    EXPECT_TRUE(renderer.isVisible());
+    EXPECT_DOUBLE_EQ(renderer.opacity(), 0.6);
+    EXPECT_EQ(renderer.mode(), StreamlineOverlayRenderer::Mode::Streamline);
+}
+
+TEST(StreamlineOverlayRendererTest, MoveConstructor) {
+    StreamlineOverlayRenderer r1;
+    r1.setOpacity(0.8);
+    r1.setMode(StreamlineOverlayRenderer::Mode::LIC);
+
+    StreamlineOverlayRenderer r2(std::move(r1));
+    EXPECT_DOUBLE_EQ(r2.opacity(), 0.8);
+    EXPECT_EQ(r2.mode(), StreamlineOverlayRenderer::Mode::LIC);
+}
+
+// =============================================================================
+// Velocity Field Input
+// =============================================================================
+
+TEST(StreamlineOverlayRendererTest, SetVelocityField) {
+    StreamlineOverlayRenderer renderer;
+    auto field = createUniformVelocityField(8, 8, 8, 1.0, 0.0, 0.0);
+
+    renderer.setVelocityField(field);
+    EXPECT_TRUE(renderer.hasVelocityField());
+
+    renderer.setVelocityField(nullptr);
+    EXPECT_FALSE(renderer.hasVelocityField());
+}
+
+// =============================================================================
+// Settings
+// =============================================================================
+
+TEST(StreamlineOverlayRendererTest, ModeSwitch) {
+    StreamlineOverlayRenderer renderer;
+    renderer.setMode(StreamlineOverlayRenderer::Mode::LIC);
+    EXPECT_EQ(renderer.mode(), StreamlineOverlayRenderer::Mode::LIC);
+
+    renderer.setMode(StreamlineOverlayRenderer::Mode::Streamline);
+    EXPECT_EQ(renderer.mode(), StreamlineOverlayRenderer::Mode::Streamline);
+}
+
+TEST(StreamlineOverlayRendererTest, OpacityClamping) {
+    StreamlineOverlayRenderer renderer;
+    renderer.setOpacity(-0.5);
+    EXPECT_DOUBLE_EQ(renderer.opacity(), 0.0);
+
+    renderer.setOpacity(1.5);
+    EXPECT_DOUBLE_EQ(renderer.opacity(), 1.0);
+
+    renderer.setOpacity(0.7);
+    EXPECT_DOUBLE_EQ(renderer.opacity(), 0.7);
+}
+
+TEST(StreamlineOverlayRendererTest, VisibilityToggle) {
+    StreamlineOverlayRenderer renderer;
+    EXPECT_TRUE(renderer.isVisible());
+
+    renderer.setVisible(false);
+    EXPECT_FALSE(renderer.isVisible());
+
+    renderer.setVisible(true);
+    EXPECT_TRUE(renderer.isVisible());
+}
+
+// =============================================================================
+// Renderer Attachment
+// =============================================================================
+
+TEST(StreamlineOverlayRendererTest, SetRenderers) {
+    StreamlineOverlayRenderer renderer;
+
+    auto axial = vtkSmartPointer<vtkRenderer>::New();
+    auto coronal = vtkSmartPointer<vtkRenderer>::New();
+    auto sagittal = vtkSmartPointer<vtkRenderer>::New();
+
+    renderer.setRenderers(axial, coronal, sagittal);
+
+    // Actors should be added (2 per plane: streamline + LIC)
+    EXPECT_GT(axial->GetViewProps()->GetNumberOfItems(), 0);
+    EXPECT_GT(coronal->GetViewProps()->GetNumberOfItems(), 0);
+    EXPECT_GT(sagittal->GetViewProps()->GetNumberOfItems(), 0);
+}
+
+// =============================================================================
+// Slice Position
+// =============================================================================
+
+TEST(StreamlineOverlayRendererTest, SetSlicePositionWithoutField) {
+    StreamlineOverlayRenderer renderer;
+    auto result = renderer.setSlicePosition(MPRPlane::Axial, 5.0);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), OverlayError::NoScalarField);
+}
+
+TEST(StreamlineOverlayRendererTest, SetSlicePositionSuccess) {
+    StreamlineOverlayRenderer renderer;
+    renderer.setVelocityField(createUniformVelocityField(16, 16, 16, 1.0, 0.0, 0.0));
+
+    auto r = renderer.setSlicePosition(MPRPlane::Axial, 8.0);
+    EXPECT_TRUE(r.has_value());
+
+    r = renderer.setSlicePosition(MPRPlane::Coronal, 8.0);
+    EXPECT_TRUE(r.has_value());
+
+    r = renderer.setSlicePosition(MPRPlane::Sagittal, 8.0);
+    EXPECT_TRUE(r.has_value());
+}
+
+// =============================================================================
+// Extract Slice Velocity
+// =============================================================================
+
+TEST(StreamlineOverlayRendererTest, ExtractAxialSliceVelocity) {
+    auto field = createUniformVelocityField(8, 8, 8, 5.0, 10.0, 15.0);
+    auto result = StreamlineOverlayRenderer::extractSliceVelocity(
+        field, MPRPlane::Axial, 4.0);
+    ASSERT_TRUE(result.has_value());
+
+    auto& slice = *result;
+    int* dims = slice->GetDimensions();
+    EXPECT_EQ(dims[0], 8);  // X preserved
+    EXPECT_EQ(dims[1], 8);  // Y preserved
+    EXPECT_EQ(dims[2], 1);  // 2D
+
+    // Axial extracts (Vx, Vy) = (5.0, 10.0)
+    auto* ptr = static_cast<float*>(slice->GetScalarPointer());
+    EXPECT_NEAR(ptr[0], 5.0f, 1e-5f);   // Vx
+    EXPECT_NEAR(ptr[1], 10.0f, 1e-5f);  // Vy
+    EXPECT_NEAR(ptr[2], 0.0f, 1e-5f);   // Z = 0
+
+    // Should have vectors set for vtkStreamTracer
+    EXPECT_NE(slice->GetPointData()->GetVectors(), nullptr);
+}
+
+TEST(StreamlineOverlayRendererTest, ExtractCoronalSliceVelocity) {
+    auto field = createUniformVelocityField(8, 8, 8, 5.0, 10.0, 15.0);
+    auto result = StreamlineOverlayRenderer::extractSliceVelocity(
+        field, MPRPlane::Coronal, 4.0);
+    ASSERT_TRUE(result.has_value());
+
+    auto& slice = *result;
+    int* dims = slice->GetDimensions();
+    EXPECT_EQ(dims[0], 8);  // X preserved
+    EXPECT_EQ(dims[1], 8);  // Z mapped to Y dimension
+
+    // Coronal extracts (Vx, Vz) = (5.0, 15.0)
+    auto* ptr = static_cast<float*>(slice->GetScalarPointer());
+    EXPECT_NEAR(ptr[0], 5.0f, 1e-5f);   // Vx
+    EXPECT_NEAR(ptr[1], 15.0f, 1e-5f);  // Vz
+}
+
+TEST(StreamlineOverlayRendererTest, ExtractSagittalSliceVelocity) {
+    auto field = createUniformVelocityField(8, 8, 8, 5.0, 10.0, 15.0);
+    auto result = StreamlineOverlayRenderer::extractSliceVelocity(
+        field, MPRPlane::Sagittal, 4.0);
+    ASSERT_TRUE(result.has_value());
+
+    auto& slice = *result;
+    int* dims = slice->GetDimensions();
+    EXPECT_EQ(dims[0], 8);  // Y mapped to X
+    EXPECT_EQ(dims[1], 8);  // Z mapped to Y
+
+    // Sagittal extracts (Vy, Vz) = (10.0, 15.0)
+    auto* ptr = static_cast<float*>(slice->GetScalarPointer());
+    EXPECT_NEAR(ptr[0], 10.0f, 1e-5f);  // Vy
+    EXPECT_NEAR(ptr[1], 15.0f, 1e-5f);  // Vz
+}
+
+TEST(StreamlineOverlayRendererTest, ExtractSliceNullInput) {
+    auto result = StreamlineOverlayRenderer::extractSliceVelocity(
+        nullptr, MPRPlane::Axial, 0.0);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), OverlayError::NoScalarField);
+}
+
+TEST(StreamlineOverlayRendererTest, ExtractSliceScalarInput) {
+    // Scalar field (1 component) should fail
+    auto scalar = vtkSmartPointer<vtkImageData>::New();
+    scalar->SetDimensions(4, 4, 4);
+    scalar->AllocateScalars(VTK_FLOAT, 1);
+
+    auto result = StreamlineOverlayRenderer::extractSliceVelocity(
+        scalar, MPRPlane::Axial, 0.0);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(StreamlineOverlayRendererTest, ExtractSliceVelocityMagnitudeArray) {
+    auto field = createUniformVelocityField(8, 8, 8, 3.0, 4.0, 0.0);
+    auto result = StreamlineOverlayRenderer::extractSliceVelocity(
+        field, MPRPlane::Axial, 4.0);
+    ASSERT_TRUE(result.has_value());
+
+    // Should have VelocityMagnitude array
+    auto* magArray = (*result)->GetPointData()->GetArray("VelocityMagnitude");
+    ASSERT_NE(magArray, nullptr);
+
+    // |V| = sqrt(3^2 + 4^2) = 5.0 for axial (Vx, Vy)
+    EXPECT_NEAR(magArray->GetComponent(0, 0), 5.0, 1e-4);
+}
+
+// =============================================================================
+// 2D Streamline Generation
+// =============================================================================
+
+TEST(StreamlineOverlayRendererTest, GenerateStreamlinesFromUniformField) {
+    auto field = createUniformVelocityField(16, 16, 16, 10.0, 0.0, 0.0);
+    auto sliceResult = StreamlineOverlayRenderer::extractSliceVelocity(
+        field, MPRPlane::Axial, 8.0);
+    ASSERT_TRUE(sliceResult.has_value());
+
+    Streamline2DParams params;
+    params.numSeedPoints = 25;
+    params.maxSteps = 100;
+
+    auto result = StreamlineOverlayRenderer::generateStreamlines2D(
+        *sliceResult, params);
+    ASSERT_TRUE(result.has_value());
+
+    auto& polyData = *result;
+    // Should produce some streamline geometry
+    EXPECT_GT(polyData->GetNumberOfPoints(), 0);
+    EXPECT_GT(polyData->GetNumberOfCells(), 0);
+
+    // Should have velocity magnitude scalars for color coding
+    EXPECT_NE(polyData->GetPointData()->GetScalars(), nullptr);
+}
+
+TEST(StreamlineOverlayRendererTest, GenerateStreamlinesFromVortexField) {
+    auto field = createVortexVelocityField(16);
+    auto sliceResult = StreamlineOverlayRenderer::extractSliceVelocity(
+        field, MPRPlane::Axial, 8.0);
+    ASSERT_TRUE(sliceResult.has_value());
+
+    Streamline2DParams params;
+    params.numSeedPoints = 36;
+    params.maxSteps = 200;
+
+    auto result = StreamlineOverlayRenderer::generateStreamlines2D(
+        *sliceResult, params);
+    ASSERT_TRUE(result.has_value());
+
+    EXPECT_GT((*result)->GetNumberOfPoints(), 0);
+}
+
+TEST(StreamlineOverlayRendererTest, GenerateStreamlinesNullInput) {
+    auto result = StreamlineOverlayRenderer::generateStreamlines2D(nullptr);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), OverlayError::NoScalarField);
+}
+
+TEST(StreamlineOverlayRendererTest, GenerateStreamlinesNoVectors) {
+    // Create an image without vectors set
+    auto image = vtkSmartPointer<vtkImageData>::New();
+    image->SetDimensions(8, 8, 1);
+    image->AllocateScalars(VTK_FLOAT, 3);
+
+    // No SetVectors() call
+    auto result = StreamlineOverlayRenderer::generateStreamlines2D(image);
+    EXPECT_FALSE(result.has_value());
+}
+
+// =============================================================================
+// LIC Texture Computation
+// =============================================================================
+
+TEST(StreamlineOverlayRendererTest, ComputeLICFromUniformField) {
+    auto field = createUniformVelocityField(16, 16, 16, 10.0, 0.0, 0.0);
+    auto sliceResult = StreamlineOverlayRenderer::extractSliceVelocity(
+        field, MPRPlane::Axial, 8.0);
+    ASSERT_TRUE(sliceResult.has_value());
+
+    LICParams params;
+    params.kernelLength = 10;
+
+    auto result = StreamlineOverlayRenderer::computeLIC(*sliceResult, params);
+    ASSERT_TRUE(result.has_value());
+
+    auto& licTexture = *result;
+    int* dims = licTexture->GetDimensions();
+    EXPECT_EQ(dims[0], 16);
+    EXPECT_EQ(dims[1], 16);
+    EXPECT_EQ(dims[2], 1);
+
+    // Should be unsigned char (grayscale)
+    EXPECT_EQ(licTexture->GetScalarType(), VTK_UNSIGNED_CHAR);
+    EXPECT_EQ(licTexture->GetNumberOfScalarComponents(), 1);
+
+    // LIC values should be in [0, 255]
+    auto* ptr = static_cast<unsigned char*>(licTexture->GetScalarPointer());
+    bool hasNonZero = false;
+    for (int i = 0; i < 16 * 16; ++i) {
+        EXPECT_GE(ptr[i], 0);
+        EXPECT_LE(ptr[i], 255);
+        if (ptr[i] > 0) hasNonZero = true;
+    }
+    EXPECT_TRUE(hasNonZero);
+}
+
+TEST(StreamlineOverlayRendererTest, ComputeLICFromVortexField) {
+    auto field = createVortexVelocityField(16);
+    auto sliceResult = StreamlineOverlayRenderer::extractSliceVelocity(
+        field, MPRPlane::Axial, 8.0);
+    ASSERT_TRUE(sliceResult.has_value());
+
+    auto result = StreamlineOverlayRenderer::computeLIC(*sliceResult);
+    ASSERT_TRUE(result.has_value());
+
+    EXPECT_EQ((*result)->GetDimensions()[0], 16);
+    EXPECT_EQ((*result)->GetDimensions()[1], 16);
+}
+
+TEST(StreamlineOverlayRendererTest, ComputeLICNullInput) {
+    auto result = StreamlineOverlayRenderer::computeLIC(nullptr);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), OverlayError::NoScalarField);
+}
+
+TEST(StreamlineOverlayRendererTest, ComputeLICReproducible) {
+    auto field = createVortexVelocityField(8);
+    auto sliceResult = StreamlineOverlayRenderer::extractSliceVelocity(
+        field, MPRPlane::Axial, 4.0);
+    ASSERT_TRUE(sliceResult.has_value());
+
+    LICParams params;
+    params.noiseSeed = 123;
+
+    auto r1 = StreamlineOverlayRenderer::computeLIC(*sliceResult, params);
+    auto r2 = StreamlineOverlayRenderer::computeLIC(*sliceResult, params);
+    ASSERT_TRUE(r1.has_value());
+    ASSERT_TRUE(r2.has_value());
+
+    auto* p1 = static_cast<unsigned char*>((*r1)->GetScalarPointer());
+    auto* p2 = static_cast<unsigned char*>((*r2)->GetScalarPointer());
+
+    // Same seed should produce identical results
+    for (int i = 0; i < 8 * 8; ++i) {
+        EXPECT_EQ(p1[i], p2[i]);
+    }
+}
+
+// =============================================================================
+// OverlayType Enum Integration
+// =============================================================================
+
+TEST(StreamlineOverlayRendererTest, OverlayTypeEnumValues) {
+    // Verify the new enum values exist and are distinct
+    EXPECT_NE(static_cast<int>(OverlayType::Streamline),
+              static_cast<int>(OverlayType::VelocityMagnitude));
+    EXPECT_NE(static_cast<int>(OverlayType::VelocityTexture),
+              static_cast<int>(OverlayType::Streamline));
+}
+
+TEST(StreamlineOverlayRendererTest, DefaultColormapForStreamline) {
+    auto preset = HemodynamicOverlayRenderer::defaultColormapForType(
+        OverlayType::Streamline);
+    EXPECT_EQ(preset, ColormapPreset::Jet);
+}
+
+TEST(StreamlineOverlayRendererTest, DefaultColormapForVelocityTexture) {
+    auto preset = HemodynamicOverlayRenderer::defaultColormapForType(
+        OverlayType::VelocityTexture);
+    EXPECT_EQ(preset, ColormapPreset::Viridis);
+}
+
+// =============================================================================
+// Full Pipeline Integration
+// =============================================================================
+
+TEST(StreamlineOverlayRendererTest, FullStreamlinePipeline) {
+    StreamlineOverlayRenderer renderer;
+    auto field = createVortexVelocityField(16);
+
+    renderer.setVelocityField(field);
+    renderer.setMode(StreamlineOverlayRenderer::Mode::Streamline);
+
+    Streamline2DParams params;
+    params.numSeedPoints = 16;
+    renderer.setStreamlineParams(params);
+
+    auto axial = vtkSmartPointer<vtkRenderer>::New();
+    auto coronal = vtkSmartPointer<vtkRenderer>::New();
+    auto sagittal = vtkSmartPointer<vtkRenderer>::New();
+    renderer.setRenderers(axial, coronal, sagittal);
+
+    auto r = renderer.setSlicePosition(MPRPlane::Axial, 8.0);
+    EXPECT_TRUE(r.has_value());
+
+    // Should not crash
+    renderer.updatePlane(MPRPlane::Axial);
+}
+
+TEST(StreamlineOverlayRendererTest, FullLICPipeline) {
+    StreamlineOverlayRenderer renderer;
+    auto field = createVortexVelocityField(16);
+
+    renderer.setVelocityField(field);
+    renderer.setMode(StreamlineOverlayRenderer::Mode::LIC);
+
+    LICParams params;
+    params.kernelLength = 5;
+    renderer.setLICParams(params);
+
+    auto axial = vtkSmartPointer<vtkRenderer>::New();
+    auto coronal = vtkSmartPointer<vtkRenderer>::New();
+    auto sagittal = vtkSmartPointer<vtkRenderer>::New();
+    renderer.setRenderers(axial, coronal, sagittal);
+
+    auto r = renderer.setSlicePosition(MPRPlane::Axial, 8.0);
+    EXPECT_TRUE(r.has_value());
+
+    // Should not crash
+    renderer.updatePlane(MPRPlane::Axial);
+}
+
+TEST(StreamlineOverlayRendererTest, UpdateAllPlanes) {
+    StreamlineOverlayRenderer renderer;
+    auto field = createUniformVelocityField(8, 8, 8, 5.0, 5.0, 0.0);
+
+    renderer.setVelocityField(field);
+    auto axial = vtkSmartPointer<vtkRenderer>::New();
+    auto coronal = vtkSmartPointer<vtkRenderer>::New();
+    auto sagittal = vtkSmartPointer<vtkRenderer>::New();
+    renderer.setRenderers(axial, coronal, sagittal);
+
+    renderer.setSlicePosition(MPRPlane::Axial, 4.0);
+    renderer.setSlicePosition(MPRPlane::Coronal, 4.0);
+    renderer.setSlicePosition(MPRPlane::Sagittal, 4.0);
+
+    // Should not crash
+    renderer.update();
+}


### PR DESCRIPTION
## Summary
- Add `StreamlineOverlayRenderer` class for rendering 2D flow visualization overlays on MPR views
- Support two modes: **Streamline** (vtkStreamTracer with velocity-magnitude coloring) and **LIC** (Line Integral Convolution grayscale texture)
- Add `extractSliceVelocity()` to extract 2D in-plane velocity vectors from 3D velocity fields per MPR plane
- Add `Streamline` and `VelocityTexture` to `OverlayType` enum with default colormap mappings
- 29 new unit tests covering all features

## Architecture
```
3D velocity field (3-component vtkImageData)
  -> extractSliceVelocity() -> 2D in-plane velocity
    -> Mode::Streamline: vtkStreamTracer -> polydata -> vtkActor
    -> Mode::LIC: Euler-trace noise convolution -> grayscale vtkImageData -> vtkImageActor
```

## Test Plan
- [x] 29 streamline overlay renderer tests pass
- [x] 37 hemodynamic overlay renderer tests pass (no regression)
- [x] Slice velocity extraction verified for all 3 MPR planes
- [x] Streamline generation from uniform and vortex velocity fields
- [x] LIC computation with reproducibility (deterministic noise seed)
- [x] Full pipeline integration tests for both modes

Closes #324