### PR TITLE
feat(ui): embed SegmentationPanel and ReportPanel into WorkflowPanel (#410)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -640,6 +640,7 @@ add_library(dicom_viewer_ui STATIC
     src/ui/widgets/flow_graph_widget.cpp
     src/ui/widgets/workflow_tab_bar.cpp
     src/ui/panels/workflow_panel.cpp
+    src/ui/panels/report_panel.cpp
     src/ui/intro_page.cpp
     # Headers with Q_OBJECT for AUTOMOC
     include/ui/main_window.hpp
@@ -665,6 +666,7 @@ add_library(dicom_viewer_ui STATIC
     include/ui/widgets/flow_graph_widget.hpp
     include/ui/widgets/workflow_tab_bar.hpp
     include/ui/panels/workflow_panel.hpp
+    include/ui/panels/report_panel.hpp
 )
 
 target_link_libraries(dicom_viewer_ui PUBLIC

--- a/include/ui/panels/report_panel.hpp
+++ b/include/ui/panels/report_panel.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <memory>
+#include <QWidget>
+
+namespace dicom_viewer::ui {
+
+/**
+ * @brief Report and export panel for the workflow Report stage
+ *
+ * Provides quick-access buttons for all export operations:
+ * Screenshot, Movie, MATLAB, Ensight, DICOM, and Report generation.
+ * Designed to be embedded in WorkflowPanel as the Report tab content.
+ *
+ * @trace SRS-FR-039
+ */
+class ReportPanel : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ReportPanel(QWidget* parent = nullptr);
+    ~ReportPanel() override;
+
+    // Non-copyable
+    ReportPanel(const ReportPanel&) = delete;
+    ReportPanel& operator=(const ReportPanel&) = delete;
+
+signals:
+    /// User clicked "Save Screenshot"
+    void screenshotRequested();
+
+    /// User clicked "Save Movie"
+    void movieRequested();
+
+    /// User clicked "Export MATLAB"
+    void matlabExportRequested();
+
+    /// User clicked "Export Ensight"
+    void ensightExportRequested();
+
+    /// User clicked "Export DICOM"
+    void dicomExportRequested();
+
+    /// User clicked "Generate Report"
+    void reportGenerationRequested();
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::ui

--- a/src/ui/panels/report_panel.cpp
+++ b/src/ui/panels/report_panel.cpp
@@ -1,0 +1,123 @@
+#include "ui/panels/report_panel.hpp"
+
+#include <QFont>
+#include <QLabel>
+#include <QPushButton>
+#include <QStyle>
+#include <QVBoxLayout>
+
+namespace dicom_viewer::ui {
+
+// =========================================================================
+// Pimpl
+// =========================================================================
+
+class ReportPanel::Impl {
+public:
+    QPushButton* screenshotBtn = nullptr;
+    QPushButton* movieBtn = nullptr;
+    QPushButton* matlabBtn = nullptr;
+    QPushButton* ensightBtn = nullptr;
+    QPushButton* dicomBtn = nullptr;
+    QPushButton* reportBtn = nullptr;
+};
+
+// =========================================================================
+// Construction
+// =========================================================================
+
+ReportPanel::ReportPanel(QWidget* parent)
+    : QWidget(parent)
+    , impl_(std::make_unique<Impl>())
+{
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(8, 8, 8, 8);
+    layout->setSpacing(6);
+
+    // Section header: Image Capture
+    auto* captureHeader = new QLabel(tr("Image Capture"));
+    QFont headerFont = captureHeader->font();
+    headerFont.setBold(true);
+    captureHeader->setFont(headerFont);
+    layout->addWidget(captureHeader);
+
+    impl_->screenshotBtn = new QPushButton(
+        style()->standardIcon(QStyle::SP_DesktopIcon),
+        tr("  Save Screenshot..."));
+    impl_->screenshotBtn->setMinimumHeight(32);
+    impl_->screenshotBtn->setToolTip(tr("Capture viewport as image (Ctrl+Alt+S)"));
+    layout->addWidget(impl_->screenshotBtn);
+
+    impl_->movieBtn = new QPushButton(
+        style()->standardIcon(QStyle::SP_MediaPlay),
+        tr("  Save Movie..."));
+    impl_->movieBtn->setMinimumHeight(32);
+    impl_->movieBtn->setToolTip(tr("Export cine or 3D rotation as video"));
+    layout->addWidget(impl_->movieBtn);
+
+    layout->addSpacing(8);
+
+    // Section header: Data Export
+    auto* exportHeader = new QLabel(tr("Data Export"));
+    exportHeader->setFont(headerFont);
+    layout->addWidget(exportHeader);
+
+    impl_->matlabBtn = new QPushButton(
+        style()->standardIcon(QStyle::SP_FileIcon),
+        tr("  Export MATLAB..."));
+    impl_->matlabBtn->setMinimumHeight(32);
+    impl_->matlabBtn->setToolTip(tr("Export velocity fields as MATLAB .mat files"));
+    layout->addWidget(impl_->matlabBtn);
+
+    impl_->ensightBtn = new QPushButton(
+        style()->standardIcon(QStyle::SP_FileIcon),
+        tr("  Export Ensight..."));
+    impl_->ensightBtn->setMinimumHeight(32);
+    impl_->ensightBtn->setToolTip(tr("Export as Ensight format (not yet implemented)"));
+    impl_->ensightBtn->setEnabled(false);
+    layout->addWidget(impl_->ensightBtn);
+
+    impl_->dicomBtn = new QPushButton(
+        style()->standardIcon(QStyle::SP_FileIcon),
+        tr("  Export DICOM..."));
+    impl_->dicomBtn->setMinimumHeight(32);
+    impl_->dicomBtn->setToolTip(tr("Export as DICOM (not yet implemented)"));
+    impl_->dicomBtn->setEnabled(false);
+    layout->addWidget(impl_->dicomBtn);
+
+    layout->addSpacing(8);
+
+    // Section header: Report
+    auto* reportHeader = new QLabel(tr("Report"));
+    reportHeader->setFont(headerFont);
+    layout->addWidget(reportHeader);
+
+    impl_->reportBtn = new QPushButton(
+        style()->standardIcon(QStyle::SP_FileDialogDetailedView),
+        tr("  Generate Report..."));
+    impl_->reportBtn->setMinimumHeight(32);
+    impl_->reportBtn->setToolTip(tr("Generate analysis report (not yet implemented)"));
+    impl_->reportBtn->setEnabled(false);
+    layout->addWidget(impl_->reportBtn);
+
+    // Push everything to the top
+    layout->addStretch(1);
+
+    // Wire buttons to signals
+    connect(impl_->screenshotBtn, &QPushButton::clicked,
+            this, &ReportPanel::screenshotRequested);
+    connect(impl_->movieBtn, &QPushButton::clicked,
+            this, &ReportPanel::movieRequested);
+    connect(impl_->matlabBtn, &QPushButton::clicked,
+            this, &ReportPanel::matlabExportRequested);
+    connect(impl_->ensightBtn, &QPushButton::clicked,
+            this, &ReportPanel::ensightExportRequested);
+    connect(impl_->dicomBtn, &QPushButton::clicked,
+            this, &ReportPanel::dicomExportRequested);
+    connect(impl_->reportBtn, &QPushButton::clicked,
+            this, &ReportPanel::reportGenerationRequested);
+}
+
+ReportPanel::~ReportPanel() = default;
+
+} // namespace dicom_viewer::ui


### PR DESCRIPTION
Closes #410

## Summary
- Move SegmentationPanel from a separate QDockWidget into WorkflowPanel's Segmentation tab via `setStageWidget()`
- Create new ReportPanel widget with export buttons (Screenshot, Movie, MATLAB, Ensight, DICOM, Report)
- Wire ReportPanel signals to existing Export menu actions for consistent behavior
- Remove `segmentationPanelDock` and its View menu toggle, re-number panel keyboard shortcuts (Ctrl+4→Phase, Ctrl+5→Overlay, Ctrl+6→Flow)
- Update `onResetLayout()` to reflect removed dock

## Test Plan
- [x] Application builds without errors — CI "Build & Test" passed
- [x] All existing tests pass (3039/3056, 17 pre-existing failures) — CI "Test Results" passed
- [x] Segmentation tab shows SegmentationPanel with brush tools — `setStageWidget(Segmentation, segmentationPanel)` at main_window.cpp:1044
- [x] Report tab shows export buttons (Screenshot, Movie, MATLAB enabled; Ensight, DICOM, Report disabled) — `setStageWidget(Report, reportPanel)` at main_window.cpp:1049; disabled buttons confirmed in report_panel.cpp:77,85,100
- [x] Clicking Screenshot/Movie/MATLAB buttons in Report tab triggers the same dialog as Export menu — signals wired to `QAction::trigger` at main_window.cpp:1380-1385
- [x] View > Panels menu no longer has "Segmentation Panel" toggle — `toggleSegmentationPanelAction` fully removed (0 references)
- [x] Reset Layout restores correct dock arrangement without segmentation dock — `onResetLayout()` has no `segmentationPanelDock` references