### PR TITLE
feat(ui): integrate DropHandler for drag-and-drop DICOM and project import (#259)

### DIFF
--- a/include/ui/main_window.hpp
+++ b/include/ui/main_window.hpp
@@ -91,6 +91,8 @@ private:
     void updateRecentProjectsMenu();
     void updateIntroPageRecentProjects();
     bool promptSaveIfModified();
+    void importDicomDirectory(const QString& dir);
+    void importProjectFile(const QString& path);
 
     class Impl;
     std::unique_ptr<Impl> impl_;


### PR DESCRIPTION
Closes #259

## Summary
- Wire existing `DropHandler` event filter to `MainWindow::centralStack`, enabling drag-and-drop of DICOM folders and `.flo` project files
- Extract `importDicomDirectory(const QString&)` from `onOpenDirectory()` for reuse by both menu action and drop signal
- Extract `importProjectFile(const QString&)` from `onOpenProject()`, also used by `openRecentRequested` and drop signal
- `projectFileDropped` checks `promptSaveIfModified()` before loading, matching the existing menu-driven flow

## Test Plan
- [x] CI Build & Test passes
- [x] CI Test Results show no new failures (17 pre-existing)
- [x] `DropHandler` is created with `centralStack` as target in `setupConnections()`
- [x] `dicomFolderDropped` signal connected to `importDicomDirectory`
- [x] `projectFileDropped` signal connected with `promptSaveIfModified()` guard
- [x] `onOpenDirectory()` delegates to `importDicomDirectory()` after dialog
- [x] `onOpenProject()` delegates to `importProjectFile()` after dialog
- [x] `openRecentRequested` lambda uses `importProjectFile()` (no duplicated load logic)