### PR TITLE
feat(ui): implement ThresholdPage with dual slider and Otsu auto-threshold

### DIFF
--- a/include/ui/dialogs/mask_wizard.hpp
+++ b/include/ui/dialogs/mask_wizard.hpp
@@ -40,11 +40,44 @@ public:
      */
     [[nodiscard]] MaskWizardStep currentStep() const;
 
+    /**
+     * @brief Configure the valid intensity range for threshold sliders
+     * @param min Minimum intensity value (e.g., -1024 for CT HU)
+     * @param max Maximum intensity value (e.g., 3071 for CT HU)
+     */
+    void setThresholdRange(int min, int max);
+
+    /**
+     * @brief Get current minimum threshold value
+     */
+    [[nodiscard]] int thresholdMin() const;
+
+    /**
+     * @brief Get current maximum threshold value
+     */
+    [[nodiscard]] int thresholdMax() const;
+
+    /**
+     * @brief Set threshold from Otsu auto-calculation result
+     * @param value Otsu threshold value (sets min=value, max=range_max)
+     */
+    void setOtsuThreshold(double value);
+
 signals:
     /**
      * @brief Emitted when the wizard completes all steps successfully
      */
     void wizardCompleted();
+
+    /**
+     * @brief Emitted when threshold slider values change
+     */
+    void thresholdChanged(int min, int max);
+
+    /**
+     * @brief Emitted when user clicks the Otsu auto-threshold button
+     */
+    void otsuRequested();
 
 private:
     void setupPages();

--- a/src/ui/dialogs/mask_wizard.cpp
+++ b/src/ui/dialogs/mask_wizard.cpp
@@ -1,12 +1,21 @@
 #include "ui/dialogs/mask_wizard.hpp"
 
+#include <cmath>
+
+#include <QHBoxLayout>
 #include <QLabel>
