### PR TITLE
feat(ui): add 3D Volume measurement tab to QuantificationWindow

### DIFF
--- a/include/ui/quantification_window.hpp
+++ b/include/ui/quantification_window.hpp
@@ -38,6 +38,26 @@ struct QuantificationRow {
 };
 
 /**
+ * @brief Volume-level measurement parameter identifiers
+ */
+enum class VolumeParameter {
+    TotalKE,       ///< Total kinetic energy (mJ)
+    VortexVolume,  ///< Vortex volume (mL)
+    EnergyLoss,    ///< Energy loss (mW)
+    MeanWSS,       ///< Mean wall shear stress (Pa)
+    PeakWSS        ///< Peak wall shear stress (Pa)
+};
+
+/**
+ * @brief Row data for the 3D volume statistics table
+ */
+struct VolumeStatRow {
+    VolumeParameter parameter;
+    double value = 0.0;
+    QString unit;
+};
+
+/**
  * @brief Independent window for quantitative flow analysis
  *
  * Displays measurement statistics in a table (Mean/Std/Max/Min) and
@@ -188,6 +208,37 @@ public:
      */
     [[nodiscard]] QColor planeColor(int index) const;
 
+    // -- Volume measurement API --
+
+    /**
+     * @brief Set volume statistics data for the 3D volume tab
+     * @param rows Vector of volume stat rows
+     */
+    void setVolumeStatistics(const std::vector<VolumeStatRow>& rows);
+
+    /**
+     * @brief Get the number of rows in the volume statistics table
+     */
+    [[nodiscard]] int volumeRowCount() const;
+
+    /**
+     * @brief Clear all volume statistics data
+     */
+    void clearVolumeStatistics();
+
+    // -- Tab API --
+
+    /**
+     * @brief Get the active tab index (0=2D Plane, 1=3D Volume)
+     */
+    [[nodiscard]] int activeTab() const;
+
+    /**
+     * @brief Set the active tab by index
+     * @param index Tab index (0=2D Plane, 1=3D Volume)
+     */
+    void setActiveTab(int index);
+
 signals:
     /**
      * @brief Emitted when parameter checkbox state changes
@@ -219,6 +270,12 @@ signals:
      * @param index New active plane index
      */
     void activePlaneChanged(int index);
+
+    /**
+     * @brief Emitted when the active tab changes (2D Plane / 3D Volume)
+     * @param index New tab index
+     */
+    void activeTabChanged(int index);
 
 private:
     void setupUI();


### PR DESCRIPTION
Closes #376

## Summary
- Add QTabWidget to QuantificationWindow with "2D Plane" and "3D Volume" tabs
- Wrap existing 2D content (splitter, stats table, graph) into the first tab
- Create 3D Volume tab with volume statistics table (Parameter/Value/Unit columns) and 3D visualization placeholder
- Add VolumeParameter enum (TotalKE, VortexVolume, EnergyLoss, MeanWSS, PeakWSS) and VolumeStatRow struct
- Add volume API: setVolumeStatistics(), volumeRowCount(), clearVolumeStatistics()
- Add tab API: activeTab(), setActiveTab() with activeTabChanged signal
- Add 9 unit tests for tab management and volume statistics

## Test Plan
- [x] Build succeeds (dicom_viewer + quantification_window_test targets)
- [x] TabWidget_InitialTab: initial tab is 0, two tabs with correct names
- [x] SetActiveTab_SwitchesTo3DVolume: tab index changes to 1
- [x] SetActiveTab_OutOfRange_NoChange: out-of-range index ignored
- [x] ActiveTabChanged_Signal: signal emits on tab switch
- [x] VolumeStatistics_InitiallyEmpty: volume row count is 0
- [x] SetVolumeStatistics_PopulatesTable: 3 rows populate correctly
- [x] ClearVolumeStatistics: clears volume table
- [x] VolumeTable_Content: verifies parameter name, value, unit text
- [x] Existing 2D Plane tests pass without regression