### PR TITLE
feat(ui): add Display 2D/3D checkbox groups to FlowToolPanel

### DIFF
--- a/include/ui/panels/flow_tool_panel.hpp
+++ b/include/ui/panels/flow_tool_panel.hpp
@@ -17,10 +17,41 @@ enum class FlowSeries {
 };
 
 /**
+ * @brief 2D hemodynamic overlay items toggleable in the tool panel
+ */
+enum class Display2DItem {
+    Mask,              ///< Segmentation mask overlay
+    Velocity,          ///< Velocity magnitude colormap
+    Streamline,        ///< 2D flow streamlines
+    EnergyLoss,        ///< Viscous dissipation rate
+    Vorticity,         ///< Vorticity magnitude
+    VelocityTexture    ///< Line Integral Convolution (LIC)
+};
+
+/**
+ * @brief 3D visualization items toggleable in the tool panel
+ */
+enum class Display3DItem {
+    MaskVolume,   ///< Segmentation mask volume rendering
+    Surface,      ///< Isosurface mesh
+    Cine,         ///< Cine playback in 3D
+    Magnitude,    ///< Magnitude volume rendering
+    Velocity,     ///< Velocity volume overlay
+    ASC,          ///< Aortic sinus/cusp view
+    Streamline,   ///< 3D streamlines
+    EnergyLoss,   ///< Energy loss volume
+    WSS,          ///< Wall Shear Stress surface coloring
+    OSI,          ///< Oscillatory Shear Index surface coloring
+    AFI,          ///< Aneurysm Formation Indicator surface coloring
+    RRT,          ///< Relative Residence Time surface coloring
+    Vorticity     ///< Vorticity volume
+};
+
+/**
  * @brief Left tool panel for 4D Flow analysis workflow
  *
  * Provides collapsible sections for Settings, Series selection,
- * and placeholders for Display 2D, Display 3D, Mask, and 3D Objects.
+ * Display 2D overlay checkboxes, and Display 3D visualization toggles.
  * Uses QToolBox for collapsible section management.
  *
  * Layout:
@@ -28,8 +59,8 @@ enum class FlowSeries {
  * Flow Tool Panel
  * +-- Settings (Phase/Slice info)
  * +-- Series (Mag/RL/AP/FH/PC-MRA toggle buttons)
- * +-- Display 2D (placeholder)
- * +-- Display 3D (placeholder)
+ * +-- Display 2D (Mask/Velocity/Streamline/EnergyLoss/Vorticity/VelTexture)
+ * +-- Display 3D (MaskVol/Surface/Cine/Mag/Vel/ASC/Streamline/EL/WSS/OSI/AFI/RRT/Vorticity)
  * @endcode
  *
  * @trace SRS-FR-046, PRD FR-015
@@ -49,6 +80,16 @@ public:
      * @brief Get the currently selected series
      */
     [[nodiscard]] FlowSeries selectedSeries() const;
+
+    /**
+     * @brief Check if a 2D display item is enabled
+     */
+    [[nodiscard]] bool isDisplay2DEnabled(Display2DItem item) const;
+
+    /**
+     * @brief Check if a 3D display item is enabled
+     */
+    [[nodiscard]] bool isDisplay3DEnabled(Display3DItem item) const;
 
     /**
      * @brief Enable or disable the panel based on data availability
@@ -75,6 +116,16 @@ public slots:
      */
     void setSelectedSeries(FlowSeries series);
 
+    /**
+     * @brief Set a 2D display item checked/unchecked programmatically
+     */
+    void setDisplay2DEnabled(Display2DItem item, bool enabled);
+
+    /**
+     * @brief Set a 3D display item checked/unchecked programmatically
+     */
+    void setDisplay3DEnabled(Display3DItem item, bool enabled);
+
 signals:
     /**
      * @brief Emitted when the user selects a different velocity series
@@ -82,12 +133,27 @@ signals:
      */
     void seriesSelectionChanged(FlowSeries series);
 
