### PR TITLE
feat(ui): add video export dialog and menu integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -634,6 +634,7 @@ add_library(dicom_viewer_ui STATIC
     src/ui/dialogs/pacs_config_dialog.cpp
     src/ui/dialogs/quantification_window.cpp
     src/ui/dialogs/mask_wizard.cpp
+    src/ui/dialogs/video_export_dialog.cpp
     src/ui/mask_wizard_controller.cpp
     src/ui/drop_handler.cpp
     src/ui/widgets/flow_graph_widget.cpp
@@ -654,6 +655,7 @@ add_library(dicom_viewer_ui STATIC
     include/ui/dialogs/pacs_config_dialog.hpp
     include/ui/quantification_window.hpp
     include/ui/dialogs/mask_wizard.hpp
+    include/ui/dialogs/video_export_dialog.hpp
     include/ui/mask_wizard_controller.hpp
     include/ui/drop_handler.hpp
     include/ui/widgets/flow_graph_widget.hpp

--- a/include/ui/dialogs/video_export_dialog.hpp
+++ b/include/ui/dialogs/video_export_dialog.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "services/export/video_exporter.hpp"
+
+#include <memory>
+#include <QDialog>
+
+namespace dicom_viewer::ui {
+
+/**
+ * @brief Configuration dialog for video export
+ *
+ * Allows the user to select export mode (2D Cine, 3D Rotation, Combined),
+ * set resolution, FPS, and mode-specific parameters. Generates the
+ * appropriate VideoExporter config struct for the selected mode.
+ *
+ * @trace SRS-FR-046
+ */
+class VideoExportDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    /// Export mode selection
+    enum class ExportMode { Cine2D, Rotation3D, Combined };
+
+    /**
+     * @brief Construct the dialog
+     * @param totalPhases Total cardiac phases available (0 = no temporal data)
+     * @param parent Parent widget
+     */
+    explicit VideoExportDialog(int totalPhases, QWidget* parent = nullptr);
+    ~VideoExportDialog() override;
+
+    // Non-copyable
+    VideoExportDialog(const VideoExportDialog&) = delete;
+    VideoExportDialog& operator=(const VideoExportDialog&) = delete;
+
+    /// Get the selected export mode
+    [[nodiscard]] ExportMode exportMode() const;
+
+    /// Get the configured output file path
+    [[nodiscard]] std::filesystem::path outputPath() const;
+
+    /// Build CineConfig from dialog settings (valid when mode == Cine2D)
+    [[nodiscard]] services::VideoExporter::CineConfig buildCineConfig() const;
+
+    /// Build RotationConfig from dialog settings (valid when mode == Rotation3D)
+    [[nodiscard]] services::VideoExporter::RotationConfig buildRotationConfig() const;
+
+    /// Build CombinedConfig from dialog settings (valid when mode == Combined)
+    [[nodiscard]] services::VideoExporter::CombinedConfig buildCombinedConfig() const;
+
+private slots:
+    void onModeChanged(int index);
+    void onBrowseOutput();
+
+private:
+    void setupUI();
+    void setupConnections();
+    void updateModeOptions();
+
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::ui

--- a/include/ui/viewport_widget.hpp
+++ b/include/ui/viewport_widget.hpp
@@ -13,6 +13,7 @@
 #include "ui/quantification_window.hpp"
 
 class QVTKOpenGLNativeWidget;
+class vtkRenderWindow;
 
 namespace dicom_viewer::ui {
 
@@ -101,6 +102,12 @@ public:
      * @brief Reset camera to fit the data
      */
     void resetCamera();
+
+    /**
+     * @brief Get the underlying VTK render window
+     * @return Pointer to render window, or nullptr if not initialized
+     */
+    vtkRenderWindow* getRenderWindow() const;
 
     /**
      * @brief Capture screenshot

--- a/src/ui/dialogs/video_export_dialog.cpp
+++ b/src/ui/dialogs/video_export_dialog.cpp
@@ -1,0 +1,360 @@
+#include "ui/dialogs/video_export_dialog.hpp"
+
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QFileDialog>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QDoubleSpinBox>
+#include <QStackedWidget>
+#include <QVBoxLayout>
+
+namespace dicom_viewer::ui {
+
+// =========================================================================
+// Pimpl
+// =========================================================================
+
+class VideoExportDialog::Impl {
+public:
+    int totalPhases = 0;
+
+    // Common controls
+    QComboBox* modeCombo = nullptr;
+    QLineEdit* outputPathEdit = nullptr;
+    QPushButton* browseButton = nullptr;
+    QComboBox* resolutionCombo = nullptr;
+    QSpinBox* fpsSpin = nullptr;
+
+    // Mode-specific stacked widget
+    QStackedWidget* modeStack = nullptr;
+
+    // Cine2D controls
+    QSpinBox* cineStartPhaseSpin = nullptr;
+    QSpinBox* cineEndPhaseSpin = nullptr;
+    QSpinBox* cineLoopsSpin = nullptr;
+    QSpinBox* cineFramesPerPhaseSpin = nullptr;
+
+    // Rotation3D controls
+    QDoubleSpinBox* rotStartAngleSpin = nullptr;
+    QDoubleSpinBox* rotEndAngleSpin = nullptr;
+    QDoubleSpinBox* rotElevationSpin = nullptr;
+    QSpinBox* rotTotalFramesSpin = nullptr;
+
+    // Combined controls
+    QDoubleSpinBox* combStartAngleSpin = nullptr;
+    QDoubleSpinBox* combEndAngleSpin = nullptr;
+    QDoubleSpinBox* combElevationSpin = nullptr;
+    QSpinBox* combPhaseLoopsSpin = nullptr;
+    QSpinBox* combFramesPerPhaseSpin = nullptr;
+
+    QDialogButtonBox* buttonBox = nullptr;
+
+    struct Resolution {
+        int width;
+        int height;
+        const char* label;
+    };
+
+    static constexpr Resolution kResolutions[] = {
+        {1920, 1080, "1920 x 1080 (Full HD)"},
+        {1280,  720, "1280 x 720 (HD)"},
+        { 854,  480, "854 x 480 (480p)"},
+        { 640,  360, "640 x 360 (360p)"},
+    };
+
+    std::pair<int, int> selectedResolution() const {
+        int idx = resolutionCombo->currentIndex();
+        if (idx >= 0 && idx < static_cast<int>(std::size(kResolutions))) {
+            return {kResolutions[idx].width, kResolutions[idx].height};
+        }
+        return {1920, 1080};
+    }
+};
+
+// =========================================================================
+// Construction
+// =========================================================================
+
+VideoExportDialog::VideoExportDialog(int totalPhases, QWidget* parent)
+    : QDialog(parent)
+    , impl_(std::make_unique<Impl>())
+{
+    impl_->totalPhases = totalPhases;
+    setWindowTitle(tr("Export Video"));
+    setMinimumWidth(480);
+    setupUI();
+    setupConnections();
+    updateModeOptions();
+}
+
+VideoExportDialog::~VideoExportDialog() = default;
+
+// =========================================================================
+// Setup
+// =========================================================================
+
+void VideoExportDialog::setupUI()
+{
+    auto* mainLayout = new QVBoxLayout(this);
+
+    // --- Common settings ---
+    auto* commonGroup = new QGroupBox(tr("General Settings"));
+    auto* commonForm = new QFormLayout(commonGroup);
+
+    impl_->modeCombo = new QComboBox;
+    impl_->modeCombo->addItem(tr("2D Cine Phase Animation"), static_cast<int>(ExportMode::Cine2D));
+    impl_->modeCombo->addItem(tr("3D Rotation"), static_cast<int>(ExportMode::Rotation3D));
+    impl_->modeCombo->addItem(tr("3D Combined (Rotation + Phase)"), static_cast<int>(ExportMode::Combined));
+
+    // Disable cine modes if no temporal data
+    if (impl_->totalPhases < 1) {
+        impl_->modeCombo->model()->setData(
+            impl_->modeCombo->model()->index(0, 0), false, Qt::UserRole - 1);
+        impl_->modeCombo->model()->setData(
+            impl_->modeCombo->model()->index(2, 0), false, Qt::UserRole - 1);
+        impl_->modeCombo->setCurrentIndex(1);  // Default to 3D Rotation
+    }
+
+    commonForm->addRow(tr("Export Mode:"), impl_->modeCombo);
+
+    // Output path
+    auto* pathLayout = new QHBoxLayout;
+    impl_->outputPathEdit = new QLineEdit;
+    impl_->outputPathEdit->setPlaceholderText(tr("Select output file..."));
+    impl_->browseButton = new QPushButton(tr("Browse..."));
+    pathLayout->addWidget(impl_->outputPathEdit);
+    pathLayout->addWidget(impl_->browseButton);
+    commonForm->addRow(tr("Output File:"), pathLayout);
+
+    // Resolution
+    impl_->resolutionCombo = new QComboBox;
+    for (const auto& res : Impl::kResolutions) {
+        impl_->resolutionCombo->addItem(res.label);
+    }
+    commonForm->addRow(tr("Resolution:"), impl_->resolutionCombo);
+
+    // FPS
+    impl_->fpsSpin = new QSpinBox;
+    impl_->fpsSpin->setRange(1, 120);
+    impl_->fpsSpin->setValue(15);
+    impl_->fpsSpin->setSuffix(tr(" fps"));
+    commonForm->addRow(tr("Frame Rate:"), impl_->fpsSpin);
+
+    mainLayout->addWidget(commonGroup);
+
+    // --- Mode-specific settings ---
+    impl_->modeStack = new QStackedWidget;
+
+    // Page 0: Cine2D
+    auto* cinePage = new QGroupBox(tr("Cine Settings"));
+    auto* cineForm = new QFormLayout(cinePage);
+
+    impl_->cineStartPhaseSpin = new QSpinBox;
+    impl_->cineStartPhaseSpin->setRange(0, std::max(0, impl_->totalPhases - 1));
+    impl_->cineStartPhaseSpin->setValue(0);
+    cineForm->addRow(tr("Start Phase:"), impl_->cineStartPhaseSpin);
+
+    impl_->cineEndPhaseSpin = new QSpinBox;
+    impl_->cineEndPhaseSpin->setRange(-1, std::max(0, impl_->totalPhases - 1));
+    impl_->cineEndPhaseSpin->setValue(-1);
+    impl_->cineEndPhaseSpin->setSpecialValueText(tr("Last"));
+    cineForm->addRow(tr("End Phase:"), impl_->cineEndPhaseSpin);
+
+    impl_->cineLoopsSpin = new QSpinBox;
+    impl_->cineLoopsSpin->setRange(1, 10);
+    impl_->cineLoopsSpin->setValue(1);
+    cineForm->addRow(tr("Loops:"), impl_->cineLoopsSpin);
+
+    impl_->cineFramesPerPhaseSpin = new QSpinBox;
+    impl_->cineFramesPerPhaseSpin->setRange(1, 10);
+    impl_->cineFramesPerPhaseSpin->setValue(1);
+    cineForm->addRow(tr("Frames per Phase:"), impl_->cineFramesPerPhaseSpin);
+
+    impl_->modeStack->addWidget(cinePage);
+
+    // Page 1: Rotation3D
+    auto* rotPage = new QGroupBox(tr("Rotation Settings"));
+    auto* rotForm = new QFormLayout(rotPage);
+
+    impl_->rotStartAngleSpin = new QDoubleSpinBox;
+    impl_->rotStartAngleSpin->setRange(-720.0, 720.0);
+    impl_->rotStartAngleSpin->setValue(0.0);
+    impl_->rotStartAngleSpin->setSuffix(tr("\u00B0"));
+    rotForm->addRow(tr("Start Angle:"), impl_->rotStartAngleSpin);
+
+    impl_->rotEndAngleSpin = new QDoubleSpinBox;
+    impl_->rotEndAngleSpin->setRange(-720.0, 720.0);
+    impl_->rotEndAngleSpin->setValue(360.0);
+    impl_->rotEndAngleSpin->setSuffix(tr("\u00B0"));
+    rotForm->addRow(tr("End Angle:"), impl_->rotEndAngleSpin);
+
+    impl_->rotElevationSpin = new QDoubleSpinBox;
+    impl_->rotElevationSpin->setRange(-90.0, 90.0);
+    impl_->rotElevationSpin->setValue(15.0);
+    impl_->rotElevationSpin->setSuffix(tr("\u00B0"));
+    rotForm->addRow(tr("Elevation:"), impl_->rotElevationSpin);
+
+    impl_->rotTotalFramesSpin = new QSpinBox;
+    impl_->rotTotalFramesSpin->setRange(2, 3600);
+    impl_->rotTotalFramesSpin->setValue(180);
+    rotForm->addRow(tr("Total Frames:"), impl_->rotTotalFramesSpin);
+
+    impl_->modeStack->addWidget(rotPage);
+
+    // Page 2: Combined
+    auto* combPage = new QGroupBox(tr("Combined Settings"));
+    auto* combForm = new QFormLayout(combPage);
+
+    impl_->combStartAngleSpin = new QDoubleSpinBox;
+    impl_->combStartAngleSpin->setRange(-720.0, 720.0);
+    impl_->combStartAngleSpin->setValue(0.0);
+    impl_->combStartAngleSpin->setSuffix(tr("\u00B0"));
+    combForm->addRow(tr("Start Angle:"), impl_->combStartAngleSpin);
+
+    impl_->combEndAngleSpin = new QDoubleSpinBox;
+    impl_->combEndAngleSpin->setRange(-720.0, 720.0);
+    impl_->combEndAngleSpin->setValue(360.0);
+    impl_->combEndAngleSpin->setSuffix(tr("\u00B0"));
+    combForm->addRow(tr("End Angle:"), impl_->combEndAngleSpin);
+
+    impl_->combElevationSpin = new QDoubleSpinBox;
+    impl_->combElevationSpin->setRange(-90.0, 90.0);
+    impl_->combElevationSpin->setValue(15.0);
+    impl_->combElevationSpin->setSuffix(tr("\u00B0"));
+    combForm->addRow(tr("Elevation:"), impl_->combElevationSpin);
+
+    impl_->combPhaseLoopsSpin = new QSpinBox;
+    impl_->combPhaseLoopsSpin->setRange(1, 10);
+    impl_->combPhaseLoopsSpin->setValue(1);
+    combForm->addRow(tr("Phase Loops:"), impl_->combPhaseLoopsSpin);
+
+    impl_->combFramesPerPhaseSpin = new QSpinBox;
+    impl_->combFramesPerPhaseSpin->setRange(1, 10);
+    impl_->combFramesPerPhaseSpin->setValue(1);
+    combForm->addRow(tr("Frames per Phase:"), impl_->combFramesPerPhaseSpin);
+
+    impl_->modeStack->addWidget(combPage);
+
+    mainLayout->addWidget(impl_->modeStack);
+
+    // --- Button box ---
+    impl_->buttonBox = new QDialogButtonBox(
+        QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+    mainLayout->addWidget(impl_->buttonBox);
+}
+
+void VideoExportDialog::setupConnections()
+{
+    connect(impl_->modeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &VideoExportDialog::onModeChanged);
+    connect(impl_->browseButton, &QPushButton::clicked,
+            this, &VideoExportDialog::onBrowseOutput);
+    connect(impl_->buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(impl_->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+}
+
+void VideoExportDialog::updateModeOptions()
+{
+    int idx = impl_->modeCombo->currentIndex();
+    impl_->modeStack->setCurrentIndex(idx);
+
+    // Set default FPS based on mode
+    if (idx == 0) {
+        impl_->fpsSpin->setValue(15);   // Cine: slower
+    } else {
+        impl_->fpsSpin->setValue(30);   // Rotation/Combined: smoother
+    }
+}
+
+// =========================================================================
+// Slots
+// =========================================================================
+
+void VideoExportDialog::onModeChanged(int /*index*/)
+{
+    updateModeOptions();
+}
+
+void VideoExportDialog::onBrowseOutput()
+{
+    QString filePath = QFileDialog::getSaveFileName(
+        this, tr("Save Video"), QString(),
+        tr("OGG Theora Video (*.ogv);;All Files (*)"));
+    if (!filePath.isEmpty()) {
+        impl_->outputPathEdit->setText(filePath);
+    }
+}
+
+// =========================================================================
+// Accessors
+// =========================================================================
+
+VideoExportDialog::ExportMode VideoExportDialog::exportMode() const
+{
+    return static_cast<ExportMode>(
+        impl_->modeCombo->currentData().toInt());
+}
+
+std::filesystem::path VideoExportDialog::outputPath() const
+{
+    return std::filesystem::path(
+        impl_->outputPathEdit->text().toStdString());
+}
+
+services::VideoExporter::CineConfig
+VideoExportDialog::buildCineConfig() const
+{
+    auto [w, h] = impl_->selectedResolution();
+    services::VideoExporter::CineConfig config;
+    config.outputPath = outputPath();
+    config.width = w;
+    config.height = h;
+    config.fps = impl_->fpsSpin->value();
+    config.startPhase = impl_->cineStartPhaseSpin->value();
+    config.endPhase = impl_->cineEndPhaseSpin->value();
+    config.totalPhases = impl_->totalPhases;
+    config.loops = impl_->cineLoopsSpin->value();
+    config.framesPerPhase = impl_->cineFramesPerPhaseSpin->value();
+    return config;
+}
+
+services::VideoExporter::RotationConfig
+VideoExportDialog::buildRotationConfig() const
+{
+    auto [w, h] = impl_->selectedResolution();
+    services::VideoExporter::RotationConfig config;
+    config.outputPath = outputPath();
+    config.width = w;
+    config.height = h;
+    config.fps = impl_->fpsSpin->value();
+    config.startAngle = impl_->rotStartAngleSpin->value();
+    config.endAngle = impl_->rotEndAngleSpin->value();
+    config.elevation = impl_->rotElevationSpin->value();
+    config.totalFrames = impl_->rotTotalFramesSpin->value();
+    return config;
+}
+
+services::VideoExporter::CombinedConfig
+VideoExportDialog::buildCombinedConfig() const
+{
+    auto [w, h] = impl_->selectedResolution();
+    services::VideoExporter::CombinedConfig config;
+    config.outputPath = outputPath();
+    config.width = w;
+    config.height = h;
+    config.fps = impl_->fpsSpin->value();
+    config.startAngle = impl_->combStartAngleSpin->value();
+    config.endAngle = impl_->combEndAngleSpin->value();
+    config.elevation = impl_->combElevationSpin->value();
+    config.totalPhases = impl_->totalPhases;
+    config.phaseLoops = impl_->combPhaseLoopsSpin->value();
+    config.framesPerPhase = impl_->combFramesPerPhaseSpin->value();
+    return config;
+}
+
+} // namespace dicom_viewer::ui

--- a/src/ui/widgets/viewport_widget.cpp
+++ b/src/ui/widgets/viewport_widget.cpp
@@ -469,6 +469,11 @@ void ViewportWidget::resetCamera()
     impl_->vtkWidget->renderWindow()->Render();
 }
 
+vtkRenderWindow* ViewportWidget::getRenderWindow() const
+{
+    return impl_->renderWindow;
+}
+
 bool ViewportWidget::captureScreenshot(const QString& filePath)
 {
     auto windowToImage = vtkSmartPointer<vtkWindowToImageFilter>::New();


### PR DESCRIPTION
Closes #402

## Summary
- Add `VideoExportDialog` with mode selection (2D Cine, 3D Rotation, Combined), resolution presets, FPS configuration, and mode-specific parameters
- Add `getRenderWindow()` public method to `ViewportWidget` for render window access
- Add "Save Movie..." action to Export menu with `Ctrl+Alt+M` shortcut
- Wire `QProgressDialog` for real-time progress feedback during video export
- Cine modes auto-disabled when no temporal data is loaded

## Architecture
```
Export Menu → "Save Movie..." → VideoExportDialog
                                    ↓ (on Accept)
                               VideoExporter.exportCine2D()
                               VideoExporter.exportRotation3D()
                               VideoExporter.exportCombined3D()
                                    ↓ (progress callback)
                               QProgressDialog (modal)
```

## Test Plan
- [x] Full build succeeds (100% targets built)
- [x] All 49 VideoExporter unit tests pass
- [x] All 3042/3056 tests pass (14 pre-existing failures unrelated)
- [ ] Manual: Open app → Export → Save Movie → configure and export