### PR TITLE
feat(ui): add recent projects list and Close Case action to IntroPage (#408)

### DIFF
--- a/include/ui/intro_page.hpp
+++ b/include/ui/intro_page.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <QStringList>
 #include <QWidget>
 
 namespace dicom_viewer::ui {
@@ -9,7 +10,7 @@ namespace dicom_viewer::ui {
  * @brief Landing page shown on application startup
  *
  * Provides quick access to DICOM import, project opening,
- * and PACS connection before any data is loaded.
+ * recent project list, and PACS connection before any data is loaded.
  *
  * @trace SRS-FR-039
  */
@@ -24,6 +25,9 @@ public:
     IntroPage(const IntroPage&) = delete;
     IntroPage& operator=(const IntroPage&) = delete;
 
+    /// Update the recent projects list displayed in the right column
+    void setRecentProjects(const QStringList& paths);
+
 signals:
     /// User clicked "Import DICOM Folder"
     void importFolderRequested();
@@ -36,6 +40,9 @@ signals:
 
     /// User clicked "Open Project"
     void openProjectRequested();
+
+    /// User clicked on a recent project entry
+    void openRecentRequested(const QString& path);
 
 private:
     class Impl;

--- a/include/ui/main_window.hpp
+++ b/include/ui/main_window.hpp
@@ -89,6 +89,7 @@ private:
     void uncheckAllMeasurementActions();
     void updateWindowTitle();
     void updateRecentProjectsMenu();
+    void updateIntroPageRecentProjects();
     bool promptSaveIfModified();
 
     class Impl;


### PR DESCRIPTION
Closes #408

## Summary
- Add `QListWidget` showing recent projects in IntroPage right column with file name display and tooltip with full path
- Add `setRecentProjects(const QStringList&)` method and `openRecentRequested(const QString&)` signal to IntroPage
- Add "Close Case" menu action (`Ctrl+W`) in File menu that returns from viewer to IntroPage
- Wire IntroPage recent project double-clicks to project loading with page transition
- Synchronize recent projects list on startup and after every project open/save operation

## Changes
- `include/ui/intro_page.hpp` — Add `setRecentProjects()` method and `openRecentRequested` signal
- `src/ui/intro_page.cpp` — Add QListWidget with recent projects, double-click handler, visibility toggling
- `include/ui/main_window.hpp` — Add `updateIntroPageRecentProjects()` declaration
- `src/ui/main_window.cpp` — Add Close Case action, recent projects sync, signal connections

## Test Plan
- [x] Build succeeds (cmake --build 100%)
- [x] All tests pass (3039/3056, 17 pre-existing failures)
- [x] Close Case action exists in File menu with Ctrl+W shortcut (code verified)
- [x] Close Case is disabled when on IntroPage, enabled after loading data (code verified)
- [x] Recent projects list populated from ProjectManager on startup (code verified)
- [x] Double-clicking recent project opens it and transitions to viewer (code verified)
- [ ] Visual verification: recent projects appear in IntroPage right column