+    /**
+     * @brief Emitted when a 2D display checkbox is toggled
+     * @param item The display item
+     * @param enabled True if checked
+     */
+    void display2DToggled(Display2DItem item, bool enabled);
+
+    /**
+     * @brief Emitted when a 3D display checkbox is toggled
+     * @param item The display item
+     * @param enabled True if checked
+     */
+    void display3DToggled(Display3DItem item, bool enabled);
+
 private:
     void setupUI();
     void setupConnections();
     void createSettingsSection();
     void createSeriesSection();
-    void createPlaceholderSections();
+    void createDisplay2DSection();
+    void createDisplay3DSection();
 
     class Impl;
     std::unique_ptr<Impl> impl_;

--- a/tests/unit/flow_tool_panel_test.cpp
+++ b/tests/unit/flow_tool_panel_test.cpp
@@ -124,3 +124,109 @@ TEST(FlowToolPanelTest, SetFlowDataAvailable_EnableDisable) {
     // Series selection should persist even when disabled
     EXPECT_EQ(panel.selectedSeries(), FlowSeries::FH);
 }
+
+// =============================================================================
+// Display 2D checkboxes
+// =============================================================================
+
+TEST(FlowToolPanelTest, Display2D_AllDisabledByDefault) {
+    FlowToolPanel panel;
+    EXPECT_FALSE(panel.isDisplay2DEnabled(Display2DItem::Mask));
+    EXPECT_FALSE(panel.isDisplay2DEnabled(Display2DItem::Velocity));
+    EXPECT_FALSE(panel.isDisplay2DEnabled(Display2DItem::Streamline));
+    EXPECT_FALSE(panel.isDisplay2DEnabled(Display2DItem::EnergyLoss));
+    EXPECT_FALSE(panel.isDisplay2DEnabled(Display2DItem::Vorticity));
+    EXPECT_FALSE(panel.isDisplay2DEnabled(Display2DItem::VelocityTexture));
+}
+
+TEST(FlowToolPanelTest, Display2D_SetEnabled) {
+    FlowToolPanel panel;
+    panel.setFlowDataAvailable(true);
+
+    panel.setDisplay2DEnabled(Display2DItem::Velocity, true);
+    EXPECT_TRUE(panel.isDisplay2DEnabled(Display2DItem::Velocity));
+    EXPECT_FALSE(panel.isDisplay2DEnabled(Display2DItem::Mask));
+
+    panel.setDisplay2DEnabled(Display2DItem::Velocity, false);
+    EXPECT_FALSE(panel.isDisplay2DEnabled(Display2DItem::Velocity));
+}
+
+TEST(FlowToolPanelTest, Display2D_MultipleCheckboxes) {
+    FlowToolPanel panel;
+    panel.setFlowDataAvailable(true);
+
+    panel.setDisplay2DEnabled(Display2DItem::Vorticity, true);
+    panel.setDisplay2DEnabled(Display2DItem::EnergyLoss, true);
+
+    EXPECT_TRUE(panel.isDisplay2DEnabled(Display2DItem::Vorticity));
+    EXPECT_TRUE(panel.isDisplay2DEnabled(Display2DItem::EnergyLoss));
+    EXPECT_FALSE(panel.isDisplay2DEnabled(Display2DItem::Streamline));
+}
+
+TEST(FlowToolPanelTest, Display2D_SignalNotEmittedOnProgrammatic) {
+    FlowToolPanel panel;
+    panel.setFlowDataAvailable(true);
+
+    QSignalSpy spy(&panel, &FlowToolPanel::display2DToggled);
+    ASSERT_TRUE(spy.isValid());
+
+    panel.setDisplay2DEnabled(Display2DItem::Velocity, true);
+    EXPECT_EQ(spy.count(), 0);
+}
+
+// =============================================================================
+// Display 3D checkboxes
+// =============================================================================
+
+TEST(FlowToolPanelTest, Display3D_AllDisabledByDefault) {
+    FlowToolPanel panel;
+    EXPECT_FALSE(panel.isDisplay3DEnabled(Display3DItem::MaskVolume));
+    EXPECT_FALSE(panel.isDisplay3DEnabled(Display3DItem::Surface));
+    EXPECT_FALSE(panel.isDisplay3DEnabled(Display3DItem::Cine));
+    EXPECT_FALSE(panel.isDisplay3DEnabled(Display3DItem::Magnitude));
+    EXPECT_FALSE(panel.isDisplay3DEnabled(Display3DItem::Velocity));
+    EXPECT_FALSE(panel.isDisplay3DEnabled(Display3DItem::ASC));
+    EXPECT_FALSE(panel.isDisplay3DEnabled(Display3DItem::Streamline));
+    EXPECT_FALSE(panel.isDisplay3DEnabled(Display3DItem::EnergyLoss));
+    EXPECT_FALSE(panel.isDisplay3DEnabled(Display3DItem::WSS));
+    EXPECT_FALSE(panel.isDisplay3DEnabled(Display3DItem::OSI));
+    EXPECT_FALSE(panel.isDisplay3DEnabled(Display3DItem::AFI));
+    EXPECT_FALSE(panel.isDisplay3DEnabled(Display3DItem::RRT));
+    EXPECT_FALSE(panel.isDisplay3DEnabled(Display3DItem::Vorticity));
+}
+
+TEST(FlowToolPanelTest, Display3D_SetEnabled) {
+    FlowToolPanel panel;
+    panel.setFlowDataAvailable(true);
+
+    panel.setDisplay3DEnabled(Display3DItem::WSS, true);
+    EXPECT_TRUE(panel.isDisplay3DEnabled(Display3DItem::WSS));
+
+    panel.setDisplay3DEnabled(Display3DItem::WSS, false);
+    EXPECT_FALSE(panel.isDisplay3DEnabled(Display3DItem::WSS));
+}
+
+TEST(FlowToolPanelTest, Display3D_MultipleSurfaceParams) {
+    FlowToolPanel panel;
+    panel.setFlowDataAvailable(true);
+
+    panel.setDisplay3DEnabled(Display3DItem::WSS, true);
+    panel.setDisplay3DEnabled(Display3DItem::OSI, true);
+    panel.setDisplay3DEnabled(Display3DItem::RRT, true);
+
+    EXPECT_TRUE(panel.isDisplay3DEnabled(Display3DItem::WSS));
+    EXPECT_TRUE(panel.isDisplay3DEnabled(Display3DItem::OSI));
+    EXPECT_TRUE(panel.isDisplay3DEnabled(Display3DItem::RRT));
+    EXPECT_FALSE(panel.isDisplay3DEnabled(Display3DItem::AFI));
+}
+
+TEST(FlowToolPanelTest, Display3D_SignalNotEmittedOnProgrammatic) {
+    FlowToolPanel panel;
+    panel.setFlowDataAvailable(true);
+
+    QSignalSpy spy(&panel, &FlowToolPanel::display3DToggled);
+    ASSERT_TRUE(spy.isValid());
+
+    panel.setDisplay3DEnabled(Display3DItem::Vorticity, true);
+    EXPECT_EQ(spy.count(), 0);
+}


