### PR TITLE
feat(ui): add File menu items and project management UI

### DIFF
--- a/include/ui/main_window.hpp
+++ b/include/ui/main_window.hpp
@@ -1,7 +1,12 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <QMainWindow>
+
+namespace dicom_viewer::core {
+class ProjectManager;
+}
 
 namespace dicom_viewer::ui {
 
@@ -52,6 +57,18 @@ public slots:
     /// Show ROI statistics for current measurements
     void onShowRoiStatistics();
 
+    /// Create a new project
+    void onNewProject();
+
+    /// Save the current project
+    void onSaveProject();
+
+    /// Save the current project to a new path
+    void onSaveProjectAs();
+
+    /// Open a project file
+    void onOpenProject();
+
 protected:
     void closeEvent(QCloseEvent* event) override;
     void showEvent(QShowEvent* event) override;
@@ -70,6 +87,9 @@ private:
     void restoreLayout();
     void registerShortcuts();
     void uncheckAllMeasurementActions();
+    void updateWindowTitle();
+    void updateRecentProjectsMenu();
+    bool promptSaveIfModified();
 
     class Impl;
     std::unique_ptr<Impl> impl_;


### PR DESCRIPTION
Closes #274

## Summary
- Restructure File menu with New/Open/Save/Save As project operations
- Add Open Recent submenu with ProjectManager integration
- Window title reflects project name and modified state (*)
- Unsaved changes prompt on Close, New, Open

## Changes

### File Menu Restructure
| Action | Shortcut | Description |
|--------|----------|-------------|
| New Project | Ctrl+N | Create new project with unsaved prompt |
| Open Project | Ctrl+O | Open .flo project file |
| Open Recent | - | Submenu with last 10 projects |
| Save | Ctrl+S | Save to current path (or Save As if new) |
| Save As | Ctrl+Shift+S | Save to new path |
| Save Screenshot | Ctrl+Alt+S | Remapped from Ctrl+S |
| Storage SCP | - | Removed shortcut (was Ctrl+Shift+S) |

### Project State
- Window title: `* ProjectName - DICOM Viewer` (modified) or `ProjectName - DICOM Viewer`
- Close event triggers unsaved changes prompt
- Recent projects persisted to `~/.dicom_viewer_recent.json`

## Test Plan
- [x] UI library compiles cleanly
- [x] 36 display_3d_controller_test tests pass
- [x] 14 asc_view_controller_test tests pass
- [x] 30 project_manager_test tests pass