### PR TITLE
feat(ui): add crop confirmation dialog to MaskWizard CropPage

### DIFF
--- a/include/ui/dialogs/mask_wizard.hpp
+++ b/include/ui/dialogs/mask_wizard.hpp
@@ -76,6 +76,12 @@ public:
      */
     [[nodiscard]] CropRegion cropRegion() const;
 
+    /**
+     * @brief Check if crop region covers the full volume (no actual crop)
+     * @return True if crop equals full volume dimensions
+     */
+    [[nodiscard]] bool isCropFullVolume() const;
+
     // -- Threshold page API --
 
     /**

--- a/src/ui/dialogs/mask_wizard.cpp
+++ b/src/ui/dialogs/mask_wizard.cpp
@@ -5,6 +5,7 @@
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QLabel>
+#include <QMessageBox>
 #include <QProgressBar>
 #include <QPushButton>
 #include <QSlider>
@@ -159,6 +160,32 @@ public:
         return {xMinSpin_->value(), xMaxSpin_->value(),
                 yMinSpin_->value(), yMaxSpin_->value(),
                 zMinSpin_->value(), zMaxSpin_->value()};
+    }
+
+    [[nodiscard]] bool isFullVolume() const {
+        return xMinSpin_->value() == 0
+            && xMaxSpin_->value() == dimX_ - 1
+            && yMinSpin_->value() == 0
+            && yMaxSpin_->value() == dimY_ - 1
+            && zMinSpin_->value() == 0
+            && zMaxSpin_->value() == dimZ_ - 1;
+    }
+
+    bool validatePage() override {
+        // Skip dialog if crop region is full volume (no actual crop)
+        if (isFullVolume()) {
+            return true;
+        }
+
+        auto result = QMessageBox::question(
+            this,
+            tr("Confirm Crop"),
+            tr("Cropping is irreversible within this wizard session.\n\n"
+               "Do you want to proceed with the current crop region?"),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No);
+
+        return result == QMessageBox::Yes;
     }
 
 private:
@@ -779,6 +806,11 @@ void MaskWizard::setVolumeDimensions(int x, int y, int z)
 CropRegion MaskWizard::cropRegion() const
 {
     return impl_->cropPage->region();
+}
+
+bool MaskWizard::isCropFullVolume() const
+{
+    return impl_->cropPage->isFullVolume();
 }
 
 void MaskWizard::setPhaseCount(int count)


### PR DESCRIPTION
Closes #378

## Summary
- Override `validatePage()` in CropPage to show QMessageBox confirmation dialog when user clicks Next
- Dialog warns that cropping is irreversible and asks for confirmation (Yes/No)
- Skip dialog when crop region equals full volume (no actual crop operation)
- Add `isCropFullVolume()` public API to MaskWizard for testability
- Add 5 unit tests for full-volume detection and confirmation skip logic

## Test Plan
- [x] Build succeeds (dicom_viewer + mask_wizard_test targets)
- [x] CropFullVolume_DefaultIsTrue: default crop region is full volume
- [x] CropFullVolume_AfterModification: modifying spinbox makes it non-full
- [x] CropFullVolume_AfterReset: reset button restores full volume
- [x] CropFullVolume_AfterDimensionChange: dimension change resets to full
- [x] CropNextSucceeds_WhenFullVolume: next() works without dialog for full volume
- [x] Existing MaskWizard tests pass without regression