### PR TITLE
feat(ui): add multi-plane selector to QuantificationWindow with color-coded plane management

### DIFF
--- a/include/ui/quantification_window.hpp
+++ b/include/ui/quantification_window.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include <QColor>
 #include <QMainWindow>
 #include <QRectF>
 
@@ -141,6 +142,52 @@ public:
      */
     [[nodiscard]] bool isFlowDirectionFlipped() const;
 
+    // -- Plane management API --
+
+    /**
+     * @brief Add a measurement plane with name and color
+     * @param name Display name (e.g., "Plane 1")
+     * @param color Color for graph line and selector indicator
+     */
+    void addPlane(const QString& name, const QColor& color);
+
+    /**
+     * @brief Remove a measurement plane by index
+     * @param index 0-based plane index
+     */
+    void removePlane(int index);
+
+    /**
+     * @brief Get the number of registered planes
+     */
+    [[nodiscard]] int planeCount() const;
+
+    /**
+     * @brief Get the currently active plane index
+     * @return Active plane index, or -1 if no planes
+     */
+    [[nodiscard]] int activePlaneIndex() const;
+
+    /**
+     * @brief Programmatically select an active plane
+     * @param index 0-based plane index
+     */
+    void setActivePlane(int index);
+
+    /**
+     * @brief Get a plane's display name
+     * @param index 0-based plane index
+     * @return Plane name, or empty string if out of range
+     */
+    [[nodiscard]] QString planeName(int index) const;
+
+    /**
+     * @brief Get a plane's color
+     * @param index 0-based plane index
+     * @return Plane color, or invalid QColor if out of range
+     */
+    [[nodiscard]] QColor planeColor(int index) const;
+
 signals:
     /**
      * @brief Emitted when parameter checkbox state changes
@@ -166,6 +213,12 @@ signals:
      * @param flipped New flip state
      */
     void flowDirectionFlipped(bool flipped);
+
+    /**
+     * @brief Emitted when the active measurement plane changes
+     * @param index New active plane index
+     */
+    void activePlaneChanged(int index);
 
 private:
     void setupUI();


### PR DESCRIPTION
Closes #370

## Summary
- Add QComboBox-based measurement plane selector with colored circle swatch icons
- Implement `addPlane()`, `removePlane()`, `planeCount()`, `activePlaneIndex()`, `setActivePlane()`, `planeName()`, `planeColor()` public API
- Add `activePlaneChanged(int)` signal emitted on combo box selection change
- Place plane selector between Parameters group and Statistics table in the left panel

## Test Plan
- [x] Build succeeds (dicom_viewer_ui, quantification_window_test)
- [x] PlaneManagement_InitiallyEmpty — no planes and index -1
- [x] AddPlane_IncreasesCount — single plane with correct name/color
- [x] AddMultiplePlanes — three planes with correct data
- [x] RemovePlane — removal shifts remaining planes
- [x] FirstPlane_AutoActivated — first addPlane sets active to 0
- [x] SetActivePlane — programmatic selection works
- [x] ActivePlaneChanged_Signal — signal emitted on selection change
- [x] PlaneNameOutOfRange_ReturnsEmpty — graceful out-of-range handling
- [x] PlaneComboBox_Exists — combo box visible in widget tree
- [x] All existing QuantificationWindowTest cases still pass