### PR TITLE
feat(export): add 3D rotation and combined animation to VideoExporter

### DIFF
--- a/src/services/export/video_exporter.cpp
+++ b/src/services/export/video_exporter.cpp
@@ -1,5 +1,6 @@
 #include "services/export/video_exporter.hpp"
 
+#include <cmath>
 #include <format>
 
 #include <vtkNew.h>
@@ -89,6 +90,108 @@ VideoExporter::validateCineConfig(const CineConfig& config) {
         return std::unexpected(ExportError{
             ExportError::Code::InvalidData,
             std::format("Loops must be >= 1, got {}", config.loops)});
+    }
+
+    if (config.framesPerPhase < 1) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            std::format("Frames per phase must be >= 1, got {}",
+                        config.framesPerPhase)});
+    }
+
+    return {};
+}
+
+std::expected<void, ExportError>
+VideoExporter::validateRotationConfig(const RotationConfig& config) {
+    if (config.outputPath.empty()) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            "Output path is empty"});
+    }
+
+    if (config.width < 1 || config.height < 1) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            std::format("Invalid resolution {}x{}",
+                        config.width, config.height)});
+    }
+
+    if (config.fps < 1 || config.fps > 120) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            std::format("FPS must be in [1, 120], got {}", config.fps)});
+    }
+
+    if (std::abs(config.endAngle - config.startAngle) < 0.01) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            "Angle range is effectively zero"});
+    }
+
+    if (config.elevation < -90.0 || config.elevation > 90.0) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            std::format("Elevation must be in [-90, 90], got {}",
+                        config.elevation)});
+    }
+
+    if (config.totalFrames < 2) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            std::format("Total frames must be >= 2, got {}",
+                        config.totalFrames)});
+    }
+
+    return {};
+}
+
+std::expected<void, ExportError>
+VideoExporter::validateCombinedConfig(const CombinedConfig& config) {
+    if (config.outputPath.empty()) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            "Output path is empty"});
+    }
+
+    if (config.width < 1 || config.height < 1) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            std::format("Invalid resolution {}x{}",
+                        config.width, config.height)});
+    }
+
+    if (config.fps < 1 || config.fps > 120) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            std::format("FPS must be in [1, 120], got {}", config.fps)});
+    }
+
+    if (std::abs(config.endAngle - config.startAngle) < 0.01) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            "Angle range is effectively zero"});
+    }
+
+    if (config.elevation < -90.0 || config.elevation > 90.0) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            std::format("Elevation must be in [-90, 90], got {}",
+                        config.elevation)});
+    }
+
+    if (config.totalPhases < 1) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            std::format("Total phases must be >= 1, got {}",
+                        config.totalPhases)});
+    }
+
+    if (config.phaseLoops < 1) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            std::format("Phase loops must be >= 1, got {}",
+                        config.phaseLoops)});
     }
 
     if (config.framesPerPhase < 1) {
@@ -199,6 +302,210 @@ VideoExporter::exportCine2D(
     writer->End();
 
     impl_->reportProgress(1.0, "Video export complete");
+
+    return {};
+}
+
+// =========================================================================
+// 3D Rotation Export
+// =========================================================================
+
+std::expected<void, ExportError>
+VideoExporter::exportRotation3D(
+    vtkRenderWindow* renderWindow,
+    const RotationConfig& config,
+    CameraCallback setCamera) const {
+
+    if (!renderWindow) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            "Render window is null"});
+    }
+
+    if (!setCamera) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            "Camera callback is null"});
+    }
+
+    auto validation = validateRotationConfig(config);
+    if (!validation) {
+        return validation;
+    }
+
+    const double angleRange = config.endAngle - config.startAngle;
+    const double angleStep = angleRange / (config.totalFrames - 1);
+
+    renderWindow->SetSize(config.width, config.height);
+
+    vtkNew<vtkWindowToImageFilter> windowToImage;
+    windowToImage->SetInput(renderWindow);
+    windowToImage->SetInputBufferTypeToRGB();
+    windowToImage->ReadFrontBufferOff();
+
+    vtkNew<vtkOggTheoraWriter> writer;
+    writer->SetInputConnection(windowToImage->GetOutputPort());
+    writer->SetFileName(config.outputPath.string().c_str());
+    writer->SetRate(config.fps);
+
+    impl_->reportProgress(0.0, "Starting 3D rotation export");
+
+    writer->Start();
+    if (writer->GetError()) {
+        return std::unexpected(ExportError{
+            ExportError::Code::FileAccessDenied,
+            std::format("Failed to open video file: {}",
+                        config.outputPath.string())});
+    }
+
+    try {
+        for (int frame = 0; frame < config.totalFrames; ++frame) {
+            double azimuth = config.startAngle + angleStep * frame;
+            setCamera(azimuth, config.elevation);
+            renderWindow->Render();
+
+            windowToImage->Modified();
+            windowToImage->Update();
+
+            writer->Write();
+            if (writer->GetError()) {
+                writer->End();
+                return std::unexpected(ExportError{
+                    ExportError::Code::EncodingFailed,
+                    std::format("Failed writing frame {} (azimuth {:.1f}°)",
+                                frame, azimuth)});
+            }
+
+            double progress =
+                static_cast<double>(frame + 1) / config.totalFrames;
+            impl_->reportProgress(
+                progress,
+                std::format("Rotation {:.0f}°/{:.0f}°",
+                            azimuth, config.endAngle));
+        }
+    } catch (const std::exception& e) {
+        writer->End();
+        return std::unexpected(ExportError{
+            ExportError::Code::InternalError,
+            std::format("Exception during rotation export: {}", e.what())});
+    }
+
+    writer->End();
+
+    impl_->reportProgress(1.0, "3D rotation export complete");
+
+    return {};
+}
+
+// =========================================================================
+// Combined Rotation + Phase Export
+// =========================================================================
+
+std::expected<void, ExportError>
+VideoExporter::exportCombined3D(
+    vtkRenderWindow* renderWindow,
+    const CombinedConfig& config,
+    PhaseCallback setPhase,
+    CameraCallback setCamera) const {
+
+    if (!renderWindow) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            "Render window is null"});
+    }
+
+    if (!setPhase) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            "Phase callback is null"});
+    }
+
+    if (!setCamera) {
+        return std::unexpected(ExportError{
+            ExportError::Code::InvalidData,
+            "Camera callback is null"});
+    }
+
+    auto validation = validateCombinedConfig(config);
+    if (!validation) {
+        return validation;
+    }
+
+    const int totalFrames =
+        config.totalPhases * config.phaseLoops * config.framesPerPhase;
+    const double angleRange = config.endAngle - config.startAngle;
+    const double angleStep = angleRange / std::max(totalFrames - 1, 1);
+
+    renderWindow->SetSize(config.width, config.height);
+
+    vtkNew<vtkWindowToImageFilter> windowToImage;
+    windowToImage->SetInput(renderWindow);
+    windowToImage->SetInputBufferTypeToRGB();
+    windowToImage->ReadFrontBufferOff();
+
+    vtkNew<vtkOggTheoraWriter> writer;
+    writer->SetInputConnection(windowToImage->GetOutputPort());
+    writer->SetFileName(config.outputPath.string().c_str());
+    writer->SetRate(config.fps);
+
+    impl_->reportProgress(0.0, "Starting combined rotation+phase export");
+
+    writer->Start();
+    if (writer->GetError()) {
+        return std::unexpected(ExportError{
+            ExportError::Code::FileAccessDenied,
+            std::format("Failed to open video file: {}",
+                        config.outputPath.string())});
+    }
+
+    int frameIndex = 0;
+
+    try {
+        for (int loop = 0; loop < config.phaseLoops; ++loop) {
+            for (int phase = 0; phase < config.totalPhases; ++phase) {
+                setPhase(phase);
+
+                for (int f = 0; f < config.framesPerPhase; ++f) {
+                    double azimuth =
+                        config.startAngle + angleStep * frameIndex;
+                    setCamera(azimuth, config.elevation);
+                    renderWindow->Render();
+
+                    windowToImage->Modified();
+                    windowToImage->Update();
+
+                    writer->Write();
+                    if (writer->GetError()) {
+                        writer->End();
+                        return std::unexpected(ExportError{
+                            ExportError::Code::EncodingFailed,
+                            std::format(
+                                "Failed writing frame {} (phase {}, "
+                                "azimuth {:.1f}°)",
+                                frameIndex, phase, azimuth)});
+                    }
+                    ++frameIndex;
+                }
+
+                double progress =
+                    static_cast<double>(frameIndex) / totalFrames;
+                impl_->reportProgress(
+                    progress,
+                    std::format("Phase {}/{}, rotation {:.0f}°",
+                                phase + 1, config.totalPhases,
+                                config.startAngle + angleStep * frameIndex));
+            }
+        }
+    } catch (const std::exception& e) {
+        writer->End();
+        return std::unexpected(ExportError{
+            ExportError::Code::InternalError,
+            std::format("Exception during combined export: {}", e.what())});
+    }
+
+    writer->End();
+
+    impl_->reportProgress(1.0, "Combined export complete");
 
     return {};
 }

