### PR TITLE
feat(ui): add cross-view synchronization and MPR crosshair linking

### DIFF
--- a/include/ui/viewport_layout_manager.hpp
+++ b/include/ui/viewport_layout_manager.hpp
@@ -79,6 +79,11 @@ public:
      */
     [[nodiscard]] ViewportWidget* activeViewport() const;
 
+    /**
+     * @brief Check if crosshair linking between viewports is enabled
+     */
+    [[nodiscard]] bool isCrosshairLinkEnabled() const;
+
 public slots:
     /**
      * @brief Switch layout mode
@@ -91,6 +96,17 @@ public slots:
      * @param index 0-based viewport index
      */
     void setActiveViewport(int index);
+
+    /**
+     * @brief Enable or disable crosshair linking between viewports
+     *
+     * When enabled, clicking on any 2D viewport synchronizes the
+     * crosshair position (and thus slice) across all other viewports.
+     * MPR crosshair intersection lines are shown on 2D viewports.
+     *
+     * @param enabled True to enable linking
+     */
+    void setCrosshairLinkEnabled(bool enabled);
 
 signals:
     /**
@@ -106,10 +122,18 @@ signals:
      */
     void activeViewportChanged(ViewportWidget* viewport, int index);
 
+    /**
+     * @brief Emitted when crosshair link mode changes
+     * @param enabled True if linking is now enabled
+     */
+    void crosshairLinkEnabledChanged(bool enabled);
+
 private:
     void buildSingleLayout();
     void buildDualLayout();
     void buildQuadLayout();
+    void setupCrosshairLinking();
+    void teardownCrosshairLinking();
 
     class Impl;
     std::unique_ptr<Impl> impl_;

--- a/include/ui/viewport_widget.hpp
+++ b/include/ui/viewport_widget.hpp
@@ -234,6 +234,17 @@ public:
      */
     bool isSegmentationModeActive() const;
 
+    /**
+     * @brief Show/hide MPR crosshair intersection lines
+     * @param visible True to show crosshair lines
+     */
+    void setCrosshairLinesVisible(bool visible);
+
+    /**
+     * @brief Check if crosshair lines are visible
+     */
+    [[nodiscard]] bool isCrosshairLinesVisible() const;
+
 signals:
     /// Emitted when crosshair position changes (world coordinates)
     void crosshairPositionChanged(double x, double y, double z);


### PR DESCRIPTION
Closes #320

## Summary
- Fix `ViewportWidget::setCrosshairPosition()` to map world coordinates to the correct slice axis per orientation (Axial/Z, Coronal/Y, Sagittal/X) instead of always using Z
- Add MPR crosshair intersection lines on 2D viewports with color coding: Red=Axial, Blue=Coronal, Green=Sagittal
- Add `ViewportLayoutManager::setCrosshairLinkEnabled()` to synchronize crosshair position across all viewports with feedback-loop guard
- Crosshair linking automatically reconnects when layout mode changes
- Add 10 unit tests for crosshair linking and line visibility

## Implementation Details

### Orientation-Aware Slice Mapping
Previously, `setCrosshairPosition(x, y, z)` always computed slice index from Z axis. Now it selects the axis based on `SliceOrientation`:
| Orientation | Slicing Axis | World Coordinate |
|-------------|-------------|-----------------|
| Axial       | Z           | z               |
| Coronal     | Y           | y               |
| Sagittal    | X           | x               |

### MPR Crosshair Lines
Each 2D viewport draws two colored lines showing the intersection of the other two planes:
- **Axial view**: Horizontal (Coronal/blue) + Vertical (Sagittal/green)
- **Coronal view**: Horizontal (Axial/red) + Vertical (Sagittal/green)
- **Sagittal view**: Horizontal (Axial/red) + Vertical (Coronal/blue)

### Crosshair Link Guard
Uses `propagatingCrosshair` flag to prevent A\u2192B\u2192A feedback loops when forwarding crosshair position between viewports.

## Test Plan
- [x] 80 existing service tests pass (display_3d_controller: 36, asc_view: 14, project_manager: 30)
- [x] 10 new crosshair linking tests added
- [x] `dicom_viewer_ui` library compiles successfully
- [ ] UI-linked test binary blocked by pre-existing ASAN environment issue (CI expected to pass)