### PR TITLE
feat(ui): implement TrackPage with phase propagation controls and progress feedback

### DIFF
--- a/include/ui/dialogs/mask_wizard.hpp
+++ b/include/ui/dialogs/mask_wizard.hpp
@@ -119,6 +119,31 @@ public:
      */
     [[nodiscard]] std::vector<int> selectedComponentIndices() const;
 
+    // -- Track page API --
+
+    /**
+     * @brief Set the number of cardiac phases for propagation
+     * @param count Total number of phases (must be >= 1)
+     */
+    void setPhaseCount(int count);
+
+    /**
+     * @brief Get the configured phase count
+     */
+    [[nodiscard]] int phaseCount() const;
+
+    /**
+     * @brief Update the propagation progress bar
+     * @param percent Progress value (0-100)
+     */
+    void setTrackProgress(int percent);
+
+    /**
+     * @brief Update the track page status message
+     * @param status Status text to display
+     */
+    void setTrackStatus(const QString& status);
+
 signals:
     /**
      * @brief Emitted when the wizard completes all steps successfully
@@ -144,6 +169,11 @@ signals:
      * @brief Emitted when crop region bounds change
      */
     void cropRegionChanged();
+
+    /**
+     * @brief Emitted when user clicks the Run Propagation button
+     */
+    void propagationRequested();
 
 private:
     void setupPages();


### PR DESCRIPTION
Closes #368

## Summary
- Add functional TrackPage (Step 4) to MaskWizard replacing the last placeholder StepPage
- Implement phase count display, Run Propagation button, QProgressBar, and status label
- Expose `setPhaseCount()`, `phaseCount()`, `setTrackProgress()`, `setTrackStatus()` public API
- Add `propagationRequested()` signal emitted when user clicks Run Propagation
- All 4 wizard pages now have fully functional UI implementations

## Test Plan
- [x] Build succeeds (dicom_viewer_ui, mask_wizard_test)
- [x] TrackDefaultPhaseCount — default phase count is 1
- [x] SetPhaseCount — custom phase count updates correctly
- [x] SetTrackProgress — progress bar updates to given percent
- [x] SetTrackStatus — status label text updates
- [x] PhaseCountLabel — phase count displayed in label
- [x] PropagationRequestedSignal — signal emitted on button click
- [x] ProgressBarFullRange — progress bar handles 0 and 100
- [x] All 38 existing + new MaskWizardTest cases pass