### PR TITLE
feat(rendering): add WSS/OSI/AFI/RRT surface coloring on vessel mesh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,7 @@ add_library(render_service STATIC
     src/services/render/oblique_reslice_renderer.cpp
     src/services/render/hemodynamic_overlay_renderer.cpp
     src/services/render/streamline_overlay_renderer.cpp
+    src/services/render/hemodynamic_surface_manager.cpp
 )
 
 target_link_libraries(render_service PUBLIC

--- a/include/services/hemodynamic_surface_manager.hpp
+++ b/include/services/hemodynamic_surface_manager.hpp
@@ -1,0 +1,136 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include <vtkSmartPointer.h>
+
+class vtkPolyData;
+
+namespace dicom_viewer::services {
+
+class SurfaceRenderer;
+
+/**
+ * @brief Coordinates hemodynamic parameter visualization on vessel wall meshes
+ *
+ * Wires VesselAnalyzer analysis results to SurfaceRenderer's per-vertex
+ * scalar coloring API. Each hemodynamic parameter (WSS, OSI, AFI, RRT)
+ * is independently toggleable and has its own colormap.
+ *
+ * This class does NOT depend on VesselAnalyzer or flow_service — it operates
+ * on generic vtkPolyData with named scalar arrays. The caller decomposes
+ * VesselAnalyzer results before passing them here.
+ *
+ * Typical usage:
+ * @code
+ * HemodynamicSurfaceManager manager;
+ * auto wssIdx = manager.showWSS(renderer, wssResult.wallMesh, wssResult.maxWSS);
+ * auto osiIdx = manager.showOSI(renderer, osiResult.wallMesh);
+ * auto afiIdx = manager.showAFI(renderer, tawssSurface);
+ * auto rrtIdx = manager.showRRT(renderer, rrtSurface, maxRRT);
+ * @endcode
+ *
+ * @trace SRS-FR-047, PRD FR-016
+ */
+class HemodynamicSurfaceManager {
+public:
+    HemodynamicSurfaceManager();
+    ~HemodynamicSurfaceManager();
+
+    // Non-copyable, movable
+    HemodynamicSurfaceManager(const HemodynamicSurfaceManager&) = delete;
+    HemodynamicSurfaceManager& operator=(const HemodynamicSurfaceManager&) = delete;
+    HemodynamicSurfaceManager(HemodynamicSurfaceManager&&) noexcept;
+    HemodynamicSurfaceManager& operator=(HemodynamicSurfaceManager&&) noexcept;
+
+    /**
+     * @brief Display WSS coloring on the vessel wall
+     *
+     * Uses blue-to-red sequential colormap via SurfaceRenderer::createWSSLookupTable.
+     * Scalar range is set to [0, maxWSS].
+     *
+     * @param renderer Target surface renderer
+     * @param wallMesh Mesh with per-vertex "WSS" array
+     * @param maxWSS Maximum WSS value in Pa for colormap scaling
+     * @return Surface index in the renderer
+     */
+    size_t showWSS(SurfaceRenderer& renderer,
+                   vtkSmartPointer<vtkPolyData> wallMesh,
+                   double maxWSS);
+
+    /**
+     * @brief Display OSI coloring on the vessel wall
+     *
+     * Uses blue-white-red diverging colormap via SurfaceRenderer::createOSILookupTable.
+     * Scalar range is fixed to [0, 0.5] (OSI definition range).
+     *
+     * @param renderer Target surface renderer
+     * @param wallMesh Mesh with per-vertex "OSI" array
+     * @return Surface index in the renderer
+     */
+    size_t showOSI(SurfaceRenderer& renderer,
+                   vtkSmartPointer<vtkPolyData> wallMesh);
+
+    /**
+     * @brief Display AFI coloring on the vessel wall
+     *
+     * AFI = TAWSS_local / mean(TAWSS) at each vertex.
+     * Input surface must have a "TAWSS" point data array.
+     * Computes AFI from the TAWSS array and applies green-yellow-red colormap.
+     *
+     * @param renderer Target surface renderer
+     * @param tawssSurface Mesh with per-vertex "TAWSS" array
+     * @return Surface index in the renderer
+     */
+    size_t showAFI(SurfaceRenderer& renderer,
+                   vtkSmartPointer<vtkPolyData> tawssSurface);
+
+    /**
+     * @brief Display RRT coloring on the vessel wall
+     *
+     * Uses yellow-to-red sequential colormap via SurfaceRenderer::createRRTLookupTable.
+     *
+     * @param renderer Target surface renderer
+     * @param rrtSurface Mesh with per-vertex "RRT" array
+     * @param maxRRT Maximum RRT value for colormap scaling
+     * @return Surface index in the renderer
+     */
+    size_t showRRT(SurfaceRenderer& renderer,
+                   vtkSmartPointer<vtkPolyData> rrtSurface,
+                   double maxRRT);
+
+    // --- Surface index accessors ---
+
+    /** @brief Get the renderer surface index for WSS (if shown) */
+    [[nodiscard]] std::optional<size_t> wssIndex() const;
+
+    /** @brief Get the renderer surface index for OSI (if shown) */
+    [[nodiscard]] std::optional<size_t> osiIndex() const;
+
+    /** @brief Get the renderer surface index for AFI (if shown) */
+    [[nodiscard]] std::optional<size_t> afiIndex() const;
+
+    /** @brief Get the renderer surface index for RRT (if shown) */
+    [[nodiscard]] std::optional<size_t> rrtIndex() const;
+
+    // --- AFI computation ---
+
+    /**
+     * @brief Compute AFI array from TAWSS surface data
+     *
+     * AFI = TAWSS_vertex / mean(TAWSS_all_vertices)
+     * Adds an "AFI" point data array to a deep-copied output surface.
+     *
+     * @param tawssSurface Mesh with "TAWSS" point data array
+     * @return New polydata with added "AFI" array, or nullptr if TAWSS not found
+     */
+    [[nodiscard]] static vtkSmartPointer<vtkPolyData>
+    computeAFI(vtkSmartPointer<vtkPolyData> tawssSurface);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::services

--- a/include/services/surface_renderer.hpp
+++ b/include/services/surface_renderer.hpp
@@ -284,6 +284,18 @@ public:
     [[nodiscard]] static vtkSmartPointer<vtkLookupTable>
     createRRTLookupTable(double maxRRT);
 
+    /**
+     * @brief Create AFI lookup table (green-yellow-red sequential)
+     *
+     * AFI (Aneurysm Formation Indicator) = TAWSS / mean_TAWSS.
+     * Green (AFI < 1, below average) → Yellow (AFI ≈ 1) → Red (AFI > 1, above average).
+     *
+     * @param maxAFI Maximum AFI value for range (default: 2.0)
+     * @return Configured lookup table for [0, maxAFI]
+     */
+    [[nodiscard]] static vtkSmartPointer<vtkLookupTable>
+    createAFILookupTable(double maxAFI = 2.0);
+
 private:
     class Impl;
     std::unique_ptr<Impl> impl_;

--- a/src/services/render/hemodynamic_surface_manager.cpp
+++ b/src/services/render/hemodynamic_surface_manager.cpp
@@ -1,0 +1,151 @@
+#include "services/hemodynamic_surface_manager.hpp"
+
+#include "services/surface_renderer.hpp"
+
+#include <vtkFloatArray.h>
+#include <vtkLookupTable.h>
+#include <vtkPointData.h>
+#include <vtkPolyData.h>
+
+#include <optional>
+
+namespace dicom_viewer::services {
+
+class HemodynamicSurfaceManager::Impl {
+public:
+    std::optional<size_t> wssIdx;
+    std::optional<size_t> osiIdx;
+    std::optional<size_t> afiIdx;
+    std::optional<size_t> rrtIdx;
+};
+
+HemodynamicSurfaceManager::HemodynamicSurfaceManager()
+    : impl_(std::make_unique<Impl>())
+{}
+
+HemodynamicSurfaceManager::~HemodynamicSurfaceManager() = default;
+HemodynamicSurfaceManager::HemodynamicSurfaceManager(HemodynamicSurfaceManager&&) noexcept = default;
+HemodynamicSurfaceManager& HemodynamicSurfaceManager::operator=(HemodynamicSurfaceManager&&) noexcept = default;
+
+size_t HemodynamicSurfaceManager::showWSS(SurfaceRenderer& renderer,
+                                           vtkSmartPointer<vtkPolyData> wallMesh,
+                                           double maxWSS)
+{
+    auto idx = renderer.addScalarSurface("WSS", wallMesh, "WSS");
+    renderer.setSurfaceScalarRange(idx, 0.0, maxWSS);
+    renderer.setSurfaceLookupTable(idx, SurfaceRenderer::createWSSLookupTable(maxWSS));
+    impl_->wssIdx = idx;
+    return idx;
+}
+
+size_t HemodynamicSurfaceManager::showOSI(SurfaceRenderer& renderer,
+                                           vtkSmartPointer<vtkPolyData> wallMesh)
+{
+    auto idx = renderer.addScalarSurface("OSI", wallMesh, "OSI");
+    renderer.setSurfaceScalarRange(idx, 0.0, 0.5);
+    renderer.setSurfaceLookupTable(idx, SurfaceRenderer::createOSILookupTable());
+    impl_->osiIdx = idx;
+    return idx;
+}
+
+size_t HemodynamicSurfaceManager::showAFI(SurfaceRenderer& renderer,
+                                           vtkSmartPointer<vtkPolyData> tawssSurface)
+{
+    auto afiSurface = computeAFI(tawssSurface);
+    if (!afiSurface) {
+        // Fallback: add with raw TAWSS data
+        auto idx = renderer.addScalarSurface("AFI", tawssSurface, "TAWSS");
+        impl_->afiIdx = idx;
+        return idx;
+    }
+
+    // Determine max AFI from the computed array
+    double maxAFI = 2.0;
+    if (auto* arr = afiSurface->GetPointData()->GetArray("AFI")) {
+        double range[2];
+        arr->GetRange(range);
+        maxAFI = range[1];
+        if (maxAFI < 2.0) maxAFI = 2.0;
+    }
+
+    auto idx = renderer.addScalarSurface("AFI", afiSurface, "AFI");
+    renderer.setSurfaceScalarRange(idx, 0.0, maxAFI);
+    renderer.setSurfaceLookupTable(idx, SurfaceRenderer::createAFILookupTable(maxAFI));
+    impl_->afiIdx = idx;
+    return idx;
+}
+
+size_t HemodynamicSurfaceManager::showRRT(SurfaceRenderer& renderer,
+                                           vtkSmartPointer<vtkPolyData> rrtSurface,
+                                           double maxRRT)
+{
+    auto idx = renderer.addScalarSurface("RRT", rrtSurface, "RRT");
+    renderer.setSurfaceScalarRange(idx, 0.0, maxRRT);
+    renderer.setSurfaceLookupTable(idx, SurfaceRenderer::createRRTLookupTable(maxRRT));
+    impl_->rrtIdx = idx;
+    return idx;
+}
+
+std::optional<size_t> HemodynamicSurfaceManager::wssIndex() const
+{
+    return impl_->wssIdx;
+}
+
+std::optional<size_t> HemodynamicSurfaceManager::osiIndex() const
+{
+    return impl_->osiIdx;
+}
+
+std::optional<size_t> HemodynamicSurfaceManager::afiIndex() const
+{
+    return impl_->afiIdx;
+}
+
+std::optional<size_t> HemodynamicSurfaceManager::rrtIndex() const
+{
+    return impl_->rrtIdx;
+}
+
+vtkSmartPointer<vtkPolyData>
+HemodynamicSurfaceManager::computeAFI(vtkSmartPointer<vtkPolyData> tawssSurface)
+{
+    if (!tawssSurface) return nullptr;
+
+    auto* tawssArray = tawssSurface->GetPointData()->GetArray("TAWSS");
+    if (!tawssArray) return nullptr;
+
+    auto numPoints = tawssArray->GetNumberOfTuples();
+    if (numPoints == 0) return nullptr;
+
+    // Compute mean TAWSS
+    double sum = 0.0;
+    for (vtkIdType i = 0; i < numPoints; ++i) {
+        sum += tawssArray->GetComponent(i, 0);
+    }
+    double meanTAWSS = sum / static_cast<double>(numPoints);
+
+    // Avoid division by zero
+    if (meanTAWSS < 1e-12) return nullptr;
+
+    // Create AFI array: AFI = TAWSS_local / mean_TAWSS
+    auto afiArray = vtkSmartPointer<vtkFloatArray>::New();
+    afiArray->SetName("AFI");
+    afiArray->SetNumberOfComponents(1);
+    afiArray->SetNumberOfTuples(numPoints);
+
+    for (vtkIdType i = 0; i < numPoints; ++i) {
+        double tawss = tawssArray->GetComponent(i, 0);
+        auto afi = static_cast<float>(tawss / meanTAWSS);
+        afiArray->SetValue(i, afi);
+    }
+
+    // Deep copy and add AFI array
+    auto output = vtkSmartPointer<vtkPolyData>::New();
+    output->DeepCopy(tawssSurface);
+    output->GetPointData()->AddArray(afiArray);
+    output->GetPointData()->SetActiveScalars("AFI");
+
+    return output;
+}
+
+} // namespace dicom_viewer::services

--- a/src/services/render/surface_renderer.cpp
+++ b/src/services/render/surface_renderer.cpp
@@ -613,4 +613,38 @@ vtkSmartPointer<vtkLookupTable> SurfaceRenderer::createRRTLookupTable(double max
     return lut;
 }
 
+vtkSmartPointer<vtkLookupTable> SurfaceRenderer::createAFILookupTable(double maxAFI)
+{
+    auto lut = vtkSmartPointer<vtkLookupTable>::New();
+    lut->SetNumberOfTableValues(256);
+    lut->SetRange(0.0, maxAFI);
+
+    lut->Build();
+
+    // Sequential colormap: green → yellow → red
+    // AFI < 1: below-average WSS (green/safe)
+    // AFI ≈ 1: average WSS (yellow/transition)
+    // AFI > 1: above-average WSS (red/risk)
+    for (int i = 0; i < 256; ++i) {
+        double t = static_cast<double>(i) / 255.0;
+        double r, g, b;
+        if (t < 0.5) {
+            // Green → Yellow
+            double s = t / 0.5;
+            r = s;
+            g = 0.8 + 0.2 * s;  // 0.8 → 1.0
+            b = 0.0;
+        } else {
+            // Yellow → Red
+            double s = (t - 0.5) / 0.5;
+            r = 1.0;
+            g = 1.0 - s;  // 1.0 → 0.0
+            b = 0.0;
+        }
+        lut->SetTableValue(i, r, g, b, 1.0);
+    }
+
+    return lut;
+}
+
 } // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1754,3 +1754,26 @@ target_include_directories(flow_tool_panel_test PRIVATE
 )
 
 gtest_discover_tests(flow_tool_panel_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for Hemodynamic Surface Manager
+add_executable(hemodynamic_surface_manager_test
+    unit/hemodynamic_surface_manager_test.cpp
+)
+
+target_link_libraries(hemodynamic_surface_manager_test PRIVATE
+    render_service
+    ${VTK_LIBRARIES}
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(hemodynamic_surface_manager_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+vtk_module_autoinit(
+    TARGETS hemodynamic_surface_manager_test
+    MODULES ${VTK_LIBRARIES}
+)
+
+gtest_discover_tests(hemodynamic_surface_manager_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/hemodynamic_surface_manager_test.cpp
+++ b/tests/unit/hemodynamic_surface_manager_test.cpp
@@ -1,0 +1,409 @@
+#include <gtest/gtest.h>
+
+#include "services/hemodynamic_surface_manager.hpp"
+#include "services/surface_renderer.hpp"
+
+#include <vtkFloatArray.h>
+#include <vtkLookupTable.h>
+#include <vtkPointData.h>
+#include <vtkPolyData.h>
+#include <vtkSmartPointer.h>
+#include <vtkSphereSource.h>
+
+using namespace dicom_viewer::services;
+
+namespace {
+
+/// Create a sphere mesh with a named per-vertex scalar array
+vtkSmartPointer<vtkPolyData> createMeshWithArray(
+    const std::string& arrayName, double maxVal, int numPoints = -1)
+{
+    auto sphere = vtkSmartPointer<vtkSphereSource>::New();
+    sphere->SetRadius(20.0);
+    sphere->SetThetaResolution(12);
+    sphere->SetPhiResolution(12);
+    sphere->Update();
+
+    auto polyData = vtkSmartPointer<vtkPolyData>::New();
+    polyData->DeepCopy(sphere->GetOutput());
+
+    auto nPts = polyData->GetNumberOfPoints();
+    if (numPoints > 0 && numPoints < nPts) nPts = numPoints;
+
+    auto scalars = vtkSmartPointer<vtkFloatArray>::New();
+    scalars->SetName(arrayName.c_str());
+    scalars->SetNumberOfComponents(1);
+    scalars->SetNumberOfTuples(polyData->GetNumberOfPoints());
+
+    for (vtkIdType i = 0; i < polyData->GetNumberOfPoints(); ++i) {
+        float val = static_cast<float>(i) / static_cast<float>(polyData->GetNumberOfPoints()) * maxVal;
+        scalars->SetValue(i, val);
+    }
+
+    polyData->GetPointData()->AddArray(scalars);
+    polyData->GetPointData()->SetActiveScalars(arrayName.c_str());
+
+    return polyData;
+}
+
+/// Create a mesh with multiple named scalar arrays
+vtkSmartPointer<vtkPolyData> createMeshWithMultipleArrays()
+{
+    auto sphere = vtkSmartPointer<vtkSphereSource>::New();
+    sphere->SetRadius(20.0);
+    sphere->SetThetaResolution(12);
+    sphere->SetPhiResolution(12);
+    sphere->Update();
+
+    auto polyData = vtkSmartPointer<vtkPolyData>::New();
+    polyData->DeepCopy(sphere->GetOutput());
+
+    auto nPts = polyData->GetNumberOfPoints();
+
+    // WSS array
+    auto wss = vtkSmartPointer<vtkFloatArray>::New();
+    wss->SetName("WSS");
+    wss->SetNumberOfTuples(nPts);
+
+    // OSI array
+    auto osi = vtkSmartPointer<vtkFloatArray>::New();
+    osi->SetName("OSI");
+    osi->SetNumberOfTuples(nPts);
+
+    // TAWSS array
+    auto tawss = vtkSmartPointer<vtkFloatArray>::New();
+    tawss->SetName("TAWSS");
+    tawss->SetNumberOfTuples(nPts);
+
+    for (vtkIdType i = 0; i < nPts; ++i) {
+        float t = static_cast<float>(i) / static_cast<float>(nPts);
+        wss->SetValue(i, t * 5.0f);        // WSS in [0, 5] Pa
+        osi->SetValue(i, t * 0.5f);        // OSI in [0, 0.5]
+        tawss->SetValue(i, t * 3.0f);      // TAWSS in [0, 3] Pa
+    }
+
+    polyData->GetPointData()->AddArray(wss);
+    polyData->GetPointData()->AddArray(osi);
+    polyData->GetPointData()->AddArray(tawss);
+
+    return polyData;
+}
+
+} // anonymous namespace
+
+class HemodynamicSurfaceManagerTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        renderer = std::make_unique<SurfaceRenderer>();
+        manager = std::make_unique<HemodynamicSurfaceManager>();
+    }
+
+    std::unique_ptr<SurfaceRenderer> renderer;
+    std::unique_ptr<HemodynamicSurfaceManager> manager;
+};
+
+// =============================================================================
+// Construction and defaults
+// =============================================================================
+
+TEST_F(HemodynamicSurfaceManagerTest, DefaultConstruction) {
+    EXPECT_FALSE(manager->wssIndex().has_value());
+    EXPECT_FALSE(manager->osiIndex().has_value());
+    EXPECT_FALSE(manager->afiIndex().has_value());
+    EXPECT_FALSE(manager->rrtIndex().has_value());
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, MoveConstruction) {
+    auto mesh = createMeshWithArray("WSS", 5.0);
+    manager->showWSS(*renderer, mesh, 5.0);
+
+    HemodynamicSurfaceManager moved(std::move(*manager));
+    EXPECT_TRUE(moved.wssIndex().has_value());
+}
+
+// =============================================================================
+// WSS surface coloring
+// =============================================================================
+
+TEST_F(HemodynamicSurfaceManagerTest, ShowWSS_AddsSurface) {
+    auto mesh = createMeshWithArray("WSS", 5.0);
+
+    auto idx = manager->showWSS(*renderer, mesh, 5.0);
+    EXPECT_EQ(idx, 0);
+    EXPECT_EQ(renderer->getSurfaceCount(), 1);
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, ShowWSS_TracksIndex) {
+    auto mesh = createMeshWithArray("WSS", 5.0);
+    auto idx = manager->showWSS(*renderer, mesh, 5.0);
+
+    ASSERT_TRUE(manager->wssIndex().has_value());
+    EXPECT_EQ(manager->wssIndex().value(), idx);
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, ShowWSS_SetsScalarRange) {
+    auto mesh = createMeshWithArray("WSS", 5.0);
+    manager->showWSS(*renderer, mesh, 5.0);
+
+    auto [minVal, maxVal] = renderer->surfaceScalarRange(0);
+    EXPECT_DOUBLE_EQ(minVal, 0.0);
+    EXPECT_DOUBLE_EQ(maxVal, 5.0);
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, ShowWSS_HasValidActor) {
+    auto mesh = createMeshWithArray("WSS", 5.0);
+    auto idx = manager->showWSS(*renderer, mesh, 5.0);
+
+    auto actor = renderer->getActor(idx);
+    ASSERT_NE(actor, nullptr);
+    EXPECT_NE(actor->GetMapper(), nullptr);
+}
+
+// =============================================================================
+// OSI surface coloring
+// =============================================================================
+
+TEST_F(HemodynamicSurfaceManagerTest, ShowOSI_AddsSurface) {
+    auto mesh = createMeshWithArray("OSI", 0.5);
+
+    auto idx = manager->showOSI(*renderer, mesh);
+    EXPECT_EQ(idx, 0);
+    EXPECT_EQ(renderer->getSurfaceCount(), 1);
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, ShowOSI_TracksIndex) {
+    auto mesh = createMeshWithArray("OSI", 0.5);
+    auto idx = manager->showOSI(*renderer, mesh);
+
+    ASSERT_TRUE(manager->osiIndex().has_value());
+    EXPECT_EQ(manager->osiIndex().value(), idx);
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, ShowOSI_FixedRange) {
+    auto mesh = createMeshWithArray("OSI", 0.5);
+    manager->showOSI(*renderer, mesh);
+
+    auto [minVal, maxVal] = renderer->surfaceScalarRange(0);
+    EXPECT_DOUBLE_EQ(minVal, 0.0);
+    EXPECT_DOUBLE_EQ(maxVal, 0.5);
+}
+
+// =============================================================================
+// AFI computation
+// =============================================================================
+
+TEST_F(HemodynamicSurfaceManagerTest, ComputeAFI_NullInput) {
+    auto result = HemodynamicSurfaceManager::computeAFI(nullptr);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, ComputeAFI_NoTAWSSArray) {
+    auto mesh = createMeshWithArray("WSS", 5.0);
+    auto result = HemodynamicSurfaceManager::computeAFI(mesh);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, ComputeAFI_ZeroTAWSS) {
+    auto mesh = createMeshWithArray("TAWSS", 0.0);
+    auto result = HemodynamicSurfaceManager::computeAFI(mesh);
+    // All TAWSS values are 0 → mean is 0 → returns nullptr
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, ComputeAFI_ValidComputation) {
+    auto mesh = createMeshWithArray("TAWSS", 4.0);
+    auto result = HemodynamicSurfaceManager::computeAFI(mesh);
+    ASSERT_NE(result, nullptr);
+
+    // Check AFI array exists
+    auto* afiArray = result->GetPointData()->GetArray("AFI");
+    ASSERT_NE(afiArray, nullptr);
+    EXPECT_EQ(afiArray->GetNumberOfTuples(), mesh->GetNumberOfPoints());
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, ComputeAFI_MeanIsOne) {
+    // With linear distribution [0, maxVal], mean AFI should be close to 1.0
+    // (since AFI = TAWSS / mean(TAWSS))
+    auto mesh = createMeshWithArray("TAWSS", 4.0);
+    auto result = HemodynamicSurfaceManager::computeAFI(mesh);
+    ASSERT_NE(result, nullptr);
+
+    auto* afiArray = result->GetPointData()->GetArray("AFI");
+    ASSERT_NE(afiArray, nullptr);
+
+    // Compute mean AFI
+    double sum = 0.0;
+    auto n = afiArray->GetNumberOfTuples();
+    for (vtkIdType i = 0; i < n; ++i) {
+        sum += afiArray->GetComponent(i, 0);
+    }
+    double meanAFI = sum / static_cast<double>(n);
+    EXPECT_NEAR(meanAFI, 1.0, 0.05);
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, ComputeAFI_PreservesOriginalData) {
+    auto mesh = createMeshWithArray("TAWSS", 4.0);
+    auto result = HemodynamicSurfaceManager::computeAFI(mesh);
+    ASSERT_NE(result, nullptr);
+
+    // Original TAWSS array should still be present in the output
+    auto* tawssArray = result->GetPointData()->GetArray("TAWSS");
+    ASSERT_NE(tawssArray, nullptr);
+    EXPECT_EQ(tawssArray->GetNumberOfTuples(), mesh->GetNumberOfPoints());
+}
+
+// =============================================================================
+// AFI surface coloring
+// =============================================================================
+
+TEST_F(HemodynamicSurfaceManagerTest, ShowAFI_AddsSurface) {
+    auto mesh = createMeshWithArray("TAWSS", 4.0);
+    auto idx = manager->showAFI(*renderer, mesh);
+
+    EXPECT_EQ(renderer->getSurfaceCount(), 1);
+    ASSERT_TRUE(manager->afiIndex().has_value());
+    EXPECT_EQ(manager->afiIndex().value(), idx);
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, ShowAFI_SetsMinRangeToTwo) {
+    auto mesh = createMeshWithArray("TAWSS", 4.0);
+    manager->showAFI(*renderer, mesh);
+
+    auto [minVal, maxVal] = renderer->surfaceScalarRange(0);
+    EXPECT_DOUBLE_EQ(minVal, 0.0);
+    // maxAFI should be at least 2.0
+    EXPECT_GE(maxVal, 2.0);
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, ShowAFI_FallbackWithoutTAWSS) {
+    // Mesh without TAWSS array — should still add a surface (fallback)
+    auto mesh = createMeshWithArray("WSS", 5.0);
+    auto idx = manager->showAFI(*renderer, mesh);
+
+    EXPECT_EQ(renderer->getSurfaceCount(), 1);
+    ASSERT_TRUE(manager->afiIndex().has_value());
+    EXPECT_EQ(manager->afiIndex().value(), idx);
+}
+
+// =============================================================================
+// RRT surface coloring
+// =============================================================================
+
+TEST_F(HemodynamicSurfaceManagerTest, ShowRRT_AddsSurface) {
+    auto mesh = createMeshWithArray("RRT", 100.0);
+
+    auto idx = manager->showRRT(*renderer, mesh, 100.0);
+    EXPECT_EQ(idx, 0);
+    EXPECT_EQ(renderer->getSurfaceCount(), 1);
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, ShowRRT_TracksIndex) {
+    auto mesh = createMeshWithArray("RRT", 100.0);
+    auto idx = manager->showRRT(*renderer, mesh, 100.0);
+
+    ASSERT_TRUE(manager->rrtIndex().has_value());
+    EXPECT_EQ(manager->rrtIndex().value(), idx);
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, ShowRRT_SetsScalarRange) {
+    auto mesh = createMeshWithArray("RRT", 100.0);
+    manager->showRRT(*renderer, mesh, 100.0);
+
+    auto [minVal, maxVal] = renderer->surfaceScalarRange(0);
+    EXPECT_DOUBLE_EQ(minVal, 0.0);
+    EXPECT_DOUBLE_EQ(maxVal, 100.0);
+}
+
+// =============================================================================
+// Multiple parameters simultaneously
+// =============================================================================
+
+TEST_F(HemodynamicSurfaceManagerTest, AllFourParameters) {
+    auto multiMesh = createMeshWithMultipleArrays();
+
+    auto wssIdx = manager->showWSS(*renderer, multiMesh, 5.0);
+    auto osiIdx = manager->showOSI(*renderer, multiMesh);
+    auto afiIdx = manager->showAFI(*renderer, multiMesh);
+
+    auto rrtMesh = createMeshWithArray("RRT", 50.0);
+    auto rrtIdx = manager->showRRT(*renderer, rrtMesh, 50.0);
+
+    EXPECT_EQ(renderer->getSurfaceCount(), 4);
+
+    ASSERT_TRUE(manager->wssIndex().has_value());
+    ASSERT_TRUE(manager->osiIndex().has_value());
+    ASSERT_TRUE(manager->afiIndex().has_value());
+    ASSERT_TRUE(manager->rrtIndex().has_value());
+
+    EXPECT_EQ(manager->wssIndex().value(), wssIdx);
+    EXPECT_EQ(manager->osiIndex().value(), osiIdx);
+    EXPECT_EQ(manager->afiIndex().value(), afiIdx);
+    EXPECT_EQ(manager->rrtIndex().value(), rrtIdx);
+
+    // All indices should be different
+    EXPECT_NE(wssIdx, osiIdx);
+    EXPECT_NE(osiIdx, afiIdx);
+    EXPECT_NE(afiIdx, rrtIdx);
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, IndependentVisibility) {
+    auto mesh = createMeshWithArray("WSS", 5.0);
+    auto wssIdx = manager->showWSS(*renderer, mesh, 5.0);
+
+    auto osiMesh = createMeshWithArray("OSI", 0.5);
+    auto osiIdx = manager->showOSI(*renderer, osiMesh);
+
+    // Toggle WSS visibility independently
+    renderer->setSurfaceVisibility(wssIdx, false);
+    auto wssConfig = renderer->getSurfaceConfig(wssIdx);
+    auto osiConfig = renderer->getSurfaceConfig(osiIdx);
+    EXPECT_FALSE(wssConfig.visible);
+    EXPECT_TRUE(osiConfig.visible);
+}
+
+// =============================================================================
+// AFI Lookup Table (via SurfaceRenderer)
+// =============================================================================
+
+TEST_F(HemodynamicSurfaceManagerTest, AFILookupTable_ValidCreation) {
+    auto lut = SurfaceRenderer::createAFILookupTable(2.0);
+    ASSERT_NE(lut, nullptr);
+    EXPECT_EQ(lut->GetNumberOfTableValues(), 256);
+
+    auto range = lut->GetRange();
+    EXPECT_DOUBLE_EQ(range[0], 0.0);
+    EXPECT_DOUBLE_EQ(range[1], 2.0);
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, AFILookupTable_GreenAtLow) {
+    auto lut = SurfaceRenderer::createAFILookupTable(2.0);
+    double rgba[4];
+    lut->GetTableValue(0, rgba);
+
+    // At min (0): should be green (r≈0, g≈0.8, b≈0)
+    EXPECT_LT(rgba[0], 0.1);    // Low red
+    EXPECT_GT(rgba[1], 0.7);    // High green
+    EXPECT_LT(rgba[2], 0.1);    // Low blue
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, AFILookupTable_YellowAtMid) {
+    auto lut = SurfaceRenderer::createAFILookupTable(2.0);
+    double rgba[4];
+    lut->GetTableValue(128, rgba);
+
+    // At middle (~AFI=1): should be yellow/greenish-yellow
+    EXPECT_GT(rgba[0], 0.8);    // High red
+    EXPECT_GT(rgba[1], 0.8);    // High green
+    EXPECT_LT(rgba[2], 0.1);    // Low blue
+}
+
+TEST_F(HemodynamicSurfaceManagerTest, AFILookupTable_RedAtHigh) {
+    auto lut = SurfaceRenderer::createAFILookupTable(2.0);
+    double rgba[4];
+    lut->GetTableValue(255, rgba);
+
+    // At max (2.0): should be red
+    EXPECT_NEAR(rgba[0], 1.0, 0.01);
+    EXPECT_LT(rgba[1], 0.1);
+    EXPECT_LT(rgba[2], 0.1);
+}


### PR DESCRIPTION
Closes #334

## Summary
- Add `HemodynamicSurfaceManager` class that wires VesselAnalyzer hemodynamic results to `SurfaceRenderer` per-vertex scalar coloring API
- Implement WSS, OSI, AFI, and RRT surface coloring with appropriate colormaps
- Add AFI (Aneurysm Formation Indicator) computation: `TAWSS_local / mean(TAWSS)`
- Add `createAFILookupTable()` static factory to `SurfaceRenderer` (green-yellow-red sequential)
- Each parameter is independently toggleable with adjustable scalar ranges
- Decoupled design: manager operates on generic vtkPolyData, no dependency on `flow_service`

## Architecture
The manager bridges `VesselAnalyzer` analysis results and `SurfaceRenderer` visualization:
- `showWSS(renderer, wallMesh, maxWSS)` → blue-to-red colormap
- `showOSI(renderer, wallMesh)` → blue-white-red diverging, fixed [0, 0.5]
- `showAFI(renderer, tawssSurface)` → green-yellow-red, computes AFI internally
- `showRRT(renderer, rrtSurface, maxRRT)` → yellow-to-red colormap

## Test Plan
- [x] 27 unit tests all passing
- [x] WSS: surface creation, index tracking, scalar range, actor validity
- [x] OSI: surface creation, index tracking, fixed [0, 0.5] range
- [x] AFI: null input, missing array, zero TAWSS, valid computation, mean≈1.0, data preservation, fallback mode
- [x] RRT: surface creation, index tracking, scalar range
- [x] Multi-parameter: all 4 simultaneously, independent visibility
- [x] AFI lookup table: green at low, yellow at mid, red at high
- [x] Existing surface_renderer_test (71/72 pass, 1 pre-existing flaky test)