### PR TITLE
feat(rendering): implement ASC View with simultaneous axial/sagittal/coronal 3D overlay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,6 +373,7 @@ add_library(render_service STATIC
     src/services/render/hemodynamic_overlay_renderer.cpp
     src/services/render/streamline_overlay_renderer.cpp
     src/services/render/hemodynamic_surface_manager.cpp
+    src/services/render/asc_view_controller.cpp
 )
 
 target_link_libraries(render_service PUBLIC

--- a/include/services/render/asc_view_controller.hpp
+++ b/include/services/render/asc_view_controller.hpp
@@ -1,0 +1,153 @@
+#pragma once
+
+#include <array>
+#include <memory>
+
+#include <vtkSmartPointer.h>
+#include <vtkImageData.h>
+
+class vtkRenderer;
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief ASC (Axial/Sagittal/Coronal) View controller for 3D overlay
+ *
+ * Creates three orthogonal cutting planes (axial, sagittal, coronal) in
+ * a 3D renderer, each showing the corresponding resliced image as a
+ * textured quad. Planes can be positioned at arbitrary slice indices
+ * and toggled visible/hidden.
+ *
+ * Uses vtkImageSliceMapper + vtkImageSlice for each plane:
+ * - Axial (Z): XY plane at specified Z slice
+ * - Coronal (Y): XZ plane at specified Y slice
+ * - Sagittal (X): YZ plane at specified X slice
+ *
+ * @trace SRS-FR-047, PRD FR-016
+ */
+class AscViewController {
+public:
+    AscViewController();
+    ~AscViewController();
+
+    // Non-copyable, movable
+    AscViewController(const AscViewController&) = delete;
+    AscViewController& operator=(const AscViewController&) = delete;
+    AscViewController(AscViewController&&) noexcept;
+    AscViewController& operator=(AscViewController&&) noexcept;
+
+    /**
+     * @brief Set the input volume data
+     * @param imageData 3D volume (must have >=2 dimensions in each axis)
+     */
+    void setInputData(vtkSmartPointer<vtkImageData> imageData);
+
+    /**
+     * @brief Get current input data
+     */
+    [[nodiscard]] vtkSmartPointer<vtkImageData> getInputData() const;
+
+    /**
+     * @brief Set the VTK renderer where ASC planes will be displayed
+     * @param renderer Non-owning pointer to 3D renderer
+     */
+    void setRenderer(vtkRenderer* renderer);
+
+    /**
+     * @brief Get current renderer
+     */
+    [[nodiscard]] vtkRenderer* getRenderer() const;
+
+    // ==================== Visibility ====================
+
+    /**
+     * @brief Toggle visibility of all three ASC planes
+     * @param visible True to show, false to hide
+     */
+    void setVisible(bool visible);
+
+    /**
+     * @brief Check if ASC planes are currently visible
+     */
+    [[nodiscard]] bool isVisible() const;
+
+    // ==================== Plane Positioning ====================
+
+    /**
+     * @brief Set axial (Z) slice index
+     * @param slice Z-axis slice index (0-based)
+     */
+    void setAxialSlice(int slice);
+
+    /**
+     * @brief Set coronal (Y) slice index
+     * @param slice Y-axis slice index (0-based)
+     */
+    void setCoronalSlice(int slice);
+
+    /**
+     * @brief Set sagittal (X) slice index
+     * @param slice X-axis slice index (0-based)
+     */
+    void setSagittalSlice(int slice);
+
+    /**
+     * @brief Set all three plane positions at once
+     */
+    void setSlicePositions(int axial, int coronal, int sagittal);
+
+    /**
+     * @brief Get current axial slice index
+     */
+    [[nodiscard]] int axialSlice() const;
+
+    /**
+     * @brief Get current coronal slice index
+     */
+    [[nodiscard]] int coronalSlice() const;
+
+    /**
+     * @brief Get current sagittal slice index
+     */
+    [[nodiscard]] int sagittalSlice() const;
+
+    /**
+     * @brief Get volume dimensions [X, Y, Z]
+     * @return Dimensions or {0,0,0} if no data set
+     */
+    [[nodiscard]] std::array<int, 3> dimensions() const;
+
+    // ==================== Rendering ====================
+
+    /**
+     * @brief Set window/level for the ASC plane display
+     */
+    void setWindowLevel(double width, double center);
+
+    /**
+     * @brief Get current window/level
+     */
+    [[nodiscard]] std::pair<double, double> getWindowLevel() const;
+
+    /**
+     * @brief Set opacity for all ASC planes
+     * @param opacity Opacity value (0.0-1.0)
+     */
+    void setOpacity(double opacity);
+
+    /**
+     * @brief Get current opacity
+     */
+    [[nodiscard]] double getOpacity() const;
+
+    /**
+     * @brief Force rendering update
+     */
+    void update();
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace dicom_viewer::services

--- a/include/ui/display_3d_controller.hpp
+++ b/include/ui/display_3d_controller.hpp
@@ -13,6 +13,7 @@ namespace dicom_viewer::services {
 class VolumeRenderer;
 class SurfaceRenderer;
 class HemodynamicSurfaceManager;
+class AscViewController;
 }  // namespace dicom_viewer::services
 
 namespace dicom_viewer::ui {
@@ -27,7 +28,8 @@ namespace dicom_viewer::ui {
  *   → SurfaceRenderer::setSurfaceVisibility() via HemodynamicSurfaceManager
  * - Streamline → vtkActor visibility
  * - MaskVolume, Surface → base renderer visibility
- * - Cine, ASC → stub (not yet implemented)
+ * - ASC → AscViewController::setVisible()
+ * - Cine → stub (not yet implemented)
  *
  * This class does NOT derive from QObject. The caller (MainWindow) wires
  * FlowToolPanel::display3DToggled to handleToggle() via a lambda.
@@ -82,6 +84,12 @@ public:
      * @param actor Surface mesh actor
      */
     void setSurfaceActor(vtkSmartPointer<vtkActor> actor);
+
+    /**
+     * @brief Set the ASC view controller for orthogonal plane visibility
+     * @param controller Non-owning pointer (caller manages lifetime)
+     */
+    void setAscController(services::AscViewController* controller);
 
     // --- Toggle dispatch ---
 

--- a/src/services/render/asc_view_controller.cpp
+++ b/src/services/render/asc_view_controller.cpp
@@ -1,0 +1,223 @@
+#include "services/render/asc_view_controller.hpp"
+
+#include <vtkImageProperty.h>
+#include <vtkImageSlice.h>
+#include <vtkImageSliceMapper.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderer.h>
+
+namespace dicom_viewer::services {
+
+class AscViewController::Impl {
+public:
+    vtkSmartPointer<vtkImageData> imageData;
+    vtkRenderer* renderer = nullptr;
+
+    // Three orthogonal plane pipelines
+    struct PlaneState {
+        vtkSmartPointer<vtkImageSliceMapper> mapper;
+        vtkSmartPointer<vtkImageSlice> slice;
+        int currentSlice = 0;
+    };
+
+    PlaneState axial;    // Z orientation
+    PlaneState coronal;  // Y orientation
+    PlaneState sagittal; // X orientation
+
+    vtkSmartPointer<vtkImageProperty> sharedProperty;
+
+    bool visible = false;
+    bool addedToRenderer = false;
+    double opacity = 1.0;
+
+    Impl() {
+        // Create mappers
+        axial.mapper = vtkSmartPointer<vtkImageSliceMapper>::New();
+        coronal.mapper = vtkSmartPointer<vtkImageSliceMapper>::New();
+        sagittal.mapper = vtkSmartPointer<vtkImageSliceMapper>::New();
+
+        axial.mapper->SetOrientationToZ();
+        coronal.mapper->SetOrientationToY();
+        sagittal.mapper->SetOrientationToX();
+
+        // Create image slices (actors)
+        axial.slice = vtkSmartPointer<vtkImageSlice>::New();
+        coronal.slice = vtkSmartPointer<vtkImageSlice>::New();
+        sagittal.slice = vtkSmartPointer<vtkImageSlice>::New();
+
+        axial.slice->SetMapper(axial.mapper);
+        coronal.slice->SetMapper(coronal.mapper);
+        sagittal.slice->SetMapper(sagittal.mapper);
+
+        // Shared image property for W/L
+        sharedProperty = vtkSmartPointer<vtkImageProperty>::New();
+        sharedProperty->SetColorWindow(400.0);
+        sharedProperty->SetColorLevel(40.0);
+        sharedProperty->SetInterpolationTypeToLinear();
+
+        axial.slice->SetProperty(sharedProperty);
+        coronal.slice->SetProperty(sharedProperty);
+        sagittal.slice->SetProperty(sharedProperty);
+
+        // Start hidden
+        axial.slice->SetVisibility(0);
+        coronal.slice->SetVisibility(0);
+        sagittal.slice->SetVisibility(0);
+    }
+
+    void addToRenderer() {
+        if (!renderer || !imageData || addedToRenderer) return;
+        renderer->AddViewProp(axial.slice);
+        renderer->AddViewProp(coronal.slice);
+        renderer->AddViewProp(sagittal.slice);
+        addedToRenderer = true;
+    }
+
+    void removeFromRenderer() {
+        if (!renderer || !addedToRenderer) return;
+        renderer->RemoveViewProp(axial.slice);
+        renderer->RemoveViewProp(coronal.slice);
+        renderer->RemoveViewProp(sagittal.slice);
+        addedToRenderer = false;
+    }
+
+    void updateVisibility() {
+        int vis = visible ? 1 : 0;
+        axial.slice->SetVisibility(vis);
+        coronal.slice->SetVisibility(vis);
+        sagittal.slice->SetVisibility(vis);
+    }
+
+    void centerSlices() {
+        if (!imageData) return;
+        int dims[3];
+        imageData->GetDimensions(dims);
+        axial.currentSlice = dims[2] / 2;
+        coronal.currentSlice = dims[1] / 2;
+        sagittal.currentSlice = dims[0] / 2;
+        axial.mapper->SetSliceNumber(axial.currentSlice);
+        coronal.mapper->SetSliceNumber(coronal.currentSlice);
+        sagittal.mapper->SetSliceNumber(sagittal.currentSlice);
+    }
+};
+
+AscViewController::AscViewController()
+    : impl_(std::make_unique<Impl>())
+{}
+
+AscViewController::~AscViewController() {
+    if (impl_) {
+        impl_->removeFromRenderer();
+    }
+}
+
+AscViewController::AscViewController(AscViewController&&) noexcept = default;
+AscViewController& AscViewController::operator=(AscViewController&&) noexcept = default;
+
+void AscViewController::setInputData(vtkSmartPointer<vtkImageData> imageData) {
+    impl_->imageData = std::move(imageData);
+    impl_->axial.mapper->SetInputData(impl_->imageData);
+    impl_->coronal.mapper->SetInputData(impl_->imageData);
+    impl_->sagittal.mapper->SetInputData(impl_->imageData);
+    impl_->centerSlices();
+    // If renderer was set before data, add props now
+    if (impl_->renderer && !impl_->addedToRenderer) {
+        impl_->addToRenderer();
+        impl_->updateVisibility();
+    }
+}
+
+vtkSmartPointer<vtkImageData> AscViewController::getInputData() const {
+    return impl_->imageData;
+}
+
+void AscViewController::setRenderer(vtkRenderer* renderer) {
+    impl_->removeFromRenderer();
+    impl_->renderer = renderer;
+    if (renderer) {
+        impl_->addToRenderer();
+        impl_->updateVisibility();
+    }
+}
+
+vtkRenderer* AscViewController::getRenderer() const {
+    return impl_->renderer;
+}
+
+void AscViewController::setVisible(bool visible) {
+    impl_->visible = visible;
+    impl_->updateVisibility();
+}
+
+bool AscViewController::isVisible() const {
+    return impl_->visible;
+}
+
+void AscViewController::setAxialSlice(int slice) {
+    impl_->axial.currentSlice = slice;
+    impl_->axial.mapper->SetSliceNumber(slice);
+}
+
+void AscViewController::setCoronalSlice(int slice) {
+    impl_->coronal.currentSlice = slice;
+    impl_->coronal.mapper->SetSliceNumber(slice);
+}
+
+void AscViewController::setSagittalSlice(int slice) {
+    impl_->sagittal.currentSlice = slice;
+    impl_->sagittal.mapper->SetSliceNumber(slice);
+}
+
+void AscViewController::setSlicePositions(int axial, int coronal, int sagittal) {
+    setAxialSlice(axial);
+    setCoronalSlice(coronal);
+    setSagittalSlice(sagittal);
+}
+
+int AscViewController::axialSlice() const {
+    return impl_->axial.currentSlice;
+}
+
+int AscViewController::coronalSlice() const {
+    return impl_->coronal.currentSlice;
+}
+
+int AscViewController::sagittalSlice() const {
+    return impl_->sagittal.currentSlice;
+}
+
+std::array<int, 3> AscViewController::dimensions() const {
+    if (!impl_->imageData) return {0, 0, 0};
+    int dims[3];
+    impl_->imageData->GetDimensions(dims);
+    return {dims[0], dims[1], dims[2]};
+}
+
+void AscViewController::setWindowLevel(double width, double center) {
+    impl_->sharedProperty->SetColorWindow(width);
+    impl_->sharedProperty->SetColorLevel(center);
+}
+
+std::pair<double, double> AscViewController::getWindowLevel() const {
+    return {
+        impl_->sharedProperty->GetColorWindow(),
+        impl_->sharedProperty->GetColorLevel()
+    };
+}
+
+void AscViewController::setOpacity(double opacity) {
+    impl_->opacity = opacity;
+    impl_->sharedProperty->SetOpacity(opacity);
+}
+
+double AscViewController::getOpacity() const {
+    return impl_->opacity;
+}
+
+void AscViewController::update() {
+    if (impl_->renderer && impl_->renderer->GetRenderWindow()) {
+        impl_->renderer->GetRenderWindow()->Render();
+    }
+}
+
+}  // namespace dicom_viewer::services

--- a/src/ui/display_3d_controller.cpp
+++ b/src/ui/display_3d_controller.cpp
@@ -1,6 +1,7 @@
 #include "ui/display_3d_controller.hpp"
 
 #include "services/hemodynamic_surface_manager.hpp"
+#include "services/render/asc_view_controller.hpp"
 #include "services/surface_renderer.hpp"
 #include "services/volume_renderer.hpp"
 
@@ -24,6 +25,7 @@ public:
     services::VolumeRenderer* volumeRenderer = nullptr;
     services::SurfaceRenderer* surfaceRenderer = nullptr;
     services::HemodynamicSurfaceManager* hemoManager = nullptr;
+    services::AscViewController* ascController = nullptr;
 
     vtkSmartPointer<vtkActor> streamlineActor;
     vtkSmartPointer<vtkActor> maskVolumeActor;
@@ -73,6 +75,11 @@ void Display3DController::setSurfaceActor(vtkSmartPointer<vtkActor> actor)
     impl_->surfaceActor = std::move(actor);
 }
 
+void Display3DController::setAscController(services::AscViewController* controller)
+{
+    impl_->ascController = controller;
+}
+
 void Display3DController::handleToggle(Display3DItem item, bool enabled)
 {
     auto idx = static_cast<int>(item);
@@ -110,7 +117,9 @@ void Display3DController::handleToggle(Display3DItem item, bool enabled)
         break;
 
     case Display3DItem::ASC:
-        // Stub: ASC view not yet implemented
+        if (impl_->ascController) {
+            impl_->ascController->setVisible(enabled);
+        }
         break;
 
     case Display3DItem::Streamline:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1800,3 +1800,24 @@ vtk_module_autoinit(
 )
 
 gtest_discover_tests(display_3d_controller_test DISCOVERY_TIMEOUT 60)
+
+add_executable(asc_view_controller_test
+    unit/asc_view_controller_test.cpp
+)
+
+target_link_libraries(asc_view_controller_test PRIVATE
+    render_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(asc_view_controller_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+vtk_module_autoinit(
+    TARGETS asc_view_controller_test
+    MODULES ${VTK_LIBRARIES}
+)
+
+gtest_discover_tests(asc_view_controller_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/asc_view_controller_test.cpp
+++ b/tests/unit/asc_view_controller_test.cpp
@@ -1,0 +1,225 @@
+#include <gtest/gtest.h>
+
+#include "services/render/asc_view_controller.hpp"
+
+#include <vtkImageData.h>
+#include <vtkRenderer.h>
+#include <vtkSmartPointer.h>
+
+using namespace dicom_viewer::services;
+
+namespace {
+
+vtkSmartPointer<vtkImageData> createTestVolume(int dimX = 16, int dimY = 16, int dimZ = 16)
+{
+    auto image = vtkSmartPointer<vtkImageData>::New();
+    image->SetDimensions(dimX, dimY, dimZ);
+    image->SetSpacing(1.0, 1.0, 1.0);
+    image->SetOrigin(0.0, 0.0, 0.0);
+    image->AllocateScalars(VTK_FLOAT, 1);
+
+    auto* ptr = static_cast<float*>(image->GetScalarPointer());
+    int total = dimX * dimY * dimZ;
+    for (int i = 0; i < total; ++i) {
+        ptr[i] = static_cast<float>(i % 256);
+    }
+    return image;
+}
+
+}  // anonymous namespace
+
+// =============================================================================
+// Construction and defaults
+// =============================================================================
+
+TEST(AscViewControllerTest, DefaultConstruction) {
+    AscViewController ctrl;
+    EXPECT_FALSE(ctrl.isVisible());
+    EXPECT_EQ(ctrl.getInputData(), nullptr);
+    EXPECT_EQ(ctrl.getRenderer(), nullptr);
+    EXPECT_EQ(ctrl.axialSlice(), 0);
+    EXPECT_EQ(ctrl.coronalSlice(), 0);
+    EXPECT_EQ(ctrl.sagittalSlice(), 0);
+}
+
+TEST(AscViewControllerTest, MoveConstruction) {
+    AscViewController ctrl;
+    ctrl.setVisible(true);
+    EXPECT_TRUE(ctrl.isVisible());
+
+    AscViewController moved(std::move(ctrl));
+    EXPECT_TRUE(moved.isVisible());
+}
+
+TEST(AscViewControllerTest, Dimensions_NoData) {
+    AscViewController ctrl;
+    auto dims = ctrl.dimensions();
+    EXPECT_EQ(dims[0], 0);
+    EXPECT_EQ(dims[1], 0);
+    EXPECT_EQ(dims[2], 0);
+}
+
+// =============================================================================
+// Input data and auto-centering
+// =============================================================================
+
+TEST(AscViewControllerTest, SetInputData_CentersSlices) {
+    AscViewController ctrl;
+    auto vol = createTestVolume(20, 30, 40);
+    ctrl.setInputData(vol);
+
+    EXPECT_EQ(ctrl.getInputData(), vol);
+
+    auto dims = ctrl.dimensions();
+    EXPECT_EQ(dims[0], 20);
+    EXPECT_EQ(dims[1], 30);
+    EXPECT_EQ(dims[2], 40);
+
+    // Slices should be centered at dim/2
+    EXPECT_EQ(ctrl.axialSlice(), 20);    // 40/2
+    EXPECT_EQ(ctrl.coronalSlice(), 15);  // 30/2
+    EXPECT_EQ(ctrl.sagittalSlice(), 10); // 20/2
+}
+
+// =============================================================================
+// Visibility
+// =============================================================================
+
+TEST(AscViewControllerTest, Visibility_Toggle) {
+    AscViewController ctrl;
+    EXPECT_FALSE(ctrl.isVisible());
+
+    ctrl.setVisible(true);
+    EXPECT_TRUE(ctrl.isVisible());
+
+    ctrl.setVisible(false);
+    EXPECT_FALSE(ctrl.isVisible());
+}
+
+// =============================================================================
+// Slice positioning
+// =============================================================================
+
+TEST(AscViewControllerTest, SlicePositioning_Individual) {
+    AscViewController ctrl;
+    auto vol = createTestVolume();
+    ctrl.setInputData(vol);
+
+    ctrl.setAxialSlice(5);
+    EXPECT_EQ(ctrl.axialSlice(), 5);
+
+    ctrl.setCoronalSlice(10);
+    EXPECT_EQ(ctrl.coronalSlice(), 10);
+
+    ctrl.setSagittalSlice(3);
+    EXPECT_EQ(ctrl.sagittalSlice(), 3);
+}
+
+TEST(AscViewControllerTest, SlicePositioning_AllAtOnce) {
+    AscViewController ctrl;
+    auto vol = createTestVolume();
+    ctrl.setInputData(vol);
+
+    ctrl.setSlicePositions(7, 11, 2);
+    EXPECT_EQ(ctrl.axialSlice(), 7);
+    EXPECT_EQ(ctrl.coronalSlice(), 11);
+    EXPECT_EQ(ctrl.sagittalSlice(), 2);
+}
+
+// =============================================================================
+// Window/Level
+// =============================================================================
+
+TEST(AscViewControllerTest, WindowLevel_Default) {
+    AscViewController ctrl;
+    auto [w, c] = ctrl.getWindowLevel();
+    EXPECT_DOUBLE_EQ(w, 400.0);
+    EXPECT_DOUBLE_EQ(c, 40.0);
+}
+
+TEST(AscViewControllerTest, WindowLevel_Set) {
+    AscViewController ctrl;
+    ctrl.setWindowLevel(1500.0, 300.0);
+    auto [w, c] = ctrl.getWindowLevel();
+    EXPECT_DOUBLE_EQ(w, 1500.0);
+    EXPECT_DOUBLE_EQ(c, 300.0);
+}
+
+// =============================================================================
+// Opacity
+// =============================================================================
+
+TEST(AscViewControllerTest, Opacity_Default) {
+    AscViewController ctrl;
+    EXPECT_DOUBLE_EQ(ctrl.getOpacity(), 1.0);
+}
+
+TEST(AscViewControllerTest, Opacity_Set) {
+    AscViewController ctrl;
+    ctrl.setOpacity(0.5);
+    EXPECT_DOUBLE_EQ(ctrl.getOpacity(), 0.5);
+}
+
+// =============================================================================
+// Renderer integration
+// =============================================================================
+
+// Note: vtkImageSlice + vtkImageSliceMapper require an OpenGL context.
+// Adding them to a bare vtkRenderer without a render window crashes VTK.
+// Renderer integration tests are deferred to integration test suite.
+// Here we test only state management (getRenderer pointer tracking).
+
+TEST(AscViewControllerTest, Renderer_GetInitiallyNull) {
+    AscViewController ctrl;
+    EXPECT_EQ(ctrl.getRenderer(), nullptr);
+}
+
+TEST(AscViewControllerTest, DataWithoutRenderer) {
+    AscViewController ctrl;
+    auto vol = createTestVolume();
+
+    ctrl.setInputData(vol);
+    EXPECT_EQ(ctrl.getInputData(), vol);
+    EXPECT_EQ(ctrl.getRenderer(), nullptr);
+
+    // All state operations should work without renderer
+    ctrl.setVisible(true);
+    EXPECT_TRUE(ctrl.isVisible());
+    ctrl.setSlicePositions(5, 5, 5);
+    EXPECT_EQ(ctrl.axialSlice(), 5);
+}
+
+// =============================================================================
+// Integration with Display3DController
+// =============================================================================
+
+TEST(AscViewControllerTest, FullWorkflow) {
+    AscViewController ctrl;
+    auto vol = createTestVolume(32, 32, 32);
+
+    ctrl.setInputData(vol);
+    ctrl.setWindowLevel(2000.0, 400.0);
+    ctrl.setOpacity(0.8);
+
+    auto [w, c] = ctrl.getWindowLevel();
+    EXPECT_DOUBLE_EQ(w, 2000.0);
+    EXPECT_DOUBLE_EQ(c, 400.0);
+    EXPECT_DOUBLE_EQ(ctrl.getOpacity(), 0.8);
+
+    // Initially hidden
+    EXPECT_FALSE(ctrl.isVisible());
+
+    // Show ASC planes
+    ctrl.setVisible(true);
+    EXPECT_TRUE(ctrl.isVisible());
+
+    // Position planes
+    ctrl.setSlicePositions(16, 16, 16);
+    EXPECT_EQ(ctrl.axialSlice(), 16);
+    EXPECT_EQ(ctrl.coronalSlice(), 16);
+    EXPECT_EQ(ctrl.sagittalSlice(), 16);
+
+    // Hide again
+    ctrl.setVisible(false);
+    EXPECT_FALSE(ctrl.isVisible());
+}


### PR DESCRIPTION
Closes #340

## Summary
- Add `AscViewController` class managing three orthogonal cutting planes (axial/sagittal/coronal) in 3D using `vtkImageSliceMapper` + `vtkImageSlice`
- Planes auto-center on volume center when input data is set, with configurable slice indices, shared window/level, and opacity
- Wire ASC toggle in `Display3DController` to `AscViewController::setVisible()`, replacing the previous stub
- Add 14 unit tests covering construction, visibility, slice positioning, window/level, opacity, dimensions, and data binding

## Test Plan
- [x] 14 `asc_view_controller_test` tests pass
- [x] 36 `display_3d_controller_test` tests pass (no regression)
- [x] Build succeeds with no compilation errors
- [ ] Manual: toggle ASC checkbox in Display 3D panel with loaded volume data to verify three orthogonal planes appear in 3D view