+#include <QPushButton>
+#include <QSlider>
+#include <QSpinBox>
 #include <QVBoxLayout>
 #include <QWizardPage>
 
 namespace dicom_viewer::ui {
 
 namespace {
+
+constexpr int kDefaultRangeMin = -1024;
+constexpr int kDefaultRangeMax = 3071;
 
 /**
  * @brief Base wizard page with step title and placeholder content
@@ -31,12 +40,172 @@ public:
     }
 };
 
+/**
+ * @brief Functional threshold page with dual sliders and Otsu button
+ */
+class ThresholdPage : public QWizardPage {
+public:
+    explicit ThresholdPage(MaskWizard* wizard, QWidget* parent = nullptr)
+        : QWizardPage(parent)
+        , wizard_(wizard)
+    {
+        setTitle(tr("Step 2: Threshold"));
+        setSubTitle(tr("Set intensity range to create a binary mask"));
+
+        auto* layout = new QVBoxLayout(this);
+
+        auto* descLabel = new QLabel(
+            tr("Adjust the minimum and maximum intensity sliders to isolate "
+               "the structures of interest."),
+            this);
+        descLabel->setWordWrap(true);
+        layout->addWidget(descLabel);
+
+        layout->addSpacing(12);
+
+        // Min threshold row
+        layout->addWidget(new QLabel(tr("Min Threshold:"), this));
+        auto* minRow = new QHBoxLayout();
+        minSlider_ = new QSlider(Qt::Horizontal, this);
+        minSpin_ = new QSpinBox(this);
+        minRow->addWidget(minSlider_, 1);
+        minRow->addWidget(minSpin_);
+        layout->addLayout(minRow);
+
+        layout->addSpacing(8);
+
+        // Max threshold row
+        layout->addWidget(new QLabel(tr("Max Threshold:"), this));
+        auto* maxRow = new QHBoxLayout();
+        maxSlider_ = new QSlider(Qt::Horizontal, this);
+        maxSpin_ = new QSpinBox(this);
+        maxRow->addWidget(maxSlider_, 1);
+        maxRow->addWidget(maxSpin_);
+        layout->addLayout(maxRow);
+
+        layout->addSpacing(12);
+
+        // Otsu button
+        auto* buttonRow = new QHBoxLayout();
+        otsuButton_ = new QPushButton(tr("Auto (Otsu)"), this);
+        buttonRow->addWidget(otsuButton_);
+        buttonRow->addStretch();
+        layout->addLayout(buttonRow);
+
+        layout->addSpacing(8);
+
+        // Status label
+        statusLabel_ = new QLabel(tr("Ready"), this);
+        statusLabel_->setStyleSheet("color: gray; font-style: italic;");
+        layout->addWidget(statusLabel_);
+
+        layout->addStretch();
+
+        setRange(kDefaultRangeMin, kDefaultRangeMax);
+        setThresholdValues(kDefaultRangeMin, kDefaultRangeMax);
+        setupConnections();
+    }
+
+    void setRange(int min, int max) {
+        minSlider_->setRange(min, max);
+        maxSlider_->setRange(min, max);
+        minSpin_->setRange(min, max);
+        maxSpin_->setRange(min, max);
+    }
+
+    void setThresholdValues(int minVal, int maxVal) {
+        blockSignals_ = true;
+        minSlider_->setValue(minVal);
+        minSpin_->setValue(minVal);
+        maxSlider_->setValue(maxVal);
+        maxSpin_->setValue(maxVal);
+        blockSignals_ = false;
+    }
+
+    [[nodiscard]] int thresholdMin() const { return minSpin_->value(); }
+    [[nodiscard]] int thresholdMax() const { return maxSpin_->value(); }
+
+    void setStatusText(const QString& text) {
+        statusLabel_->setText(text);
+    }
+
+private:
+    void setupConnections() {
+        // Min slider <-> spinbox sync
+        connect(minSlider_, &QSlider::valueChanged, this, [this](int val) {
+            if (blockSignals_) return;
+            blockSignals_ = true;
+            minSpin_->setValue(val);
+            // Enforce min <= max
+            if (val > maxSlider_->value()) {
+                maxSlider_->setValue(val);
+                maxSpin_->setValue(val);
+            }
+            blockSignals_ = false;
+            emitThresholdChanged();
+        });
+        connect(minSpin_, QOverload<int>::of(&QSpinBox::valueChanged), this, [this](int val) {
+            if (blockSignals_) return;
+            blockSignals_ = true;
+            minSlider_->setValue(val);
+            if (val > maxSpin_->value()) {
+                maxSlider_->setValue(val);
+                maxSpin_->setValue(val);
+            }
+            blockSignals_ = false;
+            emitThresholdChanged();
+        });
+
+        // Max slider <-> spinbox sync
+        connect(maxSlider_, &QSlider::valueChanged, this, [this](int val) {
+            if (blockSignals_) return;
+            blockSignals_ = true;
+            maxSpin_->setValue(val);
+            if (val < minSlider_->value()) {
+                minSlider_->setValue(val);
+                minSpin_->setValue(val);
+            }
+            blockSignals_ = false;
+            emitThresholdChanged();
+        });
+        connect(maxSpin_, QOverload<int>::of(&QSpinBox::valueChanged), this, [this](int val) {
+            if (blockSignals_) return;
+            blockSignals_ = true;
+            maxSlider_->setValue(val);
+            if (val < minSpin_->value()) {
+                minSlider_->setValue(val);
+                minSpin_->setValue(val);
+            }
+            blockSignals_ = false;
+            emitThresholdChanged();
+        });
+
+        // Otsu button
+        connect(otsuButton_, &QPushButton::clicked, this, [this]() {
+            emit wizard_->otsuRequested();
+        });
+    }
+
+    void emitThresholdChanged() {
+        emit wizard_->thresholdChanged(minSpin_->value(), maxSpin_->value());
+    }
+
+    MaskWizard* wizard_ = nullptr;
+    QSlider* minSlider_ = nullptr;
+    QSlider* maxSlider_ = nullptr;
+    QSpinBox* minSpin_ = nullptr;
+    QSpinBox* maxSpin_ = nullptr;
+    QPushButton* otsuButton_ = nullptr;
+    QLabel* statusLabel_ = nullptr;
+    bool blockSignals_ = false;
+};
+
 }  // anonymous namespace
 
 class MaskWizard::Impl {
 public:
     StepPage* cropPage = nullptr;
-    StepPage* thresholdPage = nullptr;
+    ThresholdPage* thresholdPage = nullptr;
     StepPage* separatePage = nullptr;
     StepPage* trackPage = nullptr;
 };
@@ -64,14 +233,7 @@ void MaskWizard::setupPages()
            "Note: Cropping is irreversible within this wizard session."),
         this);
 
