### PR TITLE
feat(ui): implement CropPage with dimension spinboxes and CropRegion API

### DIFF
--- a/include/ui/dialogs/mask_wizard.hpp
+++ b/include/ui/dialogs/mask_wizard.hpp
@@ -8,6 +8,15 @@
 namespace dicom_viewer::ui {
 
 /**
+ * @brief 3D bounding box for the Crop step
+ */
+struct CropRegion {
+    int xMin = 0, xMax = 0;
+    int yMin = 0, yMax = 0;
+    int zMin = 0, zMax = 0;
+};
+
+/**
  * @brief Data for a single connected component in the Separate step
  */
 struct ComponentInfo {
@@ -51,6 +60,23 @@ public:
      * @return Current step enum value
      */
     [[nodiscard]] MaskWizardStep currentStep() const;
+
+    // -- Crop page API --
+
+    /**
+     * @brief Set volume dimensions to configure crop spinbox ranges
+     * @param x Number of voxels along X axis
+     * @param y Number of voxels along Y axis
+     * @param z Number of voxels along Z axis
+     */
+    void setVolumeDimensions(int x, int y, int z);
+
+    /**
+     * @brief Get current crop region bounds
+     */
+    [[nodiscard]] CropRegion cropRegion() const;
+
+    // -- Threshold page API --
 
     /**
      * @brief Configure the valid intensity range for threshold sliders
@@ -113,6 +139,11 @@ signals:
      * @brief Emitted when component selection changes in the Separate step
      */
     void componentSelectionChanged();
+
+    /**
+     * @brief Emitted when crop region bounds change
+     */
+    void cropRegionChanged();
 
 private:
     void setupPages();


### PR DESCRIPTION
Closes #366

## Summary
- Add functional CropPage to MaskWizard replacing the placeholder StepPage
- Implement 6 QSpinBox controls for X/Y/Z min/max 3D bounding box definition
- Add per-axis min<=max constraint enforcement with signal loop prevention
- Add volume summary label, irreversibility warning, and Reset to Full Volume button
- Expose `setVolumeDimensions()` and `cropRegion()` public API on MaskWizard
- Emit `cropRegionChanged()` signal on all user interactions

## Test Plan
- [x] Build succeeds (dicom_viewer_ui, mask_wizard_test)
- [x] CropDefaultRegion — default 256x256x128 region is correct
- [x] SetVolumeDimensions — custom dimensions update ranges and reset
- [x] CropSpinboxModifiesRegion — spinbox interaction updates cropRegion()
- [x] CropMinCannotExceedMax — min<=max constraint per axis
- [x] ResetToFullVolume — reset button restores full dimensions
- [x] CropRegionChangedSignal — signal emitted on spinbox change
- [x] All 31 existing + new MaskWizardTest cases pass