### PR TITLE
feat(ui): add PDF export to QuantificationWindow

### DIFF
--- a/include/ui/quantification_window.hpp
+++ b/include/ui/quantification_window.hpp
@@ -5,6 +5,9 @@
 #include <vector>
 
 #include <QMainWindow>
+#include <QRectF>
+
+class QPainter;
 
 namespace dicom_viewer::ui {
 
@@ -107,6 +110,25 @@ public:
      * Opens a file dialog and writes comma-separated data.
      */
     void exportCsv();
+
+    /**
+     * @brief Export summary report to PDF file
+     *
+     * Generates a PDF containing the statistics table and flow graph image.
+     * Opens a file dialog for path selection.
+     */
+    void exportPdf();
+
+    /**
+     * @brief Render PDF report content to a QPainter
+     *
+     * Draws the statistics table and graph onto the given painter.
+     * Used by exportPdf() and useful for testing.
+     *
+     * @param painter Configured QPainter (from QPrinter or QPixmap)
+     * @param pageRect Bounding rectangle for content layout
+     */
+    void renderReport(QPainter& painter, const QRectF& pageRect) const;
 
     /**
      * @brief Set flow direction flip state


### PR DESCRIPTION
Closes #356

## Summary
- Add `exportPdf()` method using QPrinter/QPainter for A4 PDF report generation
- Add `renderReport()` public method for testable report rendering to any QPainter target
- Add "Export PDF..." button in the left panel alongside existing CSV button
- PDF report includes: title, statistics table (filtered by parameter checkboxes), and flow graph image

## Test Plan
- [x] ExportPdfButton_Exists — Verifies "Export PDF..." button is present in UI ✅
- [x] RenderReport_Empty_NoCrash — No crash when rendering with empty statistics ✅
- [x] RenderReport_WithData_DrawsContent — Verifies non-white pixels drawn with data ✅
- [x] RenderReport_WithGraph_DrawsChart — Verifies graph + table render together ✅
- [x] RenderReport_DisabledParams_Excluded — Disabled parameters omitted from report ✅
- [x] All 22 existing QuantificationWindowTest tests pass (22/22 ✅) → total 27/27 with new tests
- [x] All 20 existing FlowGraphWidgetTest tests pass (20/20 ✅)

### CI Results
- Build & Test: ✅ PASSED
- QuantificationWindowTest: **27/27 Passed** (22 existing + 5 new)
- FlowGraphWidgetTest: **20/20 Passed**
- All 2760 tests passed