### PR TITLE
feat(ui): implement SeparatePage with component table and selection controls

### DIFF
--- a/include/ui/dialogs/mask_wizard.hpp
+++ b/include/ui/dialogs/mask_wizard.hpp
@@ -1,9 +1,21 @@
 #pragma once
 
 #include <memory>
+#include <vector>
+#include <QColor>
 #include <QWizard>
 
 namespace dicom_viewer::ui {
+
+/**
+ * @brief Data for a single connected component in the Separate step
+ */
+struct ComponentInfo {
+    int label = 0;           ///< Component label (1-based)
+    int voxelCount = 0;      ///< Number of voxels in this component
+    QColor color;            ///< Display color for this component
+    bool selected = true;    ///< Whether this component is selected
+};
 
 /**
  * @brief Wizard page identifiers for the Mask Wizard workflow
@@ -63,6 +75,24 @@ public:
      */
     void setOtsuThreshold(double value);
 
+    // -- Separate page API --
+
+    /**
+     * @brief Populate the component list from external analysis
+     * @param components List of connected components to display
+     */
+    void setComponents(const std::vector<ComponentInfo>& components);
+
+    /**
+     * @brief Get the number of components
+     */
+    [[nodiscard]] int componentCount() const;
+
+    /**
+     * @brief Get indices of selected components (0-based)
+     */
+    [[nodiscard]] std::vector<int> selectedComponentIndices() const;
+
 signals:
     /**
      * @brief Emitted when the wizard completes all steps successfully
@@ -78,6 +108,11 @@ signals:
      * @brief Emitted when user clicks the Otsu auto-threshold button
      */
     void otsuRequested();
+
+    /**
+     * @brief Emitted when component selection changes in the Separate step
+     */
+    void componentSelectionChanged();
 
 private:
     void setupPages();


### PR DESCRIPTION
## Summary
- Replace placeholder SeparatePage with functional QWizardPage containing a QTableWidget
- Component table with checkbox, color swatch, voxel count, and label columns
- Bulk selection buttons: Select All, Deselect All, Invert
- Summary label showing selected count and total voxels
- Define `ComponentInfo` struct for external data population
- Extend MaskWizard API: `setComponents()`, `componentCount()`, `selectedComponentIndices()`
- Add `componentSelectionChanged()` signal
- Add 8 unit tests for component management, bulk operations, and signal emission

Part of #252
Closes #364

## Changes
- `include/ui/dialogs/mask_wizard.hpp` — Add ComponentInfo struct, selection API, signal
- `src/ui/dialogs/mask_wizard.cpp` — SeparatePage class with QTableWidget and selection logic
- `tests/unit/mask_wizard_test.cpp` — 8 new tests (total 24)

## Test Plan
- [x] MaskWizardTest.SeparateInitiallyEmpty — No components on init (Passed 0.53s)
- [x] MaskWizardTest.SetComponentsPopulatesTable — setComponents() populates 3 items (Passed 0.44s)
- [x] MaskWizardTest.SelectedIndicesReflectsInput — Selected indices match input data (Passed 0.42s)
- [x] MaskWizardTest.SelectAllButton — Select All selects all 3 components (Passed 0.41s)
- [x] MaskWizardTest.DeselectAllButton — Deselect All clears all selections (Passed 0.40s)
- [x] MaskWizardTest.InvertSelectionButton — Invert swaps selected/deselected (Passed 0.40s)
- [x] MaskWizardTest.ComponentSelectionChangedSignal — Signal emitted on selection change (Passed 0.39s)
- [x] MaskWizardTest.CheckboxToggleUpdatesSelection — Table checkbox toggle updates data model (Passed 0.39s)