### PR TITLE
feat(ui): add red label indicator for non-4D Flow series in PatientBrowser

### DIFF
--- a/src/ui/panels/patient_browser.cpp
+++ b/src/ui/panels/patient_browser.cpp
@@ -3,6 +3,7 @@
 #include <QVBoxLayout>
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
+#include <QBrush>
 #include <QHeaderView>
 #include <QLineEdit>
 #include <QLabel>
@@ -171,6 +172,16 @@ void PatientBrowser::addSeries(const QString& studyUid, const SeriesInfo& series
     item->setText(2, series.modality);
     item->setData(0, UidRole, series.seriesInstanceUid);
     item->setIcon(0, style()->standardIcon(QStyle::SP_FileIcon));
+
+    // Mark non-4D Flow classified series with red text
+    if (!series.is4DFlow &&
+        !series.seriesType.isEmpty() &&
+        series.seriesType != "Unknown") {
+        QBrush redBrush(Qt::red);
+        for (int col = 0; col < 3; ++col) {
+            item->setForeground(col, redBrush);
+        }
+    }
 
     impl_->seriesItems[series.seriesInstanceUid] = item;
 }

--- a/tests/unit/patient_browser_test.cpp
+++ b/tests/unit/patient_browser_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <QApplication>
+#include <QBrush>
 #include <QTreeWidget>
 
 #include "ui/panels/patient_browser.hpp"
@@ -158,4 +159,66 @@ TEST_F(PatientBrowserTreeTest, SelectedSeriesUid_NoSelection) {
         makeSeries("SER001", "Test", "CT"));
 
     EXPECT_TRUE(browser->selectedSeriesUid().isEmpty());
+}
+
+// =============================================================================
+// Red label for non-4D Flow series
+// =============================================================================
+
+TEST_F(PatientBrowserTreeTest, Non4DFlowSeries_HasRedForeground) {
+    browser->addSeries("STUDY001",
+        makeSeries("SER001", "CINE retro SA", "CINE", false));
+
+    auto* item = findSeriesItem();
+    ASSERT_NE(item, nullptr);
+    EXPECT_EQ(item->foreground(0).color(), QColor(Qt::red));
+    EXPECT_EQ(item->foreground(1).color(), QColor(Qt::red));
+    EXPECT_EQ(item->foreground(2).color(), QColor(Qt::red));
+}
+
+TEST_F(PatientBrowserTreeTest, Flow4DSeries_NoRedForeground) {
+    browser->addSeries("STUDY001",
+        makeSeries("SER001", "fl3d_4DFlow", "4D Flow Magnitude", true));
+
+    auto* item = findSeriesItem();
+    ASSERT_NE(item, nullptr);
+    // 4D Flow series should NOT have red foreground
+    EXPECT_NE(item->foreground(0).color(), QColor(Qt::red));
+}
+
+TEST_F(PatientBrowserTreeTest, UnknownType_NoRedForeground) {
+    browser->addSeries("STUDY001",
+        makeSeries("SER001", "t2_tse_tra", "Unknown", false));
+
+    auto* item = findSeriesItem();
+    ASSERT_NE(item, nullptr);
+    // Unknown series should NOT have red foreground
+    EXPECT_NE(item->foreground(0).color(), QColor(Qt::red));
+}
+
+TEST_F(PatientBrowserTreeTest, EmptyType_NoRedForeground) {
+    browser->addSeries("STUDY001",
+        makeSeries("SER001", "Generic Series", "", false));
+
+    auto* item = findSeriesItem();
+    ASSERT_NE(item, nullptr);
+    EXPECT_NE(item->foreground(0).color(), QColor(Qt::red));
+}
+
+TEST_F(PatientBrowserTreeTest, CTSeries_HasRedForeground) {
+    browser->addSeries("STUDY001",
+        makeSeries("SER001", "Chest CT Angio", "CT", false));
+
+    auto* item = findSeriesItem();
+    ASSERT_NE(item, nullptr);
+    EXPECT_EQ(item->foreground(0).color(), QColor(Qt::red));
+}
+
+TEST_F(PatientBrowserTreeTest, DIXONSeries_HasRedForeground) {
+    browser->addSeries("STUDY001",
+        makeSeries("SER001", "t1_vibe_dixon_W", "DIXON", false));
+
+    auto* item = findSeriesItem();
+    ASSERT_NE(item, nullptr);
+    EXPECT_EQ(item->foreground(0).color(), QColor(Qt::red));
 }


### PR DESCRIPTION
Closes #372

## Summary
- Mark non-4D Flow classified series (CINE, DIXON, CT, TOF, etc.) with red foreground text in PatientBrowser tree view
- 4D Flow series (Magnitude, Phase AP/FH/RL) retain default text color
- Unknown/unclassified series retain default text color
- Uses `QBrush(Qt::red)` on all 3 columns for consistent visual distinction

## Test Plan
- [x] Non-4D Flow series (CINE, CT, DIXON) display red text — 3 test cases
- [x] 4D Flow series retain default text color — 1 test case
- [x] Unknown type series retain default text color — 1 test case
- [x] Empty type series retain default text color — 1 test case
- [x] Existing PatientBrowser tests pass
- [x] Full build succeeds