### PR DESCRIPTION
Closes #331

## Summary
- Replace Display 2D/3D placeholder sections with functional checkbox groups
- Display 2D: 6 checkboxes (Mask, Velocity, Streamline, Energy Loss, Vorticity, Vel Texture)
- Display 3D: 13 checkboxes (Mask Vol, Surface, Cine, Mag, Velocity, ASC, Streamline, Energy Loss, WSS, OSI, AFI, RRT, Vorticity)
- Add `Display2DItem` and `Display3DItem` enums for type-safe checkbox identification
- Add public API: `isDisplay2DEnabled`/`setDisplay2DEnabled`, `isDisplay3DEnabled`/`setDisplay3DEnabled`
- Add `display2DToggled`/`display3DToggled` signals (UI-driven only, not emitted on programmatic changes)
- Add 8 new unit tests (19 total for FlowToolPanel)

## Test Plan
- [x] 19 FlowToolPanel unit tests pass
- [x] Main application builds without errors
- [ ] Manual verification: Display 2D section shows 6 checkboxes
- [ ] Manual verification: Display 3D section shows 13 checkboxes
- [ ] Manual verification: Checkboxes are independent (non-exclusive)

## Note
Tasks 3-5 from the original issue (renderer wiring and colormap controls) will be addressed in follow-up integration work, as they involve MainWindow controller logic rather than the panel widget itself.

Part of #243, completes UI for #277 task 5