### PR TITLE
feat(ui): add MaskWizardResult struct to aggregate wizard step outputs

### DIFF
--- a/include/ui/dialogs/mask_wizard.hpp
+++ b/include/ui/dialogs/mask_wizard.hpp
@@ -27,6 +27,21 @@ struct ComponentInfo {
 };
 
 /**
+ * @brief Aggregated result from all wizard steps
+ *
+ * Provides a single snapshot of the complete wizard configuration
+ * for external consumers (e.g., LabelManager integration).
+ */
+struct MaskWizardResult {
+    CropRegion crop;                     ///< Step 1: Crop bounds
+    int thresholdMin = 0;                ///< Step 2: Minimum intensity
+    int thresholdMax = 0;                ///< Step 2: Maximum intensity
+    std::vector<int> selectedComponents; ///< Step 3: Selected component indices (0-based)
+    int referencePhase = 0;              ///< Step 4: Phase to propagate from
+    int phaseCount = 1;                  ///< Step 4: Total cardiac phases
+};
+
+/**
  * @brief Wizard page identifiers for the Mask Wizard workflow
  */
 enum class MaskWizardStep {
@@ -162,11 +177,23 @@ public:
      */
     void setTrackStatus(const QString& status);
 
+    /**
+     * @brief Get aggregated result from all wizard steps
+     * @return Snapshot of all wizard parameters
+     */
+    [[nodiscard]] MaskWizardResult wizardResult() const;
+
 signals:
     /**
      * @brief Emitted when the wizard completes all steps successfully
      */
     void wizardCompleted();
+
+    /**
+     * @brief Emitted when the wizard completes with aggregated result
+     * @param result Snapshot of all wizard step parameters
+     */
+    void wizardFinished(const MaskWizardResult& result);
 
     /**
      * @brief Emitted when threshold slider values change
@@ -208,3 +235,5 @@ private:
 };
 
 } // namespace dicom_viewer::ui
+
+Q_DECLARE_METATYPE(dicom_viewer::ui::MaskWizardResult)

--- a/src/ui/dialogs/mask_wizard.cpp
+++ b/src/ui/dialogs/mask_wizard.cpp
@@ -757,6 +757,9 @@ MaskWizard::MaskWizard(QWidget* parent)
     setupAppearance();
 
     connect(this, &QWizard::accepted, this, &MaskWizard::wizardCompleted);
+    connect(this, &QWizard::accepted, this, [this]() {
+        emit wizardFinished(wizardResult());
+    });
 }
 
 MaskWizard::~MaskWizard() = default;
@@ -855,6 +858,18 @@ void MaskWizard::setPhaseCount(int count)
 int MaskWizard::phaseCount() const
 {
     return impl_->trackPage->phaseCount();
+}
+
+MaskWizardResult MaskWizard::wizardResult() const
+{
+    MaskWizardResult result;
+    result.crop = cropRegion();
+    result.thresholdMin = thresholdMin();
+    result.thresholdMax = thresholdMax();
+    result.selectedComponents = selectedComponentIndices();
+    result.referencePhase = referencePhase();
+    result.phaseCount = phaseCount();
+    return result;
 }
 
 int MaskWizard::referencePhase() const


### PR DESCRIPTION
## Summary
- Add `MaskWizardResult` struct aggregating all wizard step parameters into a single snapshot
- Add `wizardResult()` method for on-demand retrieval of complete wizard state
- Add `wizardFinished(MaskWizardResult)` signal emitted alongside existing `wizardCompleted()`
- Register `MaskWizardResult` with Qt meta-type system via `Q_DECLARE_METATYPE`

Closes #385

## Test Plan
- [x] `MaskWizardResult` default construction has expected zero/empty values
- [x] `wizardResult()` returns correct defaults (full crop, default threshold, empty components)
- [x] `wizardResult()` reflects modified wizard state (crop, threshold, components, phase config)
- [x] `wizardFinished` signal is valid and connectable
- [x] Existing MaskWizard tests still pass
- [x] Build succeeds without compile errors