### PR TITLE
feat(ui): add DropHandler utility class with drop type classification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,6 +601,7 @@ add_library(dicom_viewer_ui STATIC
     src/ui/dialogs/pacs_config_dialog.cpp
     src/ui/dialogs/quantification_window.cpp
     src/ui/dialogs/mask_wizard.cpp
+    src/ui/drop_handler.cpp
     src/ui/widgets/flow_graph_widget.cpp
     # Headers with Q_OBJECT for AUTOMOC
     include/ui/main_window.hpp
@@ -619,6 +620,7 @@ add_library(dicom_viewer_ui STATIC
     include/ui/dialogs/pacs_config_dialog.hpp
     include/ui/quantification_window.hpp
     include/ui/dialogs/mask_wizard.hpp
+    include/ui/drop_handler.hpp
     include/ui/widgets/flow_graph_widget.hpp
 )
 

--- a/include/ui/drop_handler.hpp
+++ b/include/ui/drop_handler.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+class QMimeData;
+class QWidget;
+
+namespace dicom_viewer::ui {
+
+/**
+ * @brief Classification of dropped content types
+ */
+enum class DropType {
+    DicomFolder,   ///< Folder containing DICOM files
+    ProjectFile,   ///< .flo project file
+    MaskFile,      ///< .nii/.nii.gz/.nrrd mask file
+    StlFile,       ///< .stl 3D mesh file
+    Unknown        ///< Unrecognized file type
+};
+
+/**
+ * @brief Drag-and-drop handler for DICOM viewers
+ *
+ * Provides drop type classification and DICOM folder detection.
+ * Install as an event filter on any QWidget to handle drag/drop events.
+ *
+ * @trace SRS-FR-051
+ */
+class DropHandler : public QObject {
+    Q_OBJECT
+
+public:
+    explicit DropHandler(QWidget* target, QObject* parent = nullptr);
+
+    /**
+     * @brief Classify a drop based on MIME data
+     * @param mimeData Drop data from drag event
+     * @return Detected drop type
+     */
+    [[nodiscard]] static DropType classifyDrop(const QMimeData* mimeData);
+
+    /**
+     * @brief Check if a folder contains DICOM files
+     *
+     * Reads up to 5 files and checks for DICM magic bytes at offset 128.
+     *
+     * @param folderPath Path to the folder
+     * @return True if DICOM files detected
+     */
+    [[nodiscard]] static bool isDicomFolder(const QString& folderPath);
+
+    /**
+     * @brief Classify a single file path by extension
+     * @param filePath File or folder path
+     * @return Detected type
+     */
+    [[nodiscard]] static DropType classifyPath(const QString& filePath);
+
+signals:
+    /**
+     * @brief Emitted when a DICOM folder is dropped
+     * @param path Folder path
+     */
+    void dicomFolderDropped(const QString& path);
+
+    /**
+     * @brief Emitted when a .flo project file is dropped
+     * @param path File path
+     */
+    void projectFileDropped(const QString& path);
+
+    /**
+     * @brief Emitted when a mask file is dropped
+     * @param path File path
+     */
+    void maskFileDropped(const QString& path);
+
+    /**
+     * @brief Emitted when an STL file is dropped
+     * @param path File path
+     */
+    void stlFileDropped(const QString& path);
+
+protected:
+    bool eventFilter(QObject* obj, QEvent* event) override;
+
+private:
+    QWidget* target_ = nullptr;
+};
+
+} // namespace dicom_viewer::ui

--- a/src/ui/drop_handler.cpp
+++ b/src/ui/drop_handler.cpp
@@ -1,0 +1,182 @@
+#include "ui/drop_handler.hpp"
+
+#include <QDir>
+#include <QDragEnterEvent>
+#include <QDropEvent>
+#include <QFile>
+#include <QFileInfo>
+#include <QMimeData>
+#include <QUrl>
+#include <QWidget>
+
+namespace dicom_viewer::ui {
+
+namespace {
+
+constexpr int kDicmPreambleOffset = 128;
+constexpr int kDicmMagicSize = 4;
+constexpr int kMaxFilesToCheck = 5;
+
+} // anonymous namespace
+
+DropHandler::DropHandler(QWidget* target, QObject* parent)
+    : QObject(parent)
+    , target_(target)
+{
+    if (target_) {
+        target_->setAcceptDrops(true);
+        target_->installEventFilter(this);
+    }
+}
+
+DropType DropHandler::classifyDrop(const QMimeData* mimeData)
+{
+    if (!mimeData || !mimeData->hasUrls()) {
+        return DropType::Unknown;
+    }
+
+    const auto urls = mimeData->urls();
+    if (urls.isEmpty()) {
+        return DropType::Unknown;
+    }
+
+    // Classify based on the first URL
+    return classifyPath(urls.first().toLocalFile());
+}
+
+bool DropHandler::isDicomFolder(const QString& folderPath)
+{
+    QDir dir(folderPath);
+    if (!dir.exists()) {
+        return false;
+    }
+
+    // Check .dcm extension first (fast path)
+    auto dcmFiles = dir.entryInfoList({"*.dcm", "*.DCM"}, QDir::Files);
+    if (!dcmFiles.isEmpty()) {
+        return true;
+    }
+
+    // Check for DICM magic bytes in first N files
+    auto allFiles = dir.entryInfoList(QDir::Files);
+    int checked = 0;
+    for (const auto& entry : allFiles) {
+        if (checked >= kMaxFilesToCheck) {
+            break;
+        }
+
+        QFile file(entry.absoluteFilePath());
+        if (!file.open(QIODevice::ReadOnly)) {
+            continue;
+        }
+
+        if (file.size() < kDicmPreambleOffset + kDicmMagicSize) {
+            ++checked;
+            continue;
+        }
+
+        file.seek(kDicmPreambleOffset);
+        auto magic = file.read(kDicmMagicSize);
+        if (magic == "DICM") {
+            return true;
+        }
+
+        ++checked;
+    }
+
+    return false;
+}
+
+DropType DropHandler::classifyPath(const QString& filePath)
+{
+    if (filePath.isEmpty()) {
+        return DropType::Unknown;
+    }
+
+    QFileInfo info(filePath);
+
+    // Directory → check for DICOM
+    if (info.isDir()) {
+        if (isDicomFolder(filePath)) {
+            return DropType::DicomFolder;
+        }
+        return DropType::Unknown;
+    }
+
+    // File → classify by extension
+    auto suffix = info.suffix().toLower();
+
+    if (suffix == "flo") {
+        return DropType::ProjectFile;
+    }
+    if (suffix == "stl") {
+        return DropType::StlFile;
+    }
+    if (suffix == "nii" || suffix == "nrrd") {
+        return DropType::MaskFile;
+    }
+    if (suffix == "gz" && info.completeSuffix().toLower().endsWith("nii.gz")) {
+        return DropType::MaskFile;
+    }
+    if (suffix == "dcm") {
+        // Single .dcm file — treat parent as DICOM folder
+        return DropType::DicomFolder;
+    }
+
+    return DropType::Unknown;
+}
+
+bool DropHandler::eventFilter(QObject* obj, QEvent* event)
+{
+    if (obj != target_) {
+        return QObject::eventFilter(obj, event);
+    }
+
+    switch (event->type()) {
+        case QEvent::DragEnter: {
+            auto* dragEvent = static_cast<QDragEnterEvent*>(event);
+            auto type = classifyDrop(dragEvent->mimeData());
+            if (type != DropType::Unknown) {
+                dragEvent->acceptProposedAction();
+                return true;
+            }
+            break;
+        }
+        case QEvent::Drop: {
+            auto* dropEvent = static_cast<QDropEvent*>(event);
+            auto* mimeData = dropEvent->mimeData();
+            if (!mimeData || !mimeData->hasUrls()) {
+                break;
+            }
+
+            auto path = mimeData->urls().first().toLocalFile();
+            auto type = classifyPath(path);
+
+            switch (type) {
+                case DropType::DicomFolder:
+                    emit dicomFolderDropped(path);
+                    break;
+                case DropType::ProjectFile:
+                    emit projectFileDropped(path);
+                    break;
+                case DropType::MaskFile:
+                    emit maskFileDropped(path);
+                    break;
+                case DropType::StlFile:
+                    emit stlFileDropped(path);
+                    break;
+                case DropType::Unknown:
+                    break;
+            }
+
+            dropEvent->acceptProposedAction();
+            return true;
+        }
+        default:
+            break;
+    }
+
+    return QObject::eventFilter(obj, event);
+}
+
+} // namespace dicom_viewer::ui

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1893,3 +1893,21 @@ target_include_directories(mask_wizard_test PRIVATE
 )
 
 gtest_discover_tests(mask_wizard_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for DropHandler (drag-and-drop classification)
+add_executable(drop_handler_test
+    unit/drop_handler_test.cpp
+)
+
+target_link_libraries(drop_handler_test PRIVATE
+    dicom_viewer_ui
+    Qt6::Test
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(drop_handler_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(drop_handler_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/drop_handler_test.cpp
+++ b/tests/unit/drop_handler_test.cpp
@@ -1,0 +1,200 @@
+#include "ui/drop_handler.hpp"
+
+#include <QApplication>
+#include <QDir>
+#include <QFile>
+#include <QMimeData>
+#include <QTemporaryDir>
+#include <QUrl>
+#include <QWidget>
+#include <gtest/gtest.h>
+
+using dicom_viewer::ui::DropHandler;
+using dicom_viewer::ui::DropType;
+
+namespace {
+
+int argc = 1;
+char arg0[] = "drop_handler_test";
+char* argv[] = {arg0, nullptr};
+QApplication app(argc, argv);
+
+/// Create a minimal valid DICOM file (128-byte preamble + "DICM" magic)
+void createDicomFile(const QString& path)
+{
+    QFile file(path);
+    ASSERT_TRUE(file.open(QIODevice::WriteOnly));
+    // 128-byte preamble (zeros)
+    QByteArray preamble(128, '\0');
+    file.write(preamble);
+    // DICM magic bytes
+    file.write("DICM");
+    // Minimal trailing data
+    file.write(QByteArray(64, '\0'));
+    file.close();
+}
+
+/// Create a non-DICOM file with arbitrary content
+void createNonDicomFile(const QString& path)
+{
+    QFile file(path);
+    ASSERT_TRUE(file.open(QIODevice::WriteOnly));
+    file.write("This is not a DICOM file");
+    file.close();
+}
+
+} // anonymous namespace
+
+// --- classifyPath tests ---
+
+TEST(DropHandlerTest, ClassifyPath_EmptyPath_ReturnsUnknown)
+{
+    EXPECT_EQ(DropHandler::classifyPath(""), DropType::Unknown);
+}
+
+TEST(DropHandlerTest, ClassifyPath_FloFile_ReturnsProjectFile)
+{
+    EXPECT_EQ(DropHandler::classifyPath("/tmp/test.flo"), DropType::ProjectFile);
+}
+
+TEST(DropHandlerTest, ClassifyPath_StlFile_ReturnsStlFile)
+{
+    EXPECT_EQ(DropHandler::classifyPath("/tmp/model.stl"), DropType::StlFile);
+}
+
+TEST(DropHandlerTest, ClassifyPath_NiiFile_ReturnsMaskFile)
+{
+    EXPECT_EQ(DropHandler::classifyPath("/tmp/mask.nii"), DropType::MaskFile);
+}
+
+TEST(DropHandlerTest, ClassifyPath_NiiGzFile_ReturnsMaskFile)
+{
+    EXPECT_EQ(DropHandler::classifyPath("/tmp/mask.nii.gz"), DropType::MaskFile);
+}
+
+TEST(DropHandlerTest, ClassifyPath_NrrdFile_ReturnsMaskFile)
+{
+    EXPECT_EQ(DropHandler::classifyPath("/tmp/mask.nrrd"), DropType::MaskFile);
+}
+
+TEST(DropHandlerTest, ClassifyPath_DcmFile_ReturnsDicomFolder)
+{
+    EXPECT_EQ(DropHandler::classifyPath("/tmp/image.dcm"), DropType::DicomFolder);
+}
+
+TEST(DropHandlerTest, ClassifyPath_UnknownExtension_ReturnsUnknown)
+{
+    EXPECT_EQ(DropHandler::classifyPath("/tmp/readme.txt"), DropType::Unknown);
+}
+
+TEST(DropHandlerTest, ClassifyPath_CaseInsensitive)
+{
+    EXPECT_EQ(DropHandler::classifyPath("/tmp/TEST.FLO"), DropType::ProjectFile);
+    EXPECT_EQ(DropHandler::classifyPath("/tmp/Model.STL"), DropType::StlFile);
+}
+
+// --- isDicomFolder tests ---
+
+TEST(DropHandlerTest, IsDicomFolder_NonExistentFolder_ReturnsFalse)
+{
+    EXPECT_FALSE(DropHandler::isDicomFolder("/nonexistent/path/xyz"));
+}
+
+TEST(DropHandlerTest, IsDicomFolder_EmptyFolder_ReturnsFalse)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    EXPECT_FALSE(DropHandler::isDicomFolder(tmpDir.path()));
+}
+
+TEST(DropHandlerTest, IsDicomFolder_FolderWithDcmExtension_ReturnsTrue)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    createNonDicomFile(tmpDir.path() + "/image.dcm");
+    EXPECT_TRUE(DropHandler::isDicomFolder(tmpDir.path()));
+}
+
+TEST(DropHandlerTest, IsDicomFolder_FolderWithDicomMagicBytes_ReturnsTrue)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    // File without .dcm extension but with DICM magic
+    createDicomFile(tmpDir.path() + "/image001");
+    EXPECT_TRUE(DropHandler::isDicomFolder(tmpDir.path()));
+}
+
+TEST(DropHandlerTest, IsDicomFolder_FolderWithNonDicomFiles_ReturnsFalse)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    createNonDicomFile(tmpDir.path() + "/readme.txt");
+    createNonDicomFile(tmpDir.path() + "/data.bin");
+    EXPECT_FALSE(DropHandler::isDicomFolder(tmpDir.path()));
+}
+
+// --- classifyPath with directory ---
+
+TEST(DropHandlerTest, ClassifyPath_DicomDirectory_ReturnsDicomFolder)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    createDicomFile(tmpDir.path() + "/slice001");
+    EXPECT_EQ(DropHandler::classifyPath(tmpDir.path()), DropType::DicomFolder);
+}
+
+TEST(DropHandlerTest, ClassifyPath_EmptyDirectory_ReturnsUnknown)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    EXPECT_EQ(DropHandler::classifyPath(tmpDir.path()), DropType::Unknown);
+}
+
+// --- classifyDrop tests ---
+
+TEST(DropHandlerTest, ClassifyDrop_NullMimeData_ReturnsUnknown)
+{
+    EXPECT_EQ(DropHandler::classifyDrop(nullptr), DropType::Unknown);
+}
+
+TEST(DropHandlerTest, ClassifyDrop_NoUrls_ReturnsUnknown)
+{
+    QMimeData mimeData;
+    EXPECT_EQ(DropHandler::classifyDrop(&mimeData), DropType::Unknown);
+}
+
+TEST(DropHandlerTest, ClassifyDrop_EmptyUrls_ReturnsUnknown)
+{
+    QMimeData mimeData;
+    mimeData.setUrls({});
+    EXPECT_EQ(DropHandler::classifyDrop(&mimeData), DropType::Unknown);
+}
+
+TEST(DropHandlerTest, ClassifyDrop_FloUrl_ReturnsProjectFile)
+{
+    QMimeData mimeData;
+    mimeData.setUrls({QUrl::fromLocalFile("/tmp/test.flo")});
+    EXPECT_EQ(DropHandler::classifyDrop(&mimeData), DropType::ProjectFile);
+}
+
+TEST(DropHandlerTest, ClassifyDrop_StlUrl_ReturnsStlFile)
+{
+    QMimeData mimeData;
+    mimeData.setUrls({QUrl::fromLocalFile("/tmp/model.stl")});
+    EXPECT_EQ(DropHandler::classifyDrop(&mimeData), DropType::StlFile);
+}
+
+// --- DropHandler construction ---
+
+TEST(DropHandlerTest, Constructor_SetsAcceptDrops)
+{
+    QWidget widget;
+    DropHandler handler(&widget);
+    EXPECT_TRUE(widget.acceptDrops());
+}
+
+TEST(DropHandlerTest, Constructor_NullTarget_NoCrash)
+{
+    DropHandler handler(nullptr);
+    // Should not crash
+}


### PR DESCRIPTION
Closes #387

## Summary
- Add `DropType` enum classifying drop content: DicomFolder, ProjectFile, MaskFile, StlFile, Unknown
- Add `DropHandler` class with static classification methods and QWidget event filter
- Implement DICOM folder detection via .dcm extension fast path and DICM magic bytes at offset 128
- Add 20 unit tests covering path classification, folder detection, MIME data, and construction

## Test Plan
- [x] `classifyPath` returns correct `DropType` for .flo, .stl, .nii, .nii.gz, .nrrd, .dcm extensions
- [x] `classifyPath` returns Unknown for empty path and unrecognized extensions
- [x] `classifyPath` handles case-insensitive extensions (.FLO, .STL)
- [x] `isDicomFolder` returns false for non-existent and empty folders
- [x] `isDicomFolder` detects .dcm extension fast path
- [x] `isDicomFolder` detects DICM magic bytes in extensionless files
- [x] `isDicomFolder` returns false for folders with only non-DICOM files
- [x] `classifyPath` with directory delegates to isDicomFolder correctly
- [x] `classifyDrop` handles null, empty, and valid QMimeData
- [x] Constructor sets acceptDrops on target widget and handles null target