### PR TITLE
feat(rendering): add Mask overlay type and performance timing

### DIFF
--- a/include/services/render/hemodynamic_overlay_renderer.hpp
+++ b/include/services/render/hemodynamic_overlay_renderer.hpp
@@ -38,7 +38,8 @@ enum class OverlayType {
     Vorticity,          ///< |curl(V)| vorticity magnitude in 1/s
     EnergyLoss,         ///< Viscous dissipation rate in W/m^3
     Streamline,         ///< 2D flow streamlines on slice plane
-    VelocityTexture     ///< Line Integral Convolution (LIC) texture
+    VelocityTexture,    ///< Line Integral Convolution (LIC) texture
+    Mask                ///< Segmentation mask overlay (per-label color)
 };
 
 /**
@@ -195,6 +196,12 @@ public:
      * @param plane MPR plane to update
      */
     void updatePlane(MPRPlane plane);
+
+    /**
+     * @brief Get the time taken by the last update() call
+     * @return Duration in milliseconds, or 0.0 if update() has not been called
+     */
+    [[nodiscard]] double lastRenderTimeMs() const noexcept;
 
     // ==================== Utility ====================
 

--- a/src/ui/panels/overlay_control_panel.cpp
+++ b/src/ui/panels/overlay_control_panel.cpp
@@ -78,6 +78,8 @@ void OverlayControlPanel::setupUI() {
     impl_->mainLayout->addWidget(titleLabel);
 
     // Create control groups for each overlay type
+    createOverlayGroup(services::OverlayType::Mask,
+                       tr("Segmentation Mask"), 0.0, 0.0);
     createOverlayGroup(services::OverlayType::VelocityMagnitude,
                        tr("Velocity Magnitude"), 0.0, 100.0);
     createOverlayGroup(services::OverlayType::VelocityX,
@@ -134,9 +136,10 @@ void OverlayControlPanel::createOverlayGroup(
     opacityRow->addWidget(group.opacityLabel);
     layout->addLayout(opacityRow);
 
-    // Scalar range row (skip for Streamline/VelocityTexture - not colormap-based)
+    // Scalar range row (skip for Streamline/VelocityTexture/Mask - not colormap-based)
     bool hasRange = (type != services::OverlayType::Streamline &&
-                     type != services::OverlayType::VelocityTexture);
+                     type != services::OverlayType::VelocityTexture &&
+                     type != services::OverlayType::Mask);
     if (hasRange) {
         auto* rangeRow = new QHBoxLayout();
         rangeRow->addWidget(new QLabel(tr("Range:")));

--- a/tests/unit/overlay_control_panel_test.cpp
+++ b/tests/unit/overlay_control_panel_test.cpp
@@ -24,6 +24,7 @@ QApplication app(argc, argv);
 TEST(OverlayControlPanelTest, DefaultConstruction) {
     OverlayControlPanel panel;
     // All overlays should be disabled by default
+    EXPECT_FALSE(panel.isOverlayEnabled(OverlayType::Mask));
     EXPECT_FALSE(panel.isOverlayEnabled(OverlayType::VelocityMagnitude));
     EXPECT_FALSE(panel.isOverlayEnabled(OverlayType::VelocityX));
     EXPECT_FALSE(panel.isOverlayEnabled(OverlayType::VelocityY));
@@ -168,4 +169,33 @@ TEST(OverlayControlPanelTest, UnknownTypeReturnsDefaults) {
     auto [minVal, maxVal] = panel.overlayScalarRange(unknownType);
     EXPECT_DOUBLE_EQ(minVal, 0.0);
     EXPECT_DOUBLE_EQ(maxVal, 100.0);
+}
+
+// =============================================================================
+// Mask overlay type
+// =============================================================================
+
+TEST(OverlayControlPanelTest, MaskOverlay_DefaultDisabled) {
+    OverlayControlPanel panel;
+    EXPECT_FALSE(panel.isOverlayEnabled(OverlayType::Mask));
+}
+
+TEST(OverlayControlPanelTest, MaskOverlay_DefaultOpacity) {
+    OverlayControlPanel panel;
+    EXPECT_DOUBLE_EQ(panel.overlayOpacity(OverlayType::Mask), 0.5);
+}
+
+TEST(OverlayControlPanelTest, MaskOverlay_NoScalarRange) {
+    OverlayControlPanel panel;
+    // Mask uses per-label coloring, no scalar range controls
+    auto [minVal, maxVal] = panel.overlayScalarRange(OverlayType::Mask);
+    EXPECT_DOUBLE_EQ(minVal, 0.0);
+    EXPECT_DOUBLE_EQ(maxVal, 100.0);
+}
+
+TEST(OverlayControlPanelTest, MaskOverlay_ResetToDefaults) {
+    OverlayControlPanel panel;
+    panel.resetToDefaults();
+    EXPECT_FALSE(panel.isOverlayEnabled(OverlayType::Mask));
+    EXPECT_DOUBLE_EQ(panel.overlayOpacity(OverlayType::Mask), 0.5);
 }


### PR DESCRIPTION
## Summary

Complete the remaining two tasks (#10 and #14) of issue #241 (2D hemodynamic overlay rendering):

- **Task 10 - Mask overlay**: Add `OverlayType::Mask` to the enum and integrate into `OverlayControlPanel` as the first Display 2D checkbox. The actual mask rendering is handled by the existing `MPRSegmentationRenderer`/`LabelMapOverlay`; this change provides unified toggle control.
- **Task 14 - Performance timing**: Add `lastRenderTimeMs()` to `HemodynamicOverlayRenderer` with `std::chrono` measurement in `update()`, enabling verification of the <50ms per-frame requirement.

Closes #241

## Changes

### `HemodynamicOverlayRenderer` (header + impl)
- Add `OverlayType::Mask` enum value for segmentation mask overlays
- Add `lastRenderTimeMs()` method returning duration of last `update()` call
- Add `Mask` case to `defaultColormapForType()` switch

### `OverlayControlPanel`
- Add "Segmentation Mask" checkbox as first entry in Display 2D panel
- Mask group has no scalar range controls (uses per-label coloring)

### Tests
- `HemodynamicOverlayRendererTest`: +5 tests (MaskOverlayType, DefaultColormapForMask, LastRenderTimeMs_InitiallyZero, LastRenderTimeMs_MeasuredAfterUpdate, PerformanceLargeField)
- `OverlayControlPanelTest`: +4 tests (MaskOverlay_DefaultDisabled, MaskOverlay_DefaultOpacity, MaskOverlay_NoScalarRange, MaskOverlay_ResetToDefaults)

## Test Plan

- [x] `render_service` library compiles with no errors
- [x] `dicom_viewer_ui` library compiles with no errors
- [x] `hemodynamic_overlay_renderer_test` links successfully (5 new tests added)
- [x] `overlay_control_panel_test` links successfully (4 new tests added)
- [x] All existing HemodynamicOverlayRendererTest pass (CI verification) — 37/37 Passed
- [x] All new renderer tests pass (CI verification) — 5/5 Passed (MaskOverlayType, DefaultColormapForMask, LastRenderTimeMs_InitiallyZero, LastRenderTimeMs_MeasuredAfterUpdate, PerformanceLargeField)
- [x] All existing OverlayControlPanelTest pass (CI verification) — 14/14 Passed
- [x] All new overlay panel tests pass (CI verification) — 4/4 Passed (MaskOverlay_DefaultDisabled, MaskOverlay_DefaultOpacity, MaskOverlay_NoScalarRange, MaskOverlay_ResetToDefaults)
- [x] Performance test: overlay rendering < 50ms for 64^3 field — Passed