### PR TITLE
feat(segmentation): add Level Tracing, Hollow, and Smoothing to SegmentationPanel UI (#255)

### DIFF
--- a/include/services/segmentation/manual_segmentation_controller.hpp
+++ b/include/services/segmentation/manual_segmentation_controller.hpp
@@ -19,13 +19,14 @@ namespace dicom_viewer::services {
  * @brief Available segmentation tools for manual drawing
  */
 enum class SegmentationTool {
-    None,         ///< No tool selected
-    Brush,        ///< Draw with circular/square brush
-    Eraser,       ///< Remove segmentation region
-    Fill,         ///< Flood fill closed region
-    Freehand,     ///< Draw freehand curve
-    Polygon,      ///< Polygon ROI
-    SmartScissors ///< Edge tracking (LiveWire)
+    None,          ///< No tool selected
+    Brush,         ///< Draw with circular/square brush
+    Eraser,        ///< Remove segmentation region
+    Fill,          ///< Flood fill closed region
+    Freehand,      ///< Draw freehand curve
+    Polygon,       ///< Polygon ROI
+    SmartScissors, ///< Edge tracking (LiveWire)
+    LevelTracing   ///< Edge-following contour at intensity boundary
 };
 
 /**

--- a/include/ui/panels/segmentation_panel.hpp
+++ b/include/ui/panels/segmentation_panel.hpp
@@ -131,6 +131,16 @@ signals:
      */
     void redoCommandRequested();
 
+    /**
+     * @brief Emitted when Hollow operation is requested on current mask
+     */
+    void hollowRequested();
+
+    /**
+     * @brief Emitted when Smoothing operation is requested on current mask
+     */
+    void smoothRequested();
+
 private slots:
     void onToolButtonClicked(int toolId);
     void onBrushSizeChanged(int size);

--- a/src/ui/panels/segmentation_panel.cpp
+++ b/src/ui/panels/segmentation_panel.cpp
@@ -27,6 +27,11 @@ public:
     QToolButton* freehandButton = nullptr;
     QToolButton* polygonButton = nullptr;
     QToolButton* smartScissorsButton = nullptr;
+    QToolButton* levelTracingButton = nullptr;
+
+    // Post-processing buttons
+    QPushButton* hollowButton = nullptr;
+    QPushButton* smoothButton = nullptr;
 
     // Brush settings
     QSlider* brushSizeSlider = nullptr;
@@ -142,12 +147,20 @@ void SegmentationPanel::setupUI()
     impl_->smartScissorsButton->setMinimumSize(60, 40);
     impl_->toolGroup->addButton(impl_->smartScissorsButton, static_cast<int>(services::SegmentationTool::SmartScissors));
 
+    impl_->levelTracingButton = new QToolButton();
+    impl_->levelTracingButton->setText(tr("Level\nTracing"));
+    impl_->levelTracingButton->setCheckable(true);
+    impl_->levelTracingButton->setMinimumSize(60, 40);
+    impl_->levelTracingButton->setToolTip(tr("Trace contour at intensity boundary"));
+    impl_->toolGroup->addButton(impl_->levelTracingButton, static_cast<int>(services::SegmentationTool::LevelTracing));
+
     toolsLayout->addWidget(impl_->brushButton, 0, 0);
     toolsLayout->addWidget(impl_->eraserButton, 0, 1);
     toolsLayout->addWidget(impl_->fillButton, 0, 2);
     toolsLayout->addWidget(impl_->freehandButton, 1, 0);
     toolsLayout->addWidget(impl_->polygonButton, 1, 1);
     toolsLayout->addWidget(impl_->smartScissorsButton, 1, 2);
+    toolsLayout->addWidget(impl_->levelTracingButton, 2, 0);
     mainLayout->addWidget(toolsGroup);
 
     // Brush options group
@@ -221,6 +234,17 @@ void SegmentationPanel::setupUI()
     actionsLayout->addWidget(impl_->completeButton);
     mainLayout->addWidget(impl_->polygonActionsWidget);
 
+    // Post-processing actions
+    auto postProcGroup = new QGroupBox(tr("Post-Processing"));
+    auto postProcLayout = new QHBoxLayout(postProcGroup);
+    impl_->hollowButton = new QPushButton(tr("Hollow"));
+    impl_->hollowButton->setToolTip(tr("Create hollow shell from solid mask"));
+    impl_->smoothButton = new QPushButton(tr("Smooth"));
+    impl_->smoothButton->setToolTip(tr("Smooth mask boundary (volume-preserving)"));
+    postProcLayout->addWidget(impl_->hollowButton);
+    postProcLayout->addWidget(impl_->smoothButton);
+    mainLayout->addWidget(postProcGroup);
+
     // History actions (Undo/Redo for command stack)
     auto historyGroup = new QGroupBox(tr("History"));
     auto historyLayout = new QHBoxLayout(historyGroup);
@@ -291,6 +315,12 @@ void SegmentationPanel::setupConnections()
             this, &SegmentationPanel::undoCommandRequested);
     connect(impl_->redoCommandButton, &QPushButton::clicked,
             this, &SegmentationPanel::redoCommandRequested);
+
+    // Post-processing
+    connect(impl_->hollowButton, &QPushButton::clicked,
+            this, &SegmentationPanel::hollowRequested);
+    connect(impl_->smoothButton, &QPushButton::clicked,
+            this, &SegmentationPanel::smoothRequested);
 }
 
 void SegmentationPanel::createToolSection() {}


### PR DESCRIPTION
Closes #255

## Summary
- Add `LevelTracing` to `SegmentationTool` enum in `manual_segmentation_controller.hpp`
- Add Level Tracing toggle button to the tool grid (row 3) in SegmentationPanel
- Add "Post-Processing" group box with Hollow and Smooth action buttons
- Wire Hollow and Smooth buttons to new `hollowRequested()` and `smoothRequested()` signals
- Existing controller switch statements have `default: break;` so no controller changes needed

## Test Plan
- [x] CI Build & Test passes
- [x] CI Test Results show no new failures (17 pre-existing)
- [x] `LevelTracing` value added to `SegmentationTool` enum
- [x] Level Tracing button in tool grid with checkable toggle behavior
- [x] Hollow and Smooth buttons in Post-Processing group box
- [x] `hollowRequested` and `smoothRequested` signals declared and connected
- [x] Existing segmentation tests pass (no enum breakage)