### PR TITLE
feat(ui): add CSV export, phase sync, and flow direction flip to QuantificationWindow

### DIFF
--- a/include/ui/quantification_window.hpp
+++ b/include/ui/quantification_window.hpp
@@ -101,6 +101,24 @@ public:
      */
     [[nodiscard]] FlowGraphWidget* graphWidget() const;
 
+    /**
+     * @brief Export statistics and time-series data to CSV file
+     *
+     * Opens a file dialog and writes comma-separated data.
+     */
+    void exportCsv();
+
+    /**
+     * @brief Set flow direction flip state
+     * @param flipped True to negate all flow rate values
+     */
+    void setFlowDirectionFlipped(bool flipped);
+
+    /**
+     * @brief Check if flow direction is flipped
+     */
+    [[nodiscard]] bool isFlowDirectionFlipped() const;
+
 signals:
     /**
      * @brief Emitted when parameter checkbox state changes
@@ -115,10 +133,23 @@ signals:
      */
     void summaryCopied(const QString& text);
 
+    /**
+     * @brief Emitted when user clicks a phase on the flow graph
+     * @param phaseIndex Clicked phase index
+     */
+    void phaseChangeRequested(int phaseIndex);
+
+    /**
+     * @brief Emitted when flow direction flip state changes
+     * @param flipped New flip state
+     */
+    void flowDirectionFlipped(bool flipped);
+
 private:
     void setupUI();
     void setupConnections();
     void updateTable();
+    void applyFlowDirectionToGraph();
 
     class Impl;
     std::unique_ptr<Impl> impl_;

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -513,6 +513,14 @@ void MainWindow::setupMenuBar()
             connect(impl_->quantificationWindow, &QObject::destroyed, this, [this]() {
                 impl_->quantificationWindow = nullptr;
             });
+            // Phase sync: graph click → viewport phase navigation
+            connect(impl_->quantificationWindow, &QuantificationWindow::phaseChangeRequested,
+                    this, [this](int phaseIndex) {
+                if (!impl_->temporalNavigator.isInitialized()) return;
+                (void)impl_->temporalNavigator.goToPhase(phaseIndex);
+                impl_->phaseSlider->setCurrentPhase(phaseIndex);
+                impl_->viewport->setPhaseIndex(phaseIndex);
+            });
         }
         impl_->quantificationWindow->show();
         impl_->quantificationWindow->raise();


### PR DESCRIPTION
## Summary

Add three new features to the existing QuantificationWindow: CSV export, graph-to-viewport phase synchronization, and flow direction flip toggle.

Closes #353
Part of #245

## Changes

### CSV Export (`Export CSV...` button)
- Writes statistics section (Parameter, Mean, Std Dev, Max, Min, Unit) as comma-separated values
- Appends time-series section if graph data is present (Phase, Plane1, Plane2, ...)
- Opens native file dialog for save location

### Phase Synchronization
- `FlowGraphWidget::phaseClicked` signal relayed through `QuantificationWindow::phaseChangeRequested`
- MainWindow connects to `TemporalNavigator::goToPhase()` + viewport + phase slider
- Clicking a phase on the flow graph navigates the main viewer to that cardiac phase

### Flow Direction Flip (`Flip Flow Direction` toggle)
- Checkable button that negates all flow rate values in the graph
- Double-flip restores original values
- Emits `flowDirectionFlipped(bool)` signal for external observers

## Test Plan

- [x] `dicom_viewer_ui` library compiles with no errors or warnings
- [x] `quantification_window_test` links successfully (8 new tests added)
- [x] All existing QuantificationWindowTest pass (CI verification) — 22/22 Passed
- [x] All new tests pass: PhaseChangeRequested_Signal, FlowDirectionFlip_Default, FlowDirectionFlip_NegatesValues, FlowDirectionFlip_Signal, FlowDirectionFlip_DoubleFlipRestores, ExportCsvButton_Exists, FlipFlowButton_Exists — 7/7 Passed
- [x] No regressions in FlowGraphWidgetTest — 20/20 Passed