### PR TITLE
feat(ui): replace 3D Volume tab placeholder with VTK streamline visualization (#392)

### DIFF
--- a/include/ui/quantification_window.hpp
+++ b/include/ui/quantification_window.hpp
@@ -8,7 +8,10 @@
 #include <QMainWindow>
 #include <QRectF>
 
+#include <vtkSmartPointer.h>
+
 class QPainter;
+class vtkImageData;
 
 namespace dicom_viewer::ui {
 
@@ -296,6 +299,19 @@ public:
      * @return True for brush, false for eraser
      */
     [[nodiscard]] bool isBrushActive() const;
+
+    // -- 3D Volume visualization API --
+
+    /**
+     * @brief Set velocity field for 3D streamline rendering in Volume tab
+     * @param velocityField 3D vtkImageData with 3-component velocity vectors
+     */
+    void setVolumeVelocityField(vtkSmartPointer<vtkImageData> velocityField);
+
+    /**
+     * @brief Reset the 3D volume camera to fit all visible actors
+     */
+    void resetVolumeCamera();
 
     // -- Tab API --
 


### PR DESCRIPTION
Closes #392

## Summary
- Replace dashed-border QLabel placeholder in 3D Volume tab with `QVTKOpenGLNativeWidget`
- Set up `vtkGenericOpenGLRenderWindow` + `vtkRenderer` with dark background (0.1, 0.1, 0.15)
- Add `setVolumeVelocityField(vtkImageData*)` API that generates 3D streamlines using `vtkStreamTracer` with Runge-Kutta 4 integration and `vtkPointSource` seeding
- Add `resetVolumeCamera()` API for camera reset to fit all visible actors
- Interactive rotation and zoom provided by built-in VTK interactor (no additional code needed)
- Volume statistics table remains synchronized above the 3D view

## Test Plan
- [x] CI Build & Test passes
- [x] CI Test Results show no new failures (17 pre-existing)
- [x] QVTKOpenGLNativeWidget replaces QLabel placeholder in 3D Volume tab
- [x] vtkRenderer and vtkGenericOpenGLRenderWindow initialized in Impl
- [x] `setVolumeVelocityField()` creates streamline pipeline (vtkStreamTracer + vtkPolyDataMapper + vtkActor)
- [x] `resetVolumeCamera()` resets the 3D renderer camera
- [x] Volume statistics table still functional above 3D view
- [x] Existing QuantificationWindow tests pass (no regression)