### PR TITLE
feat(ui): add IntroPage widget with import buttons and MainWindow integration (#406)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -640,8 +640,10 @@ add_library(dicom_viewer_ui STATIC
     src/ui/widgets/flow_graph_widget.cpp
     src/ui/widgets/workflow_tab_bar.cpp
     src/ui/panels/workflow_panel.cpp
+    src/ui/intro_page.cpp
     # Headers with Q_OBJECT for AUTOMOC
     include/ui/main_window.hpp
+    include/ui/intro_page.hpp
     include/ui/viewport_widget.hpp
     include/ui/viewport_layout_manager.hpp
     include/ui/mpr_view_widget.hpp

--- a/include/ui/intro_page.hpp
+++ b/include/ui/intro_page.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <memory>
+#include <QWidget>
+
+namespace dicom_viewer::ui {
+
+/**
+ * @brief Landing page shown on application startup
+ *
+ * Provides quick access to DICOM import, project opening,
+ * and PACS connection before any data is loaded.
+ *
+ * @trace SRS-FR-039
+ */
+class IntroPage : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit IntroPage(QWidget* parent = nullptr);
+    ~IntroPage() override;
+
+    // Non-copyable
+    IntroPage(const IntroPage&) = delete;
+    IntroPage& operator=(const IntroPage&) = delete;
+
+signals:
+    /// User clicked "Import DICOM Folder"
+    void importFolderRequested();
+
+    /// User clicked "Import DICOM File"
+    void importFileRequested();
+
+    /// User clicked "Connect to PACS"
+    void importPacsRequested();
+
+    /// User clicked "Open Project"
+    void openProjectRequested();
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::ui

--- a/src/ui/intro_page.cpp
+++ b/src/ui/intro_page.cpp
@@ -1,0 +1,127 @@
+#include "ui/intro_page.hpp"
+
+#include <QFont>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QStyle>
+#include <QVBoxLayout>
+
+namespace dicom_viewer::ui {
+
+// =========================================================================
+// Pimpl
+// =========================================================================
+
+class IntroPage::Impl {
+public:
+    QLabel* logoLabel = nullptr;
+    QLabel* versionLabel = nullptr;
+
+    QPushButton* importFolderBtn = nullptr;
+    QPushButton* importFileBtn = nullptr;
+    QPushButton* importPacsBtn = nullptr;
+    QPushButton* openProjectBtn = nullptr;
+};
+
+// =========================================================================
+// Construction
+// =========================================================================
+
+IntroPage::IntroPage(QWidget* parent)
+    : QWidget(parent)
+    , impl_(std::make_unique<Impl>())
+{
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(60, 40, 60, 40);
+
+    // Top spacer
+    root->addStretch(2);
+
+    // Logo / title area
+    impl_->logoLabel = new QLabel(tr("DICOM Viewer"));
+    QFont titleFont = impl_->logoLabel->font();
+    titleFont.setPointSize(28);
+    titleFont.setBold(true);
+    impl_->logoLabel->setFont(titleFont);
+    impl_->logoLabel->setAlignment(Qt::AlignCenter);
+    root->addWidget(impl_->logoLabel);
+
+    impl_->versionLabel = new QLabel(tr("Medical Imaging Workstation"));
+    impl_->versionLabel->setAlignment(Qt::AlignCenter);
+    QFont subFont = impl_->versionLabel->font();
+    subFont.setPointSize(12);
+    impl_->versionLabel->setFont(subFont);
+    impl_->versionLabel->setStyleSheet("color: #888;");
+    root->addWidget(impl_->versionLabel);
+
+    root->addSpacing(40);
+
+    // Button area — two columns
+    auto* buttonArea = new QHBoxLayout();
+    buttonArea->setSpacing(40);
+
+    // Left column: DICOM import
+    auto* importCol = new QVBoxLayout();
+    auto* importHeader = new QLabel(tr("Import DICOM"));
+    QFont headerFont = importHeader->font();
+    headerFont.setPointSize(14);
+    headerFont.setBold(true);
+    importHeader->setFont(headerFont);
+    importCol->addWidget(importHeader);
+
+    impl_->importFolderBtn = new QPushButton(
+        style()->standardIcon(QStyle::SP_DirOpenIcon),
+        tr("  Import Folder..."));
+    impl_->importFolderBtn->setMinimumHeight(36);
+    importCol->addWidget(impl_->importFolderBtn);
+
+    impl_->importFileBtn = new QPushButton(
+        style()->standardIcon(QStyle::SP_FileIcon),
+        tr("  Import File..."));
+    impl_->importFileBtn->setMinimumHeight(36);
+    importCol->addWidget(impl_->importFileBtn);
+
+    impl_->importPacsBtn = new QPushButton(
+        style()->standardIcon(QStyle::SP_DriveNetIcon),
+        tr("  Connect to PACS..."));
+    impl_->importPacsBtn->setMinimumHeight(36);
+    importCol->addWidget(impl_->importPacsBtn);
+
+    importCol->addStretch(1);
+    buttonArea->addLayout(importCol);
+
+    // Right column: Project
+    auto* projectCol = new QVBoxLayout();
+    auto* projectHeader = new QLabel(tr("Project"));
+    projectHeader->setFont(headerFont);
+    projectCol->addWidget(projectHeader);
+
+    impl_->openProjectBtn = new QPushButton(
+        style()->standardIcon(QStyle::SP_DialogOpenButton),
+        tr("  Open Project..."));
+    impl_->openProjectBtn->setMinimumHeight(36);
+    projectCol->addWidget(impl_->openProjectBtn);
+
+    projectCol->addStretch(1);
+    buttonArea->addLayout(projectCol);
+
+    root->addLayout(buttonArea);
+
+    // Bottom spacer
+    root->addStretch(3);
+
+    // Wire buttons to signals
+    connect(impl_->importFolderBtn, &QPushButton::clicked,
+            this, &IntroPage::importFolderRequested);
+    connect(impl_->importFileBtn, &QPushButton::clicked,
+            this, &IntroPage::importFileRequested);
+    connect(impl_->importPacsBtn, &QPushButton::clicked,
+            this, &IntroPage::importPacsRequested);
+    connect(impl_->openProjectBtn, &QPushButton::clicked,
+            this, &IntroPage::openProjectRequested);
+}
+
+IntroPage::~IntroPage() = default;
+
+} // namespace dicom_viewer::ui


### PR DESCRIPTION
Closes #406

## Summary
- Add `IntroPage` widget as the landing page shown on application startup
- Implement two-column button layout: Import DICOM (Folder, File, PACS) and Project (Open)
- Integrate with `MainWindow` using `QStackedWidget` for page switching between IntroPage and viewer
- Wire IntroPage signals to existing MainWindow import/open slots
- Automatically switch to viewer page after successful DICOM load or project open

## Changes
- `include/ui/intro_page.hpp` — New IntroPage widget header with Q_OBJECT macro and 4 signals
- `src/ui/intro_page.cpp` — Full implementation with Pimpl idiom, logo area, and button layout
- `src/ui/main_window.cpp` — QStackedWidget integration, IntroPage signal connections, page switching
- `CMakeLists.txt` — Add intro_page source and AUTOMOC header

## Test Plan
- [x] Build succeeds — CI "Build & Test" passed
- [x] All tests pass — CI "Test Results" passed (3039/3056, 17 pre-existing failures)
- [x] IntroPage appears on startup — verified `QStackedWidget::setCurrentIndex(0)` with IntroPage at index 0
- [x] Click "Import Folder" and viewer page loads — signal wired to `onOpenDirectory()` which calls `setCurrentIndex(1)`
- [x] Click "Open Project" and project loading transitions to viewer — signal wired to `onOpenProject()` which calls `setCurrentIndex(1)`
- [ ] ~Click "Import File" and verify single file import works~ — signal correctly wired to `onOpenFile()`, but handler is incomplete (pre-existing TODO; no page transition). Out of scope for this PR.