--- a/tests/unit/video_exporter_test.cpp
+++ b/tests/unit/video_exporter_test.cpp
@@ -174,7 +174,188 @@ TEST(VideoExporterTest, CustomPhaseRangePasses) {
 }
 
 // =============================================================================
-// Export error handling tests
+// RotationConfig validation tests
+// =============================================================================
+
+TEST(VideoExporterTest, ValidRotationConfigPasses) {
+    VideoExporter::RotationConfig config;
+    config.outputPath = "/tmp/test.ogv";
+
+    auto result = VideoExporter::validateRotationConfig(config);
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST(VideoExporterTest, RotationEmptyPathFails) {
+    VideoExporter::RotationConfig config;
+    auto result = VideoExporter::validateRotationConfig(config);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, ExportError::Code::InvalidData);
+}
+
+TEST(VideoExporterTest, RotationZeroAngleRangeFails) {
+    VideoExporter::RotationConfig config;
+    config.outputPath = "/tmp/test.ogv";
+    config.startAngle = 90.0;
+    config.endAngle = 90.0;
+
+    auto result = VideoExporter::validateRotationConfig(config);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(VideoExporterTest, RotationElevationTooHighFails) {
+    VideoExporter::RotationConfig config;
+    config.outputPath = "/tmp/test.ogv";
+    config.elevation = 100.0;
+
+    auto result = VideoExporter::validateRotationConfig(config);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(VideoExporterTest, RotationElevationTooLowFails) {
+    VideoExporter::RotationConfig config;
+    config.outputPath = "/tmp/test.ogv";
+    config.elevation = -95.0;
+
+    auto result = VideoExporter::validateRotationConfig(config);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(VideoExporterTest, RotationOneFrameFails) {
+    VideoExporter::RotationConfig config;
+    config.outputPath = "/tmp/test.ogv";
+    config.totalFrames = 1;
+
+    auto result = VideoExporter::validateRotationConfig(config);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(VideoExporterTest, RotationInvalidResolutionFails) {
+    VideoExporter::RotationConfig config;
+    config.outputPath = "/tmp/test.ogv";
+    config.width = 0;
+
+    auto result = VideoExporter::validateRotationConfig(config);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(VideoExporterTest, RotationInvalidFPSFails) {
+    VideoExporter::RotationConfig config;
+    config.outputPath = "/tmp/test.ogv";
+    config.fps = 0;
+
+    auto result = VideoExporter::validateRotationConfig(config);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(VideoExporterTest, RotationCustomAnglePasses) {
+    VideoExporter::RotationConfig config;
+    config.outputPath = "/tmp/test.ogv";
+    config.startAngle = -45.0;
+    config.endAngle = 45.0;
+    config.elevation = -30.0;
+    config.totalFrames = 90;
+
+    auto result = VideoExporter::validateRotationConfig(config);
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST(VideoExporterTest, RotationConfigDefaults) {
+    VideoExporter::RotationConfig config;
+    EXPECT_EQ(config.width, 1920);
+    EXPECT_EQ(config.height, 1080);
+    EXPECT_EQ(config.fps, 30);
+    EXPECT_DOUBLE_EQ(config.startAngle, 0.0);
+    EXPECT_DOUBLE_EQ(config.endAngle, 360.0);
+    EXPECT_DOUBLE_EQ(config.elevation, 15.0);
+    EXPECT_EQ(config.totalFrames, 180);
+}
+
+// =============================================================================
+// CombinedConfig validation tests
+// =============================================================================
+
+TEST(VideoExporterTest, ValidCombinedConfigPasses) {
+    VideoExporter::CombinedConfig config;
+    config.outputPath = "/tmp/test.ogv";
+    config.totalPhases = 20;
+
+    auto result = VideoExporter::validateCombinedConfig(config);
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST(VideoExporterTest, CombinedEmptyPathFails) {
+    VideoExporter::CombinedConfig config;
+    config.totalPhases = 10;
+
+    auto result = VideoExporter::validateCombinedConfig(config);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(VideoExporterTest, CombinedZeroPhasesFails) {
+    VideoExporter::CombinedConfig config;
+    config.outputPath = "/tmp/test.ogv";
+    config.totalPhases = 0;
+
+    auto result = VideoExporter::validateCombinedConfig(config);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(VideoExporterTest, CombinedZeroAngleRangeFails) {
+    VideoExporter::CombinedConfig config;
+    config.outputPath = "/tmp/test.ogv";
+    config.totalPhases = 10;
+    config.startAngle = 180.0;
+    config.endAngle = 180.0;
+
+    auto result = VideoExporter::validateCombinedConfig(config);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(VideoExporterTest, CombinedZeroLoopsFails) {
+    VideoExporter::CombinedConfig config;
+    config.outputPath = "/tmp/test.ogv";
+    config.totalPhases = 10;
+    config.phaseLoops = 0;
+
+    auto result = VideoExporter::validateCombinedConfig(config);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(VideoExporterTest, CombinedZeroFramesPerPhaseFails) {
+    VideoExporter::CombinedConfig config;
+    config.outputPath = "/tmp/test.ogv";
+    config.totalPhases = 10;
+    config.framesPerPhase = 0;
+
+    auto result = VideoExporter::validateCombinedConfig(config);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(VideoExporterTest, CombinedInvalidElevationFails) {
+    VideoExporter::CombinedConfig config;
+    config.outputPath = "/tmp/test.ogv";
+    config.totalPhases = 10;
+    config.elevation = 91.0;
+
+    auto result = VideoExporter::validateCombinedConfig(config);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(VideoExporterTest, CombinedConfigDefaults) {
+    VideoExporter::CombinedConfig config;
+    EXPECT_EQ(config.width, 1920);
+    EXPECT_EQ(config.height, 1080);
+    EXPECT_EQ(config.fps, 30);
+    EXPECT_DOUBLE_EQ(config.startAngle, 0.0);
+    EXPECT_DOUBLE_EQ(config.endAngle, 360.0);
+    EXPECT_DOUBLE_EQ(config.elevation, 15.0);
+    EXPECT_EQ(config.totalPhases, 0);
+    EXPECT_EQ(config.phaseLoops, 1);
+    EXPECT_EQ(config.framesPerPhase, 1);
+}
+
+// =============================================================================
+// Export error handling tests (Cine)
 // =============================================================================
 
 TEST(VideoExporterTest, NullRenderWindowReturnsError) {
@@ -210,6 +391,99 @@ TEST(VideoExporterTest, InvalidConfigInExportReturnsError) {
 
     auto result = exporter.exportCine2D(
         reinterpret_cast<vtkRenderWindow*>(0x1), config, [](int) {});
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, ExportError::Code::InvalidData);
+}
+
+// =============================================================================
+// Export error handling tests (Rotation)
+// =============================================================================
+
+TEST(VideoExporterTest, RotationNullRenderWindowReturnsError) {
+    VideoExporter exporter;
+    VideoExporter::RotationConfig config;
+    config.outputPath = "/tmp/test.ogv";
+
+    auto result = exporter.exportRotation3D(nullptr, config,
+                                             [](double, double) {});
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, ExportError::Code::InvalidData);
+}
+
+TEST(VideoExporterTest, RotationNullCameraCallbackReturnsError) {
+    VideoExporter exporter;
+    VideoExporter::RotationConfig config;
+    config.outputPath = "/tmp/test.ogv";
+
+    auto result = exporter.exportRotation3D(
+        reinterpret_cast<vtkRenderWindow*>(0x1), config, nullptr);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, ExportError::Code::InvalidData);
+}
+
+TEST(VideoExporterTest, RotationInvalidConfigInExportReturnsError) {
+    VideoExporter exporter;
+    VideoExporter::RotationConfig config;
+    // Empty path
+    auto result = exporter.exportRotation3D(
+        reinterpret_cast<vtkRenderWindow*>(0x1), config,
+        [](double, double) {});
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, ExportError::Code::InvalidData);
+}
+
+// =============================================================================
+// Export error handling tests (Combined)
+// =============================================================================
+
+TEST(VideoExporterTest, CombinedNullRenderWindowReturnsError) {
+    VideoExporter exporter;
+    VideoExporter::CombinedConfig config;
+    config.outputPath = "/tmp/test.ogv";
+    config.totalPhases = 10;
+
+    auto result = exporter.exportCombined3D(nullptr, config,
+                                             [](int) {},
+                                             [](double, double) {});
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, ExportError::Code::InvalidData);
+}
+
+TEST(VideoExporterTest, CombinedNullPhaseCallbackReturnsError) {
+    VideoExporter exporter;
+    VideoExporter::CombinedConfig config;
+    config.outputPath = "/tmp/test.ogv";
+    config.totalPhases = 10;
+
+    auto result = exporter.exportCombined3D(
+        reinterpret_cast<vtkRenderWindow*>(0x1), config,
+        nullptr, [](double, double) {});
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, ExportError::Code::InvalidData);
+}
+
+TEST(VideoExporterTest, CombinedNullCameraCallbackReturnsError) {
+    VideoExporter exporter;
+    VideoExporter::CombinedConfig config;
+    config.outputPath = "/tmp/test.ogv";
+    config.totalPhases = 10;
+
+    auto result = exporter.exportCombined3D(
+        reinterpret_cast<vtkRenderWindow*>(0x1), config,
+        [](int) {}, nullptr);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, ExportError::Code::InvalidData);
+}
+
+TEST(VideoExporterTest, CombinedInvalidConfigInExportReturnsError) {
+    VideoExporter exporter;
+    VideoExporter::CombinedConfig config;
+    config.totalPhases = 10;
+    // Empty path
+
+    auto result = exporter.exportCombined3D(
+        reinterpret_cast<vtkRenderWindow*>(0x1), config,
+        [](int) {}, [](double, double) {});
     EXPECT_FALSE(result.has_value());
     EXPECT_EQ(result.error().code, ExportError::Code::InvalidData);
 }


### PR DESCRIPTION
Closes #400

## Summary
- Add 3D rotation animation export: camera orbits 360° at fixed elevation
- Add combined rotation+phase animation: camera orbits while cardiac phases cycle
- New config structs: `RotationConfig`, `CombinedConfig`
- New callback type: `CameraCallback` for camera positioning
- Comprehensive validation for angle range, elevation bounds, frame counts
- 25 new tests (49 total, up from 24)

## Architecture
```
VideoExporter
├── CineConfig + exportCine2D()          (from #398)
├── RotationConfig + exportRotation3D()  (NEW)
│   └── Camera orbits startAngle→endAngle over totalFrames
├── CombinedConfig + exportCombined3D()  (NEW)
│   └── Rotation + phase cycling with configurable phaseLoops
└── CameraCallback: (azimuth, elevation) → void
```

Part of #250 (Video export for cine playback and 3D rotation)
Continues from #398/#399 (core VideoExporter with 2D cine)

## Files Changed
| File | Description |
|------|-------------|
| `include/services/export/video_exporter.hpp` | Add RotationConfig, CombinedConfig, CameraCallback, new methods |
| `src/services/export/video_exporter.cpp` | Implement rotation and combined export pipelines |
| `tests/unit/video_exporter_test.cpp` | 25 new tests for validation and error handling |

## Test Plan
- [x] 49 unit tests pass (config validation, error handling, defaults)
- [x] Full project builds without errors
- [ ] Manual verification: rotation video output from 3D render window