### PR TITLE
feat(ui): add reference phase selector to MaskWizard TrackPage

### DIFF
--- a/include/ui/dialogs/mask_wizard.hpp
+++ b/include/ui/dialogs/mask_wizard.hpp
@@ -139,6 +139,18 @@ public:
     [[nodiscard]] int phaseCount() const;
 
     /**
+     * @brief Get the selected reference phase index
+     * @return 0-based reference phase index
+     */
+    [[nodiscard]] int referencePhase() const;
+
+    /**
+     * @brief Set the reference phase index programmatically
+     * @param phase 0-based phase index (clamped to valid range)
+     */
+    void setReferencePhase(int phase);
+
+    /**
      * @brief Update the propagation progress bar
      * @param percent Progress value (0-100)
      */
@@ -180,6 +192,12 @@ signals:
      * @brief Emitted when user clicks the Run Propagation button
      */
     void propagationRequested();
+
+    /**
+     * @brief Emitted when the reference phase selection changes
+     * @param phase New reference phase index
+     */
+    void referencePhaseChanged(int phase);
 
 private:
     void setupPages();


### PR DESCRIPTION
## Summary
- Add QSpinBox for reference phase selection on MaskWizard TrackPage
- Add `referencePhase()` / `setReferencePhase()` API to MaskWizard
- Add `referencePhaseChanged(int)` signal for PhaseTracker integration
- Reference phase range auto-adjusts when phase count changes

Closes #382

## Test Plan
- [x] Reference phase spinbox visible on TrackPage (Step 4)
- [x] Default reference phase is 0
- [x] `setReferencePhase()` stores and retrieves correct value
- [x] Value clamped to valid range when exceeding phaseCount
- [x] Negative values clamped to 0
- [x] Reducing phaseCount auto-clamps reference phase
- [x] `referencePhaseChanged` signal emitted on value change
- [x] Spinbox range matches [0, phaseCount-1]
- [x] Existing TrackPage tests still pass
- [x] Build succeeds without compile errors