### PR TITLE
feat(ui): add plane position data model to QuantificationWindow

### DIFF
--- a/include/ui/quantification_window.hpp
+++ b/include/ui/quantification_window.hpp
@@ -58,6 +58,19 @@ struct VolumeStatRow {
 };
 
 /**
+ * @brief Spatial position of a measurement plane in 3D space
+ */
+struct PlanePosition {
+    double normalX = 0.0;  ///< Normal vector X component
+    double normalY = 0.0;  ///< Normal vector Y component
+    double normalZ = 1.0;  ///< Normal vector Z component (default: axial)
+    double centerX = 0.0;  ///< Center point X in mm
+    double centerY = 0.0;  ///< Center point Y in mm
+    double centerZ = 0.0;  ///< Center point Z in mm
+    double extent = 50.0;  ///< Measurement region extent in mm
+};
+
+/**
  * @brief Independent window for quantitative flow analysis
  *
  * Displays measurement statistics in a table (Mean/Std/Max/Min) and
@@ -208,6 +221,29 @@ public:
      */
     [[nodiscard]] QColor planeColor(int index) const;
 
+    /**
+     * @brief Add a measurement plane with name, color, and position
+     * @param name Display name
+     * @param color Color for graph line and selector indicator
+     * @param position Spatial position in 3D space
+     */
+    void addPlane(const QString& name, const QColor& color,
+                  const PlanePosition& position);
+
+    /**
+     * @brief Get a plane's spatial position
+     * @param index 0-based plane index
+     * @return Plane position, or default PlanePosition if out of range
+     */
+    [[nodiscard]] PlanePosition planePosition(int index) const;
+
+    /**
+     * @brief Set a plane's spatial position
+     * @param index 0-based plane index
+     * @param position New spatial position
+     */
+    void setPlanePosition(int index, const PlanePosition& position);
+
     // -- Volume measurement API --
 
     /**
@@ -276,6 +312,12 @@ signals:
      * @param index New tab index
      */
     void activeTabChanged(int index);
+
+    /**
+     * @brief Emitted when a plane's spatial position changes
+     * @param index Plane index whose position changed
+     */
+    void planePositionChanged(int index);
 
 private:
     void setupUI();

--- a/src/ui/dialogs/quantification_window.cpp
+++ b/src/ui/dialogs/quantification_window.cpp
@@ -81,6 +81,7 @@ QIcon colorSwatchIcon(const QColor& color)
 struct PlaneInfo {
     QString name;
     QColor color;
+    PlanePosition position;
 };
 
 class QuantificationWindow::Impl {
@@ -637,7 +638,17 @@ void QuantificationWindow::renderReport(QPainter& painter, const QRectF& pageRec
 
 void QuantificationWindow::addPlane(const QString& name, const QColor& color)
 {
-    impl_->planes.push_back({name, color});
+    impl_->planes.push_back({name, color, {}});
+    impl_->planeCombo->addItem(colorSwatchIcon(color), name);
+    if (impl_->planes.size() == 1) {
+        impl_->planeCombo->setCurrentIndex(0);
+    }
+}
+
+void QuantificationWindow::addPlane(const QString& name, const QColor& color,
+                                     const PlanePosition& position)
+{
+    impl_->planes.push_back({name, color, position});
     impl_->planeCombo->addItem(colorSwatchIcon(color), name);
     if (impl_->planes.size() == 1) {
         impl_->planeCombo->setCurrentIndex(0);
@@ -678,6 +689,19 @@ QColor QuantificationWindow::planeColor(int index) const
 {
     if (index < 0 || index >= static_cast<int>(impl_->planes.size())) return {};
     return impl_->planes[index].color;
+}
+
+PlanePosition QuantificationWindow::planePosition(int index) const
+{
+    if (index < 0 || index >= static_cast<int>(impl_->planes.size())) return {};
+    return impl_->planes[index].position;
+}
+
+void QuantificationWindow::setPlanePosition(int index, const PlanePosition& position)
+{
+    if (index < 0 || index >= static_cast<int>(impl_->planes.size())) return;
+    impl_->planes[index].position = position;
+    emit planePositionChanged(index);
 }
 
 void QuantificationWindow::setVolumeStatistics(const std::vector<VolumeStatRow>& rows)


### PR DESCRIPTION
Closes #380

## Summary
- Add `PlanePosition` struct with normal vector, center point, and extent for 3D spatial positioning
- Add `addPlane(name, color, position)` overload for planes with initial position
- Add `planePosition(index)` getter and `setPlanePosition(index, position)` setter
- Add `planePositionChanged(int index)` signal for view synchronization
- Extend internal `PlaneInfo` struct with position field
- Add 6 unit tests for position data model

## Test Plan
- [x] Build succeeds (dicom_viewer + quantification_window_test targets)
- [x] PlanePosition_DefaultIsZeroNormal: default position has normalZ=1, extent=50
- [x] PlanePosition_OutOfRange_ReturnsDefault: out-of-range returns default
- [x] AddPlane_WithPosition: 3-arg overload stores position correctly
- [x] SetPlanePosition_StoresAndRetrieves: setter/getter round-trip
- [x] SetPlanePosition_OutOfRange_NoEffect: out-of-range does not crash
- [x] PlanePositionChanged_Signal: signal emits with correct plane index
- [x] Existing plane management tests pass without regression