-    impl_->thresholdPage = new StepPage(
-        tr("Step 2: Threshold"),
-        tr("Set intensity range to create a binary mask"),
-        tr("Adjust the minimum and maximum intensity sliders to isolate "
-           "the structures of interest. The histogram shows the voxel "
-           "intensity distribution of the cropped volume.\n\n"
-           "A real-time preview overlay shows the resulting mask."),
-        this);
+    impl_->thresholdPage = new ThresholdPage(this, this);
 
     impl_->separatePage = new StepPage(
         tr("Step 3: Separate"),
@@ -111,6 +273,29 @@ void MaskWizard::setupAppearance()
 MaskWizardStep MaskWizard::currentStep() const
 {
     return static_cast<MaskWizardStep>(currentId());
+}
+
+void MaskWizard::setThresholdRange(int min, int max)
+{
+    impl_->thresholdPage->setRange(min, max);
+}
+
+int MaskWizard::thresholdMin() const
+{
+    return impl_->thresholdPage->thresholdMin();
+}
+
+int MaskWizard::thresholdMax() const
+{
+    return impl_->thresholdPage->thresholdMax();
+}
+
+void MaskWizard::setOtsuThreshold(double value)
+{
+    auto intValue = static_cast<int>(std::round(value));
+    impl_->thresholdPage->setThresholdValues(intValue, impl_->thresholdPage->thresholdMax());
+    impl_->thresholdPage->setStatusText(
+        tr("Otsu threshold: %1").arg(intValue));
 }
 
 } // namespace dicom_viewer::ui

--- a/tests/unit/mask_wizard_test.cpp
+++ b/tests/unit/mask_wizard_test.cpp
@@ -1,7 +1,10 @@
 #include <gtest/gtest.h>
 
 #include <QApplication>
+#include <QPushButton>
 #include <QSignalSpy>
+#include <QSlider>
+#include <QSpinBox>
 #include <QWizardPage>
 
 #include "ui/dialogs/mask_wizard.hpp"
@@ -101,4 +104,119 @@ TEST(MaskWizardTest, WizardCompletedSignalExists) {
     MaskWizard wizard;
     QSignalSpy spy(&wizard, &MaskWizard::wizardCompleted);
     EXPECT_TRUE(spy.isValid());
+}
+
+// =============================================================================
+// Threshold page — default values
+// =============================================================================
+
+TEST(MaskWizardTest, ThresholdDefaultRange) {
+    MaskWizard wizard;
+    // Default CT HU range: -1024 to 3071
+    EXPECT_EQ(wizard.thresholdMin(), -1024);
+    EXPECT_EQ(wizard.thresholdMax(), 3071);
+}
+
+// =============================================================================
+// Threshold page — API
+// =============================================================================
+
+TEST(MaskWizardTest, SetThresholdRange) {
+    MaskWizard wizard;
+    wizard.setThresholdRange(0, 1000);
+    // After range change, values should be clamped
+    EXPECT_GE(wizard.thresholdMin(), 0);
+    EXPECT_LE(wizard.thresholdMax(), 1000);
+}
+
+TEST(MaskWizardTest, SetOtsuThreshold) {
+    MaskWizard wizard;
+    wizard.setOtsuThreshold(245.7);
+    // Otsu sets min to rounded value
+    EXPECT_EQ(wizard.thresholdMin(), 246);
+    // Max remains at range max
+    EXPECT_EQ(wizard.thresholdMax(), 3071);
+}
+
+// =============================================================================
+// Threshold page — signals
+// =============================================================================
+
+TEST(MaskWizardTest, ThresholdChangedSignal) {
+    MaskWizard wizard;
+    QSignalSpy spy(&wizard, &MaskWizard::thresholdChanged);
+    EXPECT_TRUE(spy.isValid());
+
+    // Navigate to threshold page and change slider
+    wizard.restart();
+    wizard.next();  // Now on Threshold page
+
+    // Find the min spinbox on the threshold page and change it
+    auto* thresholdPage = wizard.page(1);
+    auto* minSpin = thresholdPage->findChild<QSpinBox*>();
+    ASSERT_NE(minSpin, nullptr);
+    minSpin->setValue(100);
+
+    EXPECT_GE(spy.count(), 1);
+    auto lastArgs = spy.last();
+    EXPECT_EQ(lastArgs.at(0).toInt(), 100);
+}
+
+TEST(MaskWizardTest, OtsuRequestedSignal) {
+    MaskWizard wizard;
+    QSignalSpy spy(&wizard, &MaskWizard::otsuRequested);
+    EXPECT_TRUE(spy.isValid());
+
+    // Find the Otsu button and click it
+    auto* thresholdPage = wizard.page(1);
+    auto* otsuButton = thresholdPage->findChild<QPushButton*>();
+    ASSERT_NE(otsuButton, nullptr);
+    otsuButton->click();
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// =============================================================================
+// Threshold page — constraint enforcement
+// =============================================================================
+
+TEST(MaskWizardTest, MinCannotExceedMax) {
+    MaskWizard wizard;
+    wizard.restart();
+    wizard.next();  // Threshold page
+
+    auto* thresholdPage = wizard.page(1);
+    auto spinBoxes = thresholdPage->findChildren<QSpinBox*>();
+    ASSERT_GE(spinBoxes.size(), 2);
+
+    // First spinbox is min, second is max
+    auto* minSpin = spinBoxes[0];
+    auto* maxSpin = spinBoxes[1];
+
+    // Set max to 500 first, then try to set min to 600
+    maxSpin->setValue(500);
+    minSpin->setValue(600);
+
+    // min <= max must hold
+    EXPECT_LE(wizard.thresholdMin(), wizard.thresholdMax());
+}
+
+TEST(MaskWizardTest, MaxCannotGoBelowMin) {
+    MaskWizard wizard;
+    wizard.restart();
+    wizard.next();  // Threshold page
+
+    auto* thresholdPage = wizard.page(1);
+    auto spinBoxes = thresholdPage->findChildren<QSpinBox*>();
+    ASSERT_GE(spinBoxes.size(), 2);
+
+    auto* minSpin = spinBoxes[0];
+    auto* maxSpin = spinBoxes[1];
+
+    // Set min to 800 first, then try to set max to 200
+    minSpin->setValue(800);
+    maxSpin->setValue(200);
+
+    // min <= max must hold
+    EXPECT_LE(wizard.thresholdMin(), wizard.thresholdMax());
 }


### PR DESCRIPTION
## Summary
- Replace placeholder ThresholdPage with functional QWizardPage containing dual min/max sliders
- Add bidirectional QSlider + QSpinBox sync with min <= max constraint enforcement
- Add Otsu auto-threshold button that emits `otsuRequested()` signal
- Extend MaskWizard public API: `setThresholdRange()`, `thresholdMin/Max()`, `setOtsuThreshold()`
- Add 7 new unit tests for threshold page functionality

Part of #252
Closes #362

## Changes
- `include/ui/dialogs/mask_wizard.hpp` — Add threshold API methods and signals
- `src/ui/dialogs/mask_wizard.cpp` — ThresholdPage class with slider/spinbox UI and constraint logic
- `tests/unit/mask_wizard_test.cpp` — 7 new tests (total 16)

## Test Plan
- [x] MaskWizardTest.ThresholdDefaultRange — Default CT HU range -1024 to 3071 (Passed 0.41s)
- [x] MaskWizardTest.SetThresholdRange — Custom range configuration (Passed 0.40s)
- [x] MaskWizardTest.SetOtsuThreshold — Otsu value sets min threshold (Passed 0.54s)
- [x] MaskWizardTest.ThresholdChangedSignal — Signal emitted on slider change (Passed 0.55s)
- [x] MaskWizardTest.OtsuRequestedSignal — Signal emitted on Otsu button click (Passed 0.59s)
- [x] MaskWizardTest.MinCannotExceedMax — Constraint: min <= max enforced (Passed 0.48s)
- [x] MaskWizardTest.MaxCannotGoBelowMin — Constraint: max >= min enforced (Passed 0.45s)