### PR TITLE
feat(ui): Wire Display 3D checkboxes to rendering toggles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -595,6 +595,7 @@ add_library(dicom_viewer_ui STATIC
     src/ui/panels/segmentation_panel.cpp
     src/ui/panels/overlay_control_panel.cpp
     src/ui/panels/flow_tool_panel.cpp
+    src/ui/display_3d_controller.cpp
     src/ui/dialogs/settings_dialog.cpp
     src/ui/dialogs/pacs_config_dialog.cpp
     # Headers with Q_OBJECT for AUTOMOC

--- a/include/ui/display_3d_controller.hpp
+++ b/include/ui/display_3d_controller.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <memory>
+
+#include <vtkSmartPointer.h>
+
+#include "ui/panels/flow_tool_panel.hpp"
+
+class vtkActor;
+class vtkRenderer;
+
+namespace dicom_viewer::services {
+class VolumeRenderer;
+class SurfaceRenderer;
+class HemodynamicSurfaceManager;
+}  // namespace dicom_viewer::services
+
+namespace dicom_viewer::ui {
+
+/**
+ * @brief Routes Display 3D checkbox toggles to rendering backends
+ *
+ * Maps each Display3DItem to the appropriate renderer visibility call:
+ * - Volume overlays (Velocity, Vorticity, EnergyLoss, Magnitude)
+ *   → VolumeRenderer::setOverlayVisible()
+ * - Surface parameters (WSS, OSI, AFI, RRT)
+ *   → SurfaceRenderer::setSurfaceVisibility() via HemodynamicSurfaceManager
+ * - Streamline → vtkActor visibility
+ * - MaskVolume, Surface → base renderer visibility
+ * - Cine, ASC → stub (not yet implemented)
+ *
+ * This class does NOT derive from QObject. The caller (MainWindow) wires
+ * FlowToolPanel::display3DToggled to handleToggle() via a lambda.
+ *
+ * @trace SRS-FR-047, PRD FR-016
+ */
+class Display3DController {
+public:
+    Display3DController();
+    ~Display3DController();
+
+    // Non-copyable, movable
+    Display3DController(const Display3DController&) = delete;
+    Display3DController& operator=(const Display3DController&) = delete;
+    Display3DController(Display3DController&&) noexcept;
+    Display3DController& operator=(Display3DController&&) noexcept;
+
+    // --- Renderer bindings ---
+
+    /**
+     * @brief Set the volume renderer for overlay visibility control
+     * @param renderer Non-owning pointer (caller manages lifetime)
+     */
+    void setVolumeRenderer(services::VolumeRenderer* renderer);
+
+    /**
+     * @brief Set the surface renderer for surface visibility control
+     * @param renderer Non-owning pointer (caller manages lifetime)
+     */
+    void setSurfaceRenderer(services::SurfaceRenderer* renderer);
+
+    /**
+     * @brief Set the hemodynamic surface manager for WSS/OSI/AFI/RRT index lookups
+     * @param manager Non-owning pointer (caller manages lifetime)
+     */
+    void setHemodynamicManager(services::HemodynamicSurfaceManager* manager);
+
+    /**
+     * @brief Set the streamline actor for visibility toggling
+     * @param actor Streamline geometry actor
+     */
+    void setStreamlineActor(vtkSmartPointer<vtkActor> actor);
+
+    /**
+     * @brief Set the mask volume actor for visibility toggling
+     * @param actor Mask volume rendering actor (vtkActor or vtkVolume cast)
+     */
+    void setMaskVolumeActor(vtkSmartPointer<vtkActor> actor);
+
+    /**
+     * @brief Set the isosurface actor for visibility toggling
+     * @param actor Surface mesh actor
+     */
+    void setSurfaceActor(vtkSmartPointer<vtkActor> actor);
+
+    // --- Toggle dispatch ---
+
+    /**
+     * @brief Handle a Display 3D checkbox toggle
+     *
+     * Routes the toggle to the appropriate renderer based on item type.
+     * Silently ignores items whose renderer has not been set.
+     *
+     * @param item The Display3DItem toggled
+     * @param enabled True to show, false to hide
+     */
+    void handleToggle(Display3DItem item, bool enabled);
+
+    // --- State queries ---
+
+    /**
+     * @brief Check if a Display 3D item is currently enabled
+     */
+    [[nodiscard]] bool isEnabled(Display3DItem item) const;
+
+    /**
+     * @brief Get the enabled state for all 13 items (indexed by enum ordinal)
+     */
+    [[nodiscard]] std::array<bool, 13> enabledStates() const;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace dicom_viewer::ui

--- a/src/ui/display_3d_controller.cpp
+++ b/src/ui/display_3d_controller.cpp
@@ -1,0 +1,176 @@
+#include "ui/display_3d_controller.hpp"
+
+#include "services/hemodynamic_surface_manager.hpp"
+#include "services/surface_renderer.hpp"
+#include "services/volume_renderer.hpp"
+
+#include <vtkActor.h>
+
+#include <array>
+
+namespace dicom_viewer::ui {
+
+// Overlay name constants matching the names used in VolumeRenderer::addScalarOverlay
+static constexpr const char* kVelocityOverlay = "velocity";
+static constexpr const char* kVorticityOverlay = "vorticity";
+static constexpr const char* kEnergyLossOverlay = "energy_loss";
+static constexpr const char* kMagnitudeOverlay = "magnitude";
+
+class Display3DController::Impl {
+public:
+    services::VolumeRenderer* volumeRenderer = nullptr;
+    services::SurfaceRenderer* surfaceRenderer = nullptr;
+    services::HemodynamicSurfaceManager* hemoManager = nullptr;
+
+    vtkSmartPointer<vtkActor> streamlineActor;
+    vtkSmartPointer<vtkActor> maskVolumeActor;
+    vtkSmartPointer<vtkActor> surfaceActor;
+
+    std::array<bool, 13> enabled{};  // All false by default
+};
+
+Display3DController::Display3DController()
+    : impl_(std::make_unique<Impl>())
+{}
+
+Display3DController::~Display3DController() = default;
+Display3DController::Display3DController(Display3DController&&) noexcept = default;
+Display3DController& Display3DController::operator=(Display3DController&&) noexcept = default;
+
+void Display3DController::setVolumeRenderer(services::VolumeRenderer* renderer)
+{
+    impl_->volumeRenderer = renderer;
+}
+
+void Display3DController::setSurfaceRenderer(services::SurfaceRenderer* renderer)
+{
+    impl_->surfaceRenderer = renderer;
+}
+
+void Display3DController::setHemodynamicManager(services::HemodynamicSurfaceManager* manager)
+{
+    impl_->hemoManager = manager;
+}
+
+void Display3DController::setStreamlineActor(vtkSmartPointer<vtkActor> actor)
+{
+    impl_->streamlineActor = std::move(actor);
+}
+
+void Display3DController::setMaskVolumeActor(vtkSmartPointer<vtkActor> actor)
+{
+    impl_->maskVolumeActor = std::move(actor);
+}
+
+void Display3DController::setSurfaceActor(vtkSmartPointer<vtkActor> actor)
+{
+    impl_->surfaceActor = std::move(actor);
+}
+
+void Display3DController::handleToggle(Display3DItem item, bool enabled)
+{
+    auto idx = static_cast<int>(item);
+    if (idx >= 0 && idx < 13) {
+        impl_->enabled[idx] = enabled;
+    }
+
+    switch (item) {
+    case Display3DItem::MaskVolume:
+        if (impl_->maskVolumeActor) {
+            impl_->maskVolumeActor->SetVisibility(enabled ? 1 : 0);
+        }
+        break;
+
+    case Display3DItem::Surface:
+        if (impl_->surfaceActor) {
+            impl_->surfaceActor->SetVisibility(enabled ? 1 : 0);
+        }
+        break;
+
+    case Display3DItem::Cine:
+        // Stub: cine playback not yet implemented in 3D
+        break;
+
+    case Display3DItem::Magnitude:
+        if (impl_->volumeRenderer) {
+            impl_->volumeRenderer->setOverlayVisible(kMagnitudeOverlay, enabled);
+        }
+        break;
+
+    case Display3DItem::Velocity:
+        if (impl_->volumeRenderer) {
+            impl_->volumeRenderer->setOverlayVisible(kVelocityOverlay, enabled);
+        }
+        break;
+
+    case Display3DItem::ASC:
+        // Stub: ASC view not yet implemented
+        break;
+
+    case Display3DItem::Streamline:
+        if (impl_->streamlineActor) {
+            impl_->streamlineActor->SetVisibility(enabled ? 1 : 0);
+        }
+        break;
+
+    case Display3DItem::EnergyLoss:
+        if (impl_->volumeRenderer) {
+            impl_->volumeRenderer->setOverlayVisible(kEnergyLossOverlay, enabled);
+        }
+        break;
+
+    case Display3DItem::WSS:
+        if (impl_->surfaceRenderer && impl_->hemoManager) {
+            if (auto wss = impl_->hemoManager->wssIndex()) {
+                impl_->surfaceRenderer->setSurfaceVisibility(*wss, enabled);
+            }
+        }
+        break;
+
+    case Display3DItem::OSI:
+        if (impl_->surfaceRenderer && impl_->hemoManager) {
+            if (auto osi = impl_->hemoManager->osiIndex()) {
+                impl_->surfaceRenderer->setSurfaceVisibility(*osi, enabled);
+            }
+        }
+        break;
+
+    case Display3DItem::AFI:
+        if (impl_->surfaceRenderer && impl_->hemoManager) {
+            if (auto afi = impl_->hemoManager->afiIndex()) {
+                impl_->surfaceRenderer->setSurfaceVisibility(*afi, enabled);
+            }
+        }
+        break;
+
+    case Display3DItem::RRT:
+        if (impl_->surfaceRenderer && impl_->hemoManager) {
+            if (auto rrt = impl_->hemoManager->rrtIndex()) {
+                impl_->surfaceRenderer->setSurfaceVisibility(*rrt, enabled);
+            }
+        }
+        break;
+
+    case Display3DItem::Vorticity:
+        if (impl_->volumeRenderer) {
+            impl_->volumeRenderer->setOverlayVisible(kVorticityOverlay, enabled);
+        }
+        break;
+    }
+}
+
+bool Display3DController::isEnabled(Display3DItem item) const
+{
+    auto idx = static_cast<int>(item);
+    if (idx >= 0 && idx < 13) {
+        return impl_->enabled[idx];
+    }
+    return false;
+}
+
+std::array<bool, 13> Display3DController::enabledStates() const
+{
+    return impl_->enabled;
+}
+
+}  // namespace dicom_viewer::ui

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -9,6 +9,7 @@
 #include "ui/panels/segmentation_panel.hpp"
 #include "ui/panels/overlay_control_panel.hpp"
 #include "ui/panels/flow_tool_panel.hpp"
+#include "ui/display_3d_controller.hpp"
 #include "ui/dialogs/pacs_config_dialog.hpp"
 #include "services/pacs_config_manager.hpp"
 #include "services/dicom_store_scp.hpp"
@@ -108,6 +109,9 @@ public:
     // Active viewport W/L connections
     QMetaObject::Connection activeWlToToolsConn;
     QMetaObject::Connection toolsToActiveWlConn;
+
+    // Display 3D controller
+    std::unique_ptr<Display3DController> display3DController;
 };
 
 MainWindow::MainWindow(QWidget* parent)
@@ -122,6 +126,9 @@ MainWindow::MainWindow(QWidget* parent)
 
     // Initialize Storage SCP
     impl_->storageScp = std::make_unique<services::DicomStoreSCP>();
+
+    // Initialize Display 3D controller
+    impl_->display3DController = std::make_unique<Display3DController>();
 
     applyDarkTheme();
     setupUI();
@@ -680,6 +687,12 @@ void MainWindow::setupConnections()
         static const char* names[] = {"Magnitude", "RL", "AP", "FH", "PC-MRA"};
         impl_->statusLabel->setText(
             tr("Series: %1").arg(names[static_cast<int>(series)]));
+    });
+
+    // Flow tool panel Display 3D toggles → Display3DController
+    connect(impl_->flowToolPanel, &FlowToolPanel::display3DToggled,
+            this, [this](Display3DItem item, bool enabled) {
+        impl_->display3DController->handleToggle(item, enabled);
     });
 
     // Patient browser -> Load series

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1777,3 +1777,26 @@ vtk_module_autoinit(
 )
 
 gtest_discover_tests(hemodynamic_surface_manager_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for Display3DController
+add_executable(display_3d_controller_test
+    unit/display_3d_controller_test.cpp
+)
+
+target_link_libraries(display_3d_controller_test PRIVATE
+    dicom_viewer_ui
+    Qt6::Test
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(display_3d_controller_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+vtk_module_autoinit(
+    TARGETS display_3d_controller_test
+    MODULES ${VTK_LIBRARIES}
+)
+
+gtest_discover_tests(display_3d_controller_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/display_3d_controller_test.cpp
+++ b/tests/unit/display_3d_controller_test.cpp
@@ -1,0 +1,376 @@
+#include <gtest/gtest.h>
+
+#include "ui/display_3d_controller.hpp"
+#include "services/hemodynamic_surface_manager.hpp"
+#include "services/surface_renderer.hpp"
+#include "services/volume_renderer.hpp"
+
+#include <vtkActor.h>
+#include <vtkColorTransferFunction.h>
+#include <vtkFloatArray.h>
+#include <vtkImageData.h>
+#include <vtkPiecewiseFunction.h>
+#include <vtkPointData.h>
+#include <vtkPolyData.h>
+#include <vtkSmartPointer.h>
+#include <vtkSphereSource.h>
+
+using namespace dicom_viewer::ui;
+using namespace dicom_viewer::services;
+
+namespace {
+
+/// Create a scalar volume for overlay testing
+vtkSmartPointer<vtkImageData> createTestVolume(int dim = 8, float maxVal = 100.0f)
+{
+    auto image = vtkSmartPointer<vtkImageData>::New();
+    image->SetDimensions(dim, dim, dim);
+    image->SetSpacing(1.0, 1.0, 1.0);
+    image->SetOrigin(0.0, 0.0, 0.0);
+    image->AllocateScalars(VTK_FLOAT, 1);
+
+    auto* ptr = static_cast<float*>(image->GetScalarPointer());
+    int total = dim * dim * dim;
+    for (int i = 0; i < total; ++i) {
+        ptr[i] = (static_cast<float>(i) / static_cast<float>(total)) * maxVal;
+    }
+    return image;
+}
+
+vtkSmartPointer<vtkColorTransferFunction> createColorTF(double maxVal)
+{
+    auto tf = vtkSmartPointer<vtkColorTransferFunction>::New();
+    tf->AddRGBPoint(0.0, 0.0, 0.0, 1.0);
+    tf->AddRGBPoint(maxVal, 1.0, 0.0, 0.0);
+    return tf;
+}
+
+vtkSmartPointer<vtkPiecewiseFunction> createOpacityTF(double maxVal)
+{
+    auto tf = vtkSmartPointer<vtkPiecewiseFunction>::New();
+    tf->AddPoint(0.0, 0.0);
+    tf->AddPoint(maxVal, 0.5);
+    return tf;
+}
+
+/// Create a sphere mesh with a named per-vertex scalar array
+vtkSmartPointer<vtkPolyData> createMeshWithArray(
+    const std::string& arrayName, double maxVal)
+{
+    auto sphere = vtkSmartPointer<vtkSphereSource>::New();
+    sphere->SetRadius(20.0);
+    sphere->SetThetaResolution(12);
+    sphere->SetPhiResolution(12);
+    sphere->Update();
+
+    auto polyData = vtkSmartPointer<vtkPolyData>::New();
+    polyData->DeepCopy(sphere->GetOutput());
+
+    auto nPts = polyData->GetNumberOfPoints();
+    auto scalars = vtkSmartPointer<vtkFloatArray>::New();
+    scalars->SetName(arrayName.c_str());
+    scalars->SetNumberOfTuples(nPts);
+    for (vtkIdType i = 0; i < nPts; ++i) {
+        scalars->SetValue(i, static_cast<float>(i) / static_cast<float>(nPts) * maxVal);
+    }
+
+    polyData->GetPointData()->AddArray(scalars);
+    polyData->GetPointData()->SetActiveScalars(arrayName.c_str());
+    return polyData;
+}
+
+}  // anonymous namespace
+
+// =============================================================================
+// Construction and defaults
+// =============================================================================
+
+TEST(Display3DControllerTest, DefaultConstruction) {
+    Display3DController ctrl;
+    for (int i = 0; i < 13; ++i) {
+        EXPECT_FALSE(ctrl.isEnabled(static_cast<Display3DItem>(i)));
+    }
+}
+
+TEST(Display3DControllerTest, MoveConstruction) {
+    Display3DController ctrl;
+    ctrl.handleToggle(Display3DItem::Velocity, true);
+    EXPECT_TRUE(ctrl.isEnabled(Display3DItem::Velocity));
+
+    Display3DController moved(std::move(ctrl));
+    EXPECT_TRUE(moved.isEnabled(Display3DItem::Velocity));
+}
+
+TEST(Display3DControllerTest, EnabledStatesArray) {
+    Display3DController ctrl;
+    auto states = ctrl.enabledStates();
+    for (bool s : states) {
+        EXPECT_FALSE(s);
+    }
+
+    ctrl.handleToggle(Display3DItem::WSS, true);
+    ctrl.handleToggle(Display3DItem::Vorticity, true);
+    states = ctrl.enabledStates();
+    EXPECT_TRUE(states[static_cast<int>(Display3DItem::WSS)]);
+    EXPECT_TRUE(states[static_cast<int>(Display3DItem::Vorticity)]);
+    EXPECT_FALSE(states[static_cast<int>(Display3DItem::OSI)]);
+}
+
+// =============================================================================
+// Safe no-op when renderers not set
+// =============================================================================
+
+TEST(Display3DControllerTest, ToggleWithoutRenderers_NoOp) {
+    Display3DController ctrl;
+    // Should not crash when no renderers are set
+    ctrl.handleToggle(Display3DItem::WSS, true);
+    ctrl.handleToggle(Display3DItem::Velocity, true);
+    ctrl.handleToggle(Display3DItem::Streamline, true);
+    ctrl.handleToggle(Display3DItem::MaskVolume, true);
+    ctrl.handleToggle(Display3DItem::Surface, true);
+
+    // State is still tracked even without renderers
+    EXPECT_TRUE(ctrl.isEnabled(Display3DItem::WSS));
+    EXPECT_TRUE(ctrl.isEnabled(Display3DItem::Velocity));
+}
+
+// =============================================================================
+// Volume overlay visibility (Velocity, Vorticity, EnergyLoss, Magnitude)
+// =============================================================================
+
+class Display3DControllerVolumeTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        ctrl = std::make_unique<Display3DController>();
+        volumeRenderer = std::make_unique<VolumeRenderer>();
+        ctrl->setVolumeRenderer(volumeRenderer.get());
+
+        auto vol = createTestVolume();
+        auto ctf = createColorTF(100.0);
+        auto otf = createOpacityTF(100.0);
+
+        // Add all four overlay types
+        volumeRenderer->addScalarOverlay("velocity", vol, ctf, otf);
+        volumeRenderer->addScalarOverlay("vorticity", vol, ctf, otf);
+        volumeRenderer->addScalarOverlay("energy_loss", vol, ctf, otf);
+        volumeRenderer->addScalarOverlay("magnitude", vol, ctf, otf);
+    }
+
+    std::unique_ptr<Display3DController> ctrl;
+    std::unique_ptr<VolumeRenderer> volumeRenderer;
+};
+
+TEST_F(Display3DControllerVolumeTest, ToggleVelocity) {
+    ctrl->handleToggle(Display3DItem::Velocity, false);
+    EXPECT_FALSE(ctrl->isEnabled(Display3DItem::Velocity));
+
+    ctrl->handleToggle(Display3DItem::Velocity, true);
+    EXPECT_TRUE(ctrl->isEnabled(Display3DItem::Velocity));
+}
+
+TEST_F(Display3DControllerVolumeTest, ToggleVorticity) {
+    ctrl->handleToggle(Display3DItem::Vorticity, true);
+    EXPECT_TRUE(ctrl->isEnabled(Display3DItem::Vorticity));
+
+    ctrl->handleToggle(Display3DItem::Vorticity, false);
+    EXPECT_FALSE(ctrl->isEnabled(Display3DItem::Vorticity));
+}
+
+TEST_F(Display3DControllerVolumeTest, ToggleEnergyLoss) {
+    ctrl->handleToggle(Display3DItem::EnergyLoss, true);
+    EXPECT_TRUE(ctrl->isEnabled(Display3DItem::EnergyLoss));
+}
+
+TEST_F(Display3DControllerVolumeTest, ToggleMagnitude) {
+    ctrl->handleToggle(Display3DItem::Magnitude, true);
+    EXPECT_TRUE(ctrl->isEnabled(Display3DItem::Magnitude));
+}
+
+TEST_F(Display3DControllerVolumeTest, IndependentVolumeOverlays) {
+    ctrl->handleToggle(Display3DItem::Velocity, true);
+    ctrl->handleToggle(Display3DItem::Vorticity, true);
+    ctrl->handleToggle(Display3DItem::EnergyLoss, false);
+
+    EXPECT_TRUE(ctrl->isEnabled(Display3DItem::Velocity));
+    EXPECT_TRUE(ctrl->isEnabled(Display3DItem::Vorticity));
+    EXPECT_FALSE(ctrl->isEnabled(Display3DItem::EnergyLoss));
+    EXPECT_FALSE(ctrl->isEnabled(Display3DItem::Magnitude));
+}
+
+// =============================================================================
+// Hemodynamic surface visibility (WSS, OSI, AFI, RRT)
+// =============================================================================
+
+class Display3DControllerSurfaceTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        ctrl = std::make_unique<Display3DController>();
+        surfaceRenderer = std::make_unique<SurfaceRenderer>();
+        hemoManager = std::make_unique<HemodynamicSurfaceManager>();
+        ctrl->setSurfaceRenderer(surfaceRenderer.get());
+        ctrl->setHemodynamicManager(hemoManager.get());
+
+        // Add hemodynamic surfaces
+        auto wssMesh = createMeshWithArray("WSS", 5.0);
+        hemoManager->showWSS(*surfaceRenderer, wssMesh, 5.0);
+
+        auto osiMesh = createMeshWithArray("OSI", 0.5);
+        hemoManager->showOSI(*surfaceRenderer, osiMesh);
+
+        auto tawssMesh = createMeshWithArray("TAWSS", 4.0);
+        hemoManager->showAFI(*surfaceRenderer, tawssMesh);
+
+        auto rrtMesh = createMeshWithArray("RRT", 100.0);
+        hemoManager->showRRT(*surfaceRenderer, rrtMesh, 100.0);
+    }
+
+    std::unique_ptr<Display3DController> ctrl;
+    std::unique_ptr<SurfaceRenderer> surfaceRenderer;
+    std::unique_ptr<HemodynamicSurfaceManager> hemoManager;
+};
+
+TEST_F(Display3DControllerSurfaceTest, ToggleWSS) {
+    ctrl->handleToggle(Display3DItem::WSS, false);
+    EXPECT_FALSE(ctrl->isEnabled(Display3DItem::WSS));
+
+    auto wssIdx = hemoManager->wssIndex();
+    ASSERT_TRUE(wssIdx.has_value());
+    auto config = surfaceRenderer->getSurfaceConfig(*wssIdx);
+    EXPECT_FALSE(config.visible);
+
+    ctrl->handleToggle(Display3DItem::WSS, true);
+    config = surfaceRenderer->getSurfaceConfig(*wssIdx);
+    EXPECT_TRUE(config.visible);
+}
+
+TEST_F(Display3DControllerSurfaceTest, ToggleOSI) {
+    ctrl->handleToggle(Display3DItem::OSI, false);
+    auto osiIdx = hemoManager->osiIndex();
+    ASSERT_TRUE(osiIdx.has_value());
+    auto config = surfaceRenderer->getSurfaceConfig(*osiIdx);
+    EXPECT_FALSE(config.visible);
+}
+
+TEST_F(Display3DControllerSurfaceTest, ToggleAFI) {
+    ctrl->handleToggle(Display3DItem::AFI, false);
+    auto afiIdx = hemoManager->afiIndex();
+    ASSERT_TRUE(afiIdx.has_value());
+    auto config = surfaceRenderer->getSurfaceConfig(*afiIdx);
+    EXPECT_FALSE(config.visible);
+}
+
+TEST_F(Display3DControllerSurfaceTest, ToggleRRT) {
+    ctrl->handleToggle(Display3DItem::RRT, false);
+    auto rrtIdx = hemoManager->rrtIndex();
+    ASSERT_TRUE(rrtIdx.has_value());
+    auto config = surfaceRenderer->getSurfaceConfig(*rrtIdx);
+    EXPECT_FALSE(config.visible);
+}
+
+TEST_F(Display3DControllerSurfaceTest, IndependentSurfaces) {
+    ctrl->handleToggle(Display3DItem::WSS, false);
+    ctrl->handleToggle(Display3DItem::OSI, true);
+    ctrl->handleToggle(Display3DItem::AFI, false);
+    ctrl->handleToggle(Display3DItem::RRT, true);
+
+    auto wssConfig = surfaceRenderer->getSurfaceConfig(*hemoManager->wssIndex());
+    auto osiConfig = surfaceRenderer->getSurfaceConfig(*hemoManager->osiIndex());
+    auto afiConfig = surfaceRenderer->getSurfaceConfig(*hemoManager->afiIndex());
+    auto rrtConfig = surfaceRenderer->getSurfaceConfig(*hemoManager->rrtIndex());
+
+    EXPECT_FALSE(wssConfig.visible);
+    EXPECT_TRUE(osiConfig.visible);
+    EXPECT_FALSE(afiConfig.visible);
+    EXPECT_TRUE(rrtConfig.visible);
+}
+
+// =============================================================================
+// Actor visibility (Streamline, MaskVolume, Surface)
+// =============================================================================
+
+TEST(Display3DControllerTest, ToggleStreamlineActor) {
+    Display3DController ctrl;
+    auto actor = vtkSmartPointer<vtkActor>::New();
+    ctrl.setStreamlineActor(actor);
+
+    EXPECT_EQ(actor->GetVisibility(), 1);  // VTK default
+
+    ctrl.handleToggle(Display3DItem::Streamline, false);
+    EXPECT_EQ(actor->GetVisibility(), 0);
+
+    ctrl.handleToggle(Display3DItem::Streamline, true);
+    EXPECT_EQ(actor->GetVisibility(), 1);
+}
+
+TEST(Display3DControllerTest, ToggleMaskVolumeActor) {
+    Display3DController ctrl;
+    auto actor = vtkSmartPointer<vtkActor>::New();
+    ctrl.setMaskVolumeActor(actor);
+
+    ctrl.handleToggle(Display3DItem::MaskVolume, false);
+    EXPECT_EQ(actor->GetVisibility(), 0);
+
+    ctrl.handleToggle(Display3DItem::MaskVolume, true);
+    EXPECT_EQ(actor->GetVisibility(), 1);
+}
+
+TEST(Display3DControllerTest, ToggleSurfaceActor) {
+    Display3DController ctrl;
+    auto actor = vtkSmartPointer<vtkActor>::New();
+    ctrl.setSurfaceActor(actor);
+
+    ctrl.handleToggle(Display3DItem::Surface, false);
+    EXPECT_EQ(actor->GetVisibility(), 0);
+
+    ctrl.handleToggle(Display3DItem::Surface, true);
+    EXPECT_EQ(actor->GetVisibility(), 1);
+}
+
+// =============================================================================
+// Stub items (Cine, ASC) — should not crash, just track state
+// =============================================================================
+
+TEST(Display3DControllerTest, StubItems_Cine) {
+    Display3DController ctrl;
+    ctrl.handleToggle(Display3DItem::Cine, true);
+    EXPECT_TRUE(ctrl.isEnabled(Display3DItem::Cine));
+
+    ctrl.handleToggle(Display3DItem::Cine, false);
+    EXPECT_FALSE(ctrl.isEnabled(Display3DItem::Cine));
+}
+
+TEST(Display3DControllerTest, StubItems_ASC) {
+    Display3DController ctrl;
+    ctrl.handleToggle(Display3DItem::ASC, true);
+    EXPECT_TRUE(ctrl.isEnabled(Display3DItem::ASC));
+}
+
+// =============================================================================
+// All 13 items independent toggling
+// =============================================================================
+
+TEST(Display3DControllerTest, AllItemsToggleIndependently) {
+    Display3DController ctrl;
+
+    // Enable all
+    for (int i = 0; i < 13; ++i) {
+        ctrl.handleToggle(static_cast<Display3DItem>(i), true);
+    }
+    for (int i = 0; i < 13; ++i) {
+        EXPECT_TRUE(ctrl.isEnabled(static_cast<Display3DItem>(i)));
+    }
+
+    // Disable odd indices only
+    for (int i = 0; i < 13; ++i) {
+        if (i % 2 == 1) {
+            ctrl.handleToggle(static_cast<Display3DItem>(i), false);
+        }
+    }
+    for (int i = 0; i < 13; ++i) {
+        if (i % 2 == 0) {
+            EXPECT_TRUE(ctrl.isEnabled(static_cast<Display3DItem>(i)));
+        } else {
+            EXPECT_FALSE(ctrl.isEnabled(static_cast<Display3DItem>(i)));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Display3DController` class that routes `FlowToolPanel::display3DToggled` signal to rendering backends
- Volume overlays (Velocity, Vorticity, EnergyLoss, Magnitude) → `VolumeRenderer::setOverlayVisible()`
- Hemodynamic surfaces (WSS, OSI, AFI, RRT) → `SurfaceRenderer::setSurfaceVisibility()` via `HemodynamicSurfaceManager`
- Actor-based items (Streamline, MaskVolume, Surface) → `vtkActor::SetVisibility()`
- Stub items (Cine, ASC) track state but have no rendering effect yet
- Wire signal in `MainWindow::setupConnections()` via lambda

Closes #338

## Test Plan
- [x] 20 unit tests covering all 13 Display3DItem toggles
- [x] Volume overlay toggle verification (Velocity, Vorticity, EnergyLoss, Magnitude)
- [x] Hemodynamic surface toggle with real SurfaceRenderer/HemodynamicSurfaceManager
- [x] Actor visibility toggling for Streamline, MaskVolume, Surface
- [x] Safe no-op when renderers not set
- [x] State tracking (isEnabled, enabledStates)
- [x] Move construction support
- [x] Full build passes