### PR TITLE
feat(rendering): add vorticity and energy loss 3D volume overlay convenience methods

### DIFF
--- a/include/services/volume_renderer.hpp
+++ b/include/services/volume_renderer.hpp
@@ -236,6 +236,44 @@ public:
     [[nodiscard]] static vtkSmartPointer<vtkPiecewiseFunction>
     createVelocityOpacityFunction(double maxVelocity, double baseOpacity = 0.3);
 
+    // ==================== Convenience: Vorticity Overlay ====================
+
+    /**
+     * @brief Create a blue-white-red colormap for vorticity magnitude
+     * @param maxVorticity Maximum vorticity in 1/s
+     * @return Configured color transfer function
+     */
+    [[nodiscard]] static vtkSmartPointer<vtkColorTransferFunction>
+    createVorticityColorFunction(double maxVorticity);
+
+    /**
+     * @brief Create an opacity transfer function for vorticity overlay
+     * @param maxVorticity Maximum vorticity in 1/s
+     * @param baseOpacity Base opacity for visible regions (0.0-1.0)
+     * @return Configured opacity transfer function
+     */
+    [[nodiscard]] static vtkSmartPointer<vtkPiecewiseFunction>
+    createVorticityOpacityFunction(double maxVorticity, double baseOpacity = 0.3);
+
+    // ==================== Convenience: Energy Loss Overlay ====================
+
+    /**
+     * @brief Create a hot metal colormap for energy loss (viscous dissipation)
+     * @param maxEnergyLoss Maximum energy loss in W/m^3
+     * @return Configured color transfer function
+     */
+    [[nodiscard]] static vtkSmartPointer<vtkColorTransferFunction>
+    createEnergyLossColorFunction(double maxEnergyLoss);
+
+    /**
+     * @brief Create an opacity transfer function for energy loss overlay
+     * @param maxEnergyLoss Maximum energy loss in W/m^3
+     * @param baseOpacity Base opacity for visible regions (0.0-1.0)
+     * @return Configured opacity transfer function
+     */
+    [[nodiscard]] static vtkSmartPointer<vtkPiecewiseFunction>
+    createEnergyLossOpacityFunction(double maxEnergyLoss, double baseOpacity = 0.3);
+
 private:
     class Impl;
     std::unique_ptr<Impl> impl_;

--- a/src/services/render/volume_renderer.cpp
+++ b/src/services/render/volume_renderer.cpp
@@ -529,4 +529,58 @@ VolumeRenderer::createVelocityOpacityFunction(double maxVelocity, double baseOpa
     return opacityTF;
 }
 
+vtkSmartPointer<vtkColorTransferFunction>
+VolumeRenderer::createVorticityColorFunction(double maxVorticity)
+{
+    auto colorTF = vtkSmartPointer<vtkColorTransferFunction>::New();
+    // Blue-white-red colormap for vorticity magnitude
+    colorTF->AddRGBPoint(0.0, 0.0, 0.0, 0.5);                       // Dark blue
+    colorTF->AddRGBPoint(maxVorticity * 0.15, 0.0, 0.0, 1.0);       // Blue
+    colorTF->AddRGBPoint(maxVorticity * 0.35, 0.5, 0.5, 1.0);       // Light blue
+    colorTF->AddRGBPoint(maxVorticity * 0.5, 1.0, 1.0, 1.0);        // White
+    colorTF->AddRGBPoint(maxVorticity * 0.65, 1.0, 0.5, 0.5);       // Light red
+    colorTF->AddRGBPoint(maxVorticity * 0.85, 1.0, 0.0, 0.0);       // Red
+    colorTF->AddRGBPoint(maxVorticity, 0.5, 0.0, 0.0);              // Dark red
+    return colorTF;
+}
+
+vtkSmartPointer<vtkPiecewiseFunction>
+VolumeRenderer::createVorticityOpacityFunction(double maxVorticity, double baseOpacity)
+{
+    auto opacityTF = vtkSmartPointer<vtkPiecewiseFunction>::New();
+    // Low vorticity = transparent, high vorticity = visible
+    opacityTF->AddPoint(0.0, 0.0);
+    opacityTF->AddPoint(maxVorticity * 0.1, 0.0);                    // Below 10% → invisible
+    opacityTF->AddPoint(maxVorticity * 0.2, baseOpacity * 0.2);      // Fade in
+    opacityTF->AddPoint(maxVorticity * 0.5, baseOpacity * 0.5);      // Mid range
+    opacityTF->AddPoint(maxVorticity, baseOpacity);                   // Full opacity at max
+    return opacityTF;
+}
+
+vtkSmartPointer<vtkColorTransferFunction>
+VolumeRenderer::createEnergyLossColorFunction(double maxEnergyLoss)
+{
+    auto colorTF = vtkSmartPointer<vtkColorTransferFunction>::New();
+    // Hot metal colormap: black → red → yellow → white
+    colorTF->AddRGBPoint(0.0, 0.0, 0.0, 0.0);                       // Black
+    colorTF->AddRGBPoint(maxEnergyLoss * 0.25, 0.5, 0.0, 0.0);      // Dark red
+    colorTF->AddRGBPoint(maxEnergyLoss * 0.5, 1.0, 0.0, 0.0);       // Red
+    colorTF->AddRGBPoint(maxEnergyLoss * 0.75, 1.0, 0.75, 0.0);     // Orange-yellow
+    colorTF->AddRGBPoint(maxEnergyLoss, 1.0, 1.0, 0.8);             // Near white
+    return colorTF;
+}
+
+vtkSmartPointer<vtkPiecewiseFunction>
+VolumeRenderer::createEnergyLossOpacityFunction(double maxEnergyLoss, double baseOpacity)
+{
+    auto opacityTF = vtkSmartPointer<vtkPiecewiseFunction>::New();
+    // Low energy loss = transparent, high energy loss = visible
+    opacityTF->AddPoint(0.0, 0.0);
+    opacityTF->AddPoint(maxEnergyLoss * 0.05, 0.0);                  // Below 5% → invisible
+    opacityTF->AddPoint(maxEnergyLoss * 0.15, baseOpacity * 0.2);    // Fade in
+    opacityTF->AddPoint(maxEnergyLoss * 0.5, baseOpacity * 0.6);     // Mid range
+    opacityTF->AddPoint(maxEnergyLoss, baseOpacity);                  // Full opacity at max
+    return opacityTF;
+}
+
 } // namespace dicom_viewer::services


### PR DESCRIPTION
Closes #315

## Summary
- Add `createVorticityColorFunction()` / `createVorticityOpacityFunction()` to VolumeRenderer with blue-white-red (CoolWarm) colormap
- Add `createEnergyLossColorFunction()` / `createEnergyLossOpacityFunction()` to VolumeRenderer with hot metal colormap
- Both follow the existing velocity overlay pattern with low-value transparency ramps
- ITK FloatImage3D to vtkImageData conversion already exists via `ImageConverter::itkToVtk(FloatImageType::Pointer)` — no new conversion utility needed
- Add 8 new unit tests covering color/opacity verification, end-to-end overlay creation, and multi-overlay coexistence

## Test Plan
- [x] 25 VolumeRendererOverlayTest tests pass (17 existing + 8 new)
- [x] Main application builds without errors
- [ ] Visual verification: vorticity volume renders with blue-white-red colormap
- [ ] Visual verification: energy loss volume renders with hot metal colormap

Part of #280, #242