### PR TITLE
feat(ui): add inline contour editing toolbar to QuantificationWindow (#391)

### DIFF
--- a/include/ui/quantification_window.hpp
+++ b/include/ui/quantification_window.hpp
@@ -265,6 +265,38 @@ public:
      */
     void clearVolumeStatistics();
 
+    // -- Inline contour editing API --
+
+    /**
+     * @brief Enable or disable inline contour editing tools
+     * @param enabled True to enable brush/eraser toolbar
+     */
+    void setEditingEnabled(bool enabled);
+
+    /**
+     * @brief Check if contour editing is enabled
+     */
+    [[nodiscard]] bool isEditingEnabled() const;
+
+    /**
+     * @brief Set undo/redo button enabled states
+     * @param canUndo True to enable undo button
+     * @param canRedo True to enable redo button
+     */
+    void setUndoRedoEnabled(bool canUndo, bool canRedo);
+
+    /**
+     * @brief Get current brush size
+     * @return Brush radius in pixels (1-20)
+     */
+    [[nodiscard]] int brushSize() const;
+
+    /**
+     * @brief Check if brush tool is active (vs eraser)
+     * @return True for brush, false for eraser
+     */
+    [[nodiscard]] bool isBrushActive() const;
+
     // -- Tab API --
 
     /**
@@ -321,6 +353,28 @@ signals:
      * @param index Plane index whose position changed
      */
     void planePositionChanged(int index);
+
+    /**
+     * @brief Emitted when the active editing tool changes
+     * @param isBrush True for brush, false for eraser
+     */
+    void editToolChanged(bool isBrush);
+
+    /**
+     * @brief Emitted when the brush size changes
+     * @param size New brush radius in pixels
+     */
+    void editBrushSizeChanged(int size);
+
+    /**
+     * @brief Emitted when user requests undo of a contour edit
+     */
+    void contourUndoRequested();
+
+    /**
+     * @brief Emitted when user requests redo of a contour edit
+     */
+    void contourRedoRequested();
 
 private:
     void setupUI();


### PR DESCRIPTION
Closes #391

## Summary
- Add Brush/Eraser toggle buttons (`QToolButton` + `QButtonGroup` exclusive) to the 2D Plane tab
- Add brush size `QSpinBox` (range 1-20, default 5)
- Add Undo/Redo buttons for contour edit operations
- Add contour view area placeholder (`QFrame`) for future VTK widget
- All editing controls start disabled; activate via `setEditingEnabled(true)`
- Expose signals: `editToolChanged`, `editBrushSizeChanged`, `contourUndoRequested`, `contourRedoRequested`
- Public API: `setEditingEnabled`, `isEditingEnabled`, `setUndoRedoEnabled`, `brushSize`, `isBrushActive`

## Test Plan
- [x] CI Build & Test passes
- [x] CI Test Results show no new failures (17 pre-existing)
- [x] Brush/Eraser buttons exist with exclusive toggle behavior
- [x] Brush size spinbox has range 1-20, default 5
- [x] Undo/Redo buttons start disabled
- [x] Edit toolbar starts disabled (setEditingEnabled default false)
- [x] All 4 signals declared in header and connected in setupConnections
- [x] Public getters (brushSize, isBrushActive, isEditingEnabled) implemented