### PR TITLE
feat(ui): add colormap range controls for 3D hemodynamic parameters

### DIFF
--- a/include/ui/display_3d_controller.hpp
+++ b/include/ui/display_3d_controller.hpp
@@ -96,6 +96,33 @@ public:
      */
     void handleToggle(Display3DItem item, bool enabled);
 
+    // --- Scalar range control ---
+
+    /**
+     * @brief Set the colormap scalar range for a Display 3D item
+     *
+     * Routes range changes to the appropriate renderer:
+     * - WSS/OSI/AFI/RRT → SurfaceRenderer::setSurfaceScalarRange + LUT rebuild
+     * - Velocity/Vorticity/EnergyLoss/Magnitude → VolumeRenderer TF rebuild
+     * - Other items are no-op
+     *
+     * @param item The Display3DItem to configure
+     * @param minVal Minimum scalar value (mapped to colormap start)
+     * @param maxVal Maximum scalar value (mapped to colormap end)
+     */
+    void setScalarRange(Display3DItem item, double minVal, double maxVal);
+
+    /**
+     * @brief Get the current scalar range for a Display 3D item
+     * @return {min, max} pair, or {0, 0} if item has no range
+     */
+    [[nodiscard]] std::pair<double, double> scalarRange(Display3DItem item) const;
+
+    /**
+     * @brief Check if a Display 3D item supports colormap range adjustment
+     */
+    [[nodiscard]] static bool hasColormapRange(Display3DItem item);
+
     // --- State queries ---
 
     /**

--- a/include/ui/panels/flow_tool_panel.hpp
+++ b/include/ui/panels/flow_tool_panel.hpp
@@ -126,6 +126,14 @@ public slots:
      */
     void setDisplay3DEnabled(Display3DItem item, bool enabled);
 
+    /**
+     * @brief Set the scalar range for a 3D display item programmatically
+     * @param item The display item (must have colormap)
+     * @param minVal Minimum scalar value
+     * @param maxVal Maximum scalar value
+     */
+    void setDisplay3DRange(Display3DItem item, double minVal, double maxVal);
+
 signals:
     /**
      * @brief Emitted when the user selects a different velocity series
@@ -146,6 +154,14 @@ signals:
      * @param enabled True if checked
      */
     void display3DToggled(Display3DItem item, bool enabled);
+
+    /**
+     * @brief Emitted when a 3D display item's scalar range is changed
+     * @param item The display item
+     * @param minVal New minimum scalar value
+     * @param maxVal New maximum scalar value
+     */
+    void display3DRangeChanged(Display3DItem item, double minVal, double maxVal);
 
 private:
     void setupUI();

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -695,6 +695,12 @@ void MainWindow::setupConnections()
         impl_->display3DController->handleToggle(item, enabled);
     });
 
+    // Flow tool panel Display 3D range changes → Display3DController
+    connect(impl_->flowToolPanel, &FlowToolPanel::display3DRangeChanged,
+            this, [this](Display3DItem item, double minVal, double maxVal) {
+        impl_->display3DController->setScalarRange(item, minVal, maxVal);
+    });
+
     // Patient browser -> Load series
     connect(impl_->patientBrowser, &PatientBrowser::seriesLoadRequested,
             this, [this](const QString& /*seriesUid*/, const QString& /*path*/) {


### PR DESCRIPTION
Closes #339

## Summary
- Extend `Display3DController` with scalar range API (`setScalarRange`, `scalarRange`, `hasColormapRange`) routing range changes to surface renderers (WSS/OSI/AFI/RRT with LUT rebuild) and volume renderers (Velocity/Vorticity/EnergyLoss/Magnitude with transfer function rebuild)
- Add min/max `QDoubleSpinBox` pairs to `FlowToolPanel` for each of the 8 colormap items with appropriate default ranges (e.g., WSS 0-5 Pa, OSI 0-0.5, AFI 0-2.0)
- Wire `display3DRangeChanged` signal through `MainWindow` to `Display3DController::setScalarRange`
- Add 16 new unit tests covering `hasColormapRange` classification, scalar range state tracking, and renderer integration

## Test Plan
- [x] All 36 `display_3d_controller_test` tests pass (20 existing + 16 new)
- [x] Build succeeds with no compilation errors
- [ ] Manual verification: adjust min/max spinboxes in Display 3D section and observe colormap range changes in 3D viewport