### PR TITLE
feat(ui): add resizable quad-split, independent W/L, and layout persistence

### DIFF
--- a/include/core/project_manager.hpp
+++ b/include/core/project_manager.hpp
@@ -64,6 +64,7 @@ struct ViewState {
     int sliceIndex = 0;
     int phaseIndex = 0;
     std::string activeView = "axial";  ///< axial, sagittal, coronal
+    std::string layoutMode = "single"; ///< single, dual, quad
 };
 
 /**

--- a/include/ui/main_window.hpp
+++ b/include/ui/main_window.hpp
@@ -55,6 +55,7 @@ public slots:
 protected:
     void closeEvent(QCloseEvent* event) override;
     void showEvent(QShowEvent* event) override;
+    bool eventFilter(QObject* watched, QEvent* event) override;
 
 private:
     void setupUI();

--- a/include/ui/viewport_layout_manager.hpp
+++ b/include/ui/viewport_layout_manager.hpp
@@ -67,6 +67,18 @@ public:
      */
     [[nodiscard]] int viewportCount() const;
 
+    /**
+     * @brief Get the active (focused) viewport index
+     * @return 0-based index of the last-interacted viewport
+     */
+    [[nodiscard]] int activeViewportIndex() const;
+
+    /**
+     * @brief Get the active viewport widget
+     * @return Pointer to the active viewport
+     */
+    [[nodiscard]] ViewportWidget* activeViewport() const;
+
 public slots:
     /**
      * @brief Switch layout mode
@@ -74,12 +86,25 @@ public slots:
      */
     void setLayoutMode(LayoutMode mode);
 
+    /**
+     * @brief Set the active viewport by index
+     * @param index 0-based viewport index
+     */
+    void setActiveViewport(int index);
+
 signals:
     /**
      * @brief Emitted when layout mode changes
      * @param mode New layout mode
      */
     void layoutModeChanged(LayoutMode mode);
+
+    /**
+     * @brief Emitted when active viewport changes
+     * @param viewport The newly active viewport
+     * @param index The viewport index
+     */
+    void activeViewportChanged(ViewportWidget* viewport, int index);
 
 private:
     void buildSingleLayout();

--- a/src/core/project_manager.cpp
+++ b/src/core/project_manager.cpp
@@ -82,7 +82,8 @@ nlohmann::json viewStateToJson(const ViewState& v) {
     return {
         {"slice_index", v.sliceIndex},
         {"phase_index", v.phaseIndex},
-        {"active_view", v.activeView}
+        {"active_view", v.activeView},
+        {"layout_mode", v.layoutMode}
     };
 }
 
@@ -91,6 +92,7 @@ ViewState viewStateFromJson(const nlohmann::json& j) {
     v.sliceIndex = j.value("slice_index", 0);
     v.phaseIndex = j.value("phase_index", 0);
     v.activeView = j.value("active_view", "axial");
+    v.layoutMode = j.value("layout_mode", "single");
     return v;
 }
 

--- a/tests/unit/project_manager_test.cpp
+++ b/tests/unit/project_manager_test.cpp
@@ -167,7 +167,7 @@ TEST(ProjectManagerTest, SaveLoadRoundtrip) {
         "1.2.3.4.5.6.7.8"
     });
     saver.setDisplaySettings(DisplaySettings{400.0, 1500.0, true, 0.7});
-    saver.setViewState(ViewState{42, 3, "coronal"});
+    saver.setViewState(ViewState{42, 3, "coronal", "quad"});
 
     // Save
     auto saveResult = saver.saveProject(tmp.path());
@@ -200,6 +200,7 @@ TEST(ProjectManagerTest, SaveLoadRoundtrip) {
     EXPECT_EQ(loader.viewState().sliceIndex, 42);
     EXPECT_EQ(loader.viewState().phaseIndex, 3);
     EXPECT_EQ(loader.viewState().activeView, "coronal");
+    EXPECT_EQ(loader.viewState().layoutMode, "quad");
 
     // Verify state after load
     EXPECT_FALSE(loader.isModified());


### PR DESCRIPTION
Closes #244

## Summary
- Replace QGridLayout in QuadSplit mode with nested QSplitters for user-resizable panels
- Add active viewport tracking with dynamic ToolsPanel W/L binding per viewport
- Persist layout mode preference in QSettings and ViewState project file

## Changes

### Resizable QuadSplit (Task 7)
QuadSplit layout now uses nested `QSplitter` widgets (vertical outer, two horizontal inner) instead of `QGridLayout`. Users can drag borders between Axial/Sagittal/Coronal/3D panels to resize them.

### Independent W/L per Panel (Task 8)
Added `activeViewport()` tracking to `ViewportLayoutManager`. When the user clicks a viewport, it becomes the active target for ToolsPanel W/L controls. Each viewport maintains its own window/level independently.

### Layout Persistence (Acceptance Criteria)
Layout mode (Single/Dual/Quad) is saved in `QSettings` on close and restored on startup. The `ViewState` struct now includes a `layoutMode` field for per-project persistence.

## Test Plan
- [x] All 18 ViewportLayoutManager tests pass (including 5 new active viewport tests)
- [x] All 30 ProjectManager tests pass (including layoutMode round-trip)
- [x] Application builds successfully
- [ ] Manual: Switch layout modes via toolbar and verify splitter resizing in QuadSplit
- [ ] Manual: Click different viewports and verify W/L controls bind to clicked panel