### PR TITLE
feat(segmentation): add Centerline Tracing tool UI to SegmentationPanel (#254)

### DIFF
--- a/include/services/segmentation/manual_segmentation_controller.hpp
+++ b/include/services/segmentation/manual_segmentation_controller.hpp
@@ -26,7 +26,8 @@ enum class SegmentationTool {
     Freehand,      ///< Draw freehand curve
     Polygon,       ///< Polygon ROI
     SmartScissors, ///< Edge tracking (LiveWire)
-    LevelTracing   ///< Edge-following contour at intensity boundary
+    LevelTracing,       ///< Edge-following contour at intensity boundary
+    CenterlineTracing   ///< Vessel centerline tracing between two points
 };
 
 /**

--- a/include/ui/panels/segmentation_panel.hpp
+++ b/include/ui/panels/segmentation_panel.hpp
@@ -141,6 +141,22 @@ signals:
      */
     void smoothRequested();
 
+    /**
+     * @brief Emitted when centerline radius override changes
+     * @param radiusMm Radius in mm (-1 for auto)
+     */
+    void centerlineRadiusChanged(double radiusMm);
+
+    /**
+     * @brief Emitted when centerline confirm is requested
+     */
+    void centerlineConfirmRequested();
+
+    /**
+     * @brief Emitted when centerline cancel is requested
+     */
+    void centerlineCancelRequested();
+
 private slots:
     void onToolButtonClicked(int toolId);
     void onBrushSizeChanged(int size);


### PR DESCRIPTION
Closes #254

## Summary
- Add `CenterlineTracing` to `SegmentationTool` enum in `manual_segmentation_controller.hpp`
- Add Centerline toggle button to the tool grid (row 3, column 2) in SegmentationPanel
- Add "Centerline Options" group box with radius spin box (0.5-30mm), auto radius checkbox, and Confirm/Cancel buttons
- Wire radius changes, confirm, and cancel to new signals (`centerlineRadiusChanged`, `centerlineConfirmRequested`, `centerlineCancelRequested`)
- Centerline Options group auto-shows/hides when tool is selected/deselected
- Existing controller switch statements have `default: break;` so no controller changes needed

## Test Plan
- [x] CI Build & Test passes
- [x] CI Test Results show no new failures (17 pre-existing)
- [x] `CenterlineTracing` value added to `SegmentationTool` enum
- [x] Centerline button in tool grid with checkable toggle behavior
- [x] Centerline Options group with radius, auto radius, confirm, and cancel controls
- [x] `centerlineRadiusChanged`, `centerlineConfirmRequested`, `centerlineCancelRequested` signals declared and connected
- [x] Centerline Options visibility toggles with tool selection
- [x] Existing segmentation tests pass (no enum breakage)