### PR TITLE
docs: sync documentation with implemented codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **High-Performance Medical Image Viewer** - CT/MRI 3D Volume Rendering and MPR View Support
 
-[![Version](https://img.shields.io/badge/version-0.3.0--pre-orange)](https://github.com)
+[![Version](https://img.shields.io/badge/version-0.7.0--pre-orange)](https://github.com)
 [![C++](https://img.shields.io/badge/C++-23-blue.svg)](https://isocpp.org)
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-green.svg)](LICENSE)
 
@@ -78,6 +78,53 @@
 - Horizontal/Vertical flip
 - Grid view (multi-image comparison)
 
+### 4D Flow MRI Analysis (P1 - High)
+
+| Feature | Description |
+|---------|-------------|
+| **Flow DICOM Parsing** | Vendor-specific (Siemens, Philips, GE) 4D Flow DICOM parsing with VENC extraction |
+| **Velocity Field Assembly** | Vector field construction from velocity-encoded components with VENC scaling |
+| **Phase Correction** | Velocity aliasing unwrap, eddy current correction, Maxwell term correction |
+| **Flow Visualization** | Streamlines, pathlines, vector glyphs with color-mapped hemodynamic parameters |
+| **Flow Quantification** | Flow rate at cross-section, time-velocity curves, pressure gradient estimation |
+| **Hemodynamic Analysis** | Wall Shear Stress (WSS), Oscillatory Shear Index (OSI), Turbulent Kinetic Energy (TKE) |
+
+### Enhanced DICOM Support (P0 - Critical)
+
+| Feature | Description |
+|---------|-------------|
+| **Enhanced CT/MR IOD** | Multi-frame Enhanced DICOM parsing with per-frame functional groups |
+| **Frame Extraction** | Individual frame extraction from multi-frame pixel data |
+| **Series Classification** | Automatic classification of Enhanced series by type |
+
+### Cardiac CT Analysis (P1 - High)
+
+| Feature | Description |
+|---------|-------------|
+| **ECG-Gated Phases** | Cardiac phase detection and separation from ECG-gated CT |
+| **Coronary CTA** | Centerline extraction, CPR (Curved Planar Reformation), stenosis measurement |
+| **Calcium Scoring** | Agatston, volume, and mass calcium scores with per-artery breakdown |
+| **Cine MRI** | Multi-phase cardiac cine playback with orientation detection (SA, 2CH, 3CH, 4CH) |
+
+### Data Export and Interoperability (P1 - High)
+
+| Feature | Description |
+|---------|-------------|
+| **Image Export** | NRRD and DICOM format export with metadata preservation |
+| **Mesh Export** | STL (binary/ASCII), OBJ, PLY 3D mesh export |
+| **Measurement Export** | JSON, CSV serialization and DICOM Structured Report |
+| **Video Export** | AVI/MP4/MOV generation with configurable FPS and codec |
+| **Research Export** | MATLAB .mat and Ensight Gold format for external analysis |
+| **Report Generation** | PDF/HTML medical imaging reports with templates |
+
+### Project Management
+
+| Feature | Description |
+|---------|-------------|
+| **Project Files** | .flo project file format (ZIP-based container) |
+| **Save/Load** | Persist and restore display settings, segmentation, analysis results |
+| **Drag & Drop** | Drag-and-drop DICOM and project file import |
+
 ## Technology Stack
 
 | Component | Technology | Version |
@@ -100,7 +147,8 @@ DICOM Viewer adopts a **3-Layer Architecture** to maximize separation of concern
 ┌─────────────────────────────────────────────────────────────────────────┐
 │  Presentation Layer (Qt6)                                               │
 │  • MainWindow, ViewportWidget, PatientBrowser, ToolsPanel               │
-│  • SegmentationPanel, StatisticsPanel, PacsConfigDialog                 │
+│  • SegmentationPanel, StatisticsPanel, FlowToolPanel, ReportPanel       │
+│  • SettingsDialog, PacsConfigDialog, QuantificationWindow               │
 ├─────────────────────────────────────────────────────────────────────────┤
 │  Service Layer                                                          │
 │  • Render: VolumeRenderer, SurfaceRenderer, MPRRenderer (VTK)           │
@@ -108,7 +156,10 @@ DICOM Viewer adopts a **3-Layer Architecture** to maximize separation of concern
 │  • Measurement: Linear, Area, Volume, ROI Statistics, ShapeAnalyzer     │
 │  • Preprocessing: Gaussian, AnisotropicDiffusion, N4Bias, Resampler     │
 │  • PACS: DicomFind/Move/Store/Echo (pacs_system)                        │
-│  • Export: Report, MeshExporter, DicomSR, DataExporter                  │
+│  • Flow: FlowDicomParser, VelocityField, FlowVisualizer, Quantifier    │
+│  • Export: Report, MeshExporter, DicomSR, DataExporter, VideoExporter   │
+│  • Cardiac: PhaseDetector, CenterlineExtractor, CalciumScorer           │
+│  • Enhanced DICOM: EnhancedParser, FrameExtractor, SeriesClassifier     │
 ├─────────────────────────────────────────────────────────────────────────┤
 │  Core / Data Layer                                                      │
 │  • DicomLoader, SeriesBuilder, TransferSyntaxDecoder                    │
@@ -254,7 +305,10 @@ dicom_viewer/
 │   │   ├── preprocessing/          # Image filters (Gaussian, N4, etc.)
 │   │   ├── segmentation/           # Segmentation algorithms and label mgmt
 │   │   ├── pacs/                   # PACS connectivity (C-ECHO, C-FIND, etc.)
-│   │   ├── export/                 # Report generation, mesh/data export
+│   │   ├── export/                 # Report, mesh, data, video export
+│   │   ├── flow/                   # 4D Flow MRI analysis
+│   │   ├── enhanced_dicom/         # Enhanced DICOM IOD parsing
+│   │   ├── cardiac/                # Cardiac CT/MRI analysis
 │   │   └── coordinate/             # MPR coordinate transformations
 │   └── ui/                         # Qt UI Components
 │       ├── widgets/                # ViewportWidget, MPRViewWidget, DRViewer
@@ -280,18 +334,20 @@ dicom_viewer/
 ## Roadmap
 
 ```
-v0.1 → v0.2 → v0.3 (MVP) → v0.4 → v0.5 → v1.0
-───────────────────────────────────────────────
-Phase 1        Phase 2: Core     Phase 3
-Foundation     Features          Enhancement
+v0.1 → v0.2 → v0.3 (MVP) → v0.4 → v0.5 → v0.6 → v0.7 → v1.0
+──────────────────────────────────────────────────────────────────
+Phase 1        Phase 2: Core     Phase 3          Phase 4
+Foundation     Features          Enhancement      Advanced
 ```
 
-| Version | Goal | Key Features |
-|---------|------|--------------|
-| v0.3 (MVP) | CT/MRI Viewer | DICOM loading, Volume/Surface rendering, MPR, Presets |
-| v0.4 | Core Features | PACS integration, Measurement tools, Basic segmentation, Preprocessing |
-| v0.5 | Enhancement | DR/CR viewing, Advanced segmentation, Report generation |
-| v1.0 | Release | Stabilization, User settings, Layout persistence |
+| Version | Goal | Key Features | Status |
+|---------|------|--------------|--------|
+| v0.3 (MVP) | CT/MRI Viewer | DICOM loading, Volume/Surface rendering, MPR, Presets | ✅ Complete |
+| v0.4 | Core Features | PACS integration, Measurement tools, Basic segmentation, Preprocessing | ✅ Complete |
+| v0.5 | Enhancement | DR/CR viewing, Advanced segmentation, Report generation | ✅ Complete |
+| v0.6 | 4D Flow MRI | Flow DICOM parsing, Velocity field, Streamlines, Hemodynamic analysis | ✅ Complete |
+| v0.7 | Cardiac & Export | Enhanced DICOM, Cardiac CT, Cine MRI, Data export, Project management | ✅ Complete |
+| v1.0 | Release | Stabilization, Performance optimization, User documentation | Next target |
 
 ## Target Users
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,8 +1,8 @@
 # DICOM Viewer - Product Requirements Document (PRD)
 
-> **Version**: 0.5.0
+> **Version**: 0.6.0
 > **Created**: 2025-12-31
-> **Last Updated**: 2026-02-12
+> **Last Updated**: 2026-02-20
 > **Status**: Draft (Pre-release)
 > **Author**: Development Team
 
@@ -107,6 +107,7 @@
 | UC-14 | Radiologist | Calculate Agatston calcium score from non-contrast cardiac CT | P1 |
 | UC-15 | Radiologist | Evaluate cardiac wall motion from cine MRI with temporal playback | P2 |
 | UC-16 | Radiologist | Load Enhanced DICOM multi-frame dataset from modern Siemens/Philips scanner | P0 |
+| UC-17 | Researcher | Export segmentation as STL mesh, measurements as CSV, and generate PDF analysis report | P1 |
 
 ---
 
@@ -741,6 +742,18 @@
 | FR-017.3 | Short-axis stack and long-axis (2CH, 3CH, 4CH) view reconstruction | P2 |
 | FR-017.4 | Cardiac phase-matched display (synchronize multiple cine series) | P3 |
 
+#### FR-018: Data Export and Interoperability
+
+| Requirement | Description |
+|-------------|-------------|
+| FR-018.1 | Image data export in NRRD and DICOM formats with metadata preservation |
+| FR-018.2 | 3D mesh export in STL (binary/ASCII), OBJ, and PLY formats |
+| FR-018.3 | Measurement data serialization in JSON and CSV formats, DICOM Structured Report |
+| FR-018.4 | CFD interoperability export in Ensight Gold format for external analysis tools |
+| FR-018.5 | Research data export in MATLAB .mat format |
+| FR-018.6 | Video export (AVI/MP4/MOV) with configurable FPS, codec, and overlay options |
+| FR-018.7 | Medical report generation in PDF/HTML with customizable templates |
+
 ---
 
 ## 4. Non-Functional Requirements
@@ -979,29 +992,30 @@
 ### 7.1 Release Schedule
 
 ```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                          Release Timeline                                │
-├─────────────────────────────────────────────────────────────────────────┤
-│                                                                         │
-│   Phase 1: Foundation    Phase 2: Core     Phase 3: Enhance  Phase 4: Flow│
-│   ─────────────────      ──────────────   ────────────────   ────────────│
-│                                                                         │
-│   v0.1 ─┬─ v0.2 ─┬─ v0.3 ─┬─ v0.4 ─┬─ v0.5 ─┬─ v0.6 ─┬─ v1.0        │
-│   (Pre) │ (Pre)  │ (MVP)  │ (Core) │ (Enh)  │ (Flow) │ (Release)     │
-│   ┌─────┘  ┌─────┘  ┌─────┘  ┌─────┘  ┌─────┘  ┌─────┘               │
-│   │        │        │        │        │        │                       │
-│   Wk 1-2   Wk 3-4   Wk 5-8   Wk 9-12  Wk 13-16 Wk 17-24             │
-│                                                                         │
-│   • Project • DICOM  • MPR    • PACS   • DR/CR  • 4D Flow             │
-│     setup     load   • Volume   integr.• Adv.     DICOM               │
-│   • Basic  • ITK/     render.• Measure   segm.  • Flow viz            │
-│     UI       VTK    • Surface• Basic   • Quant.  • Quantify           │
-│              integr.   render.  segm.    analysis• WSS/TKE            │
-│                      • Presets         • Reports                       │
-│                                                                         │
-│   ※ v0.x.x: Pre-release (in development) / v1.0.0+: Official release  │
-│                                                                         │
-└─────────────────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                          Release Timeline                                        │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                 │
+│   Phase 1: Foundation    Phase 2: Core     Phase 3: Enhance  Phase 4: Advanced  │
+│   ─────────────────      ──────────────   ────────────────   ──────────────────  │
+│                                                                                 │
+│   v0.1 ─┬─ v0.2 ─┬─ v0.3 ─┬─ v0.4 ─┬─ v0.5 ─┬─ v0.6 ─┬─ v0.7 ─┬─ v1.0      │
+│   (Pre) │ (Pre)  │ (MVP)  │ (Core) │ (Enh)  │ (Flow) │(Card.) │ (Release)   │
+│         │        │  ✅    │  ✅    │  ✅    │  ✅    │  ✅    │              │
+│   ┌─────┘  ┌─────┘  ┌─────┘  ┌─────┘  ┌─────┘  ┌─────┘  ┌─────┘             │
+│   │        │        │        │        │        │        │                     │
+│   Wk 1-2   Wk 3-4   Wk 5-8   Wk 9-12  Wk 13-16 Wk 17-24 Wk 25-32           │
+│                                                                                 │
+│   • Project • DICOM  • MPR    • PACS   • DR/CR  • 4D Flow • Cardiac           │
+│     setup     load   • Volume   integr.• Adv.     DICOM    CT/MRI             │
+│   • Basic  • ITK/     render.• Measure   segm.  • Flow viz• Enhanced          │
+│     UI       VTK    • Surface• Basic   • Quant.  • Quantify  DICOM            │
+│              integr.   render.  segm.    analysis• WSS/TKE • Export            │
+│                      • Presets         • Reports                               │
+│                                                                                 │
+│   ※ v0.x.x: Pre-release (in development) / v1.0.0+: Official release          │
+│                                                                                 │
+└─────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ### 7.2 Milestone Details
@@ -1153,6 +1167,7 @@ For coordinate system information, see [03-itk-vtk-integration.md](reference/03-
 | 0.3.0 | 2026-02-11 | Development Team | Replaced DCMTK with pacs_system for DICOM network operations; version sync with build system |
 | 0.4.0 | 2026-02-11 | Development Team | Added FR-014 (4D Flow MRI Analysis) with 21 sub-requirements; added NFR-016~020 for tiered performance targets; added UC-11, UC-12; added Milestone 5 (v0.6.0) |
 | 0.5.0 | 2026-02-12 | Development Team | Added FR-015 (Enhanced DICOM IOD, 6 sub-reqs), FR-016 (Cardiac CT, 14 sub-reqs), FR-017 (Cine MRI, 4 sub-reqs); added NFR-021~024; added UC-13~16; added Milestone 6 (v0.7.0) |
+| 0.6.0 | 2026-02-20 | Development Team | Added FR-018 (Data Export and Interoperability, 7 sub-reqs); added UC-17; updated release timeline with completion status for v0.3-v0.7 |
 
 > **Note**: v0.x.x are Pre-release versions. Official releases start from v1.0.0.
 

--- a/docs/SDS.md
+++ b/docs/SDS.md
@@ -1,11 +1,11 @@
 # DICOM Viewer - Software Design Specification (SDS)
 
-> **Version**: 0.6.0
+> **Version**: 0.7.0
 > **Created**: 2025-12-31
-> **Last Updated**: 2026-02-12
+> **Last Updated**: 2026-02-20
 > **Status**: Draft (Pre-release)
 > **Author**: Development Team
-> **Based on**: [SRS v0.6.0](SRS.md), [PRD v0.5.0](PRD.md)
+> **Based on**: [SRS v0.7.0](SRS.md), [PRD v0.6.0](PRD.md)
 
 ---
 
@@ -20,6 +20,8 @@
 | 0.3.0 | 2026-02-11 | Development Team | Replaced DCMTK with pacs_system for DICOM network operations; version sync with build system |
 | 0.4.0 | 2026-02-11 | Development Team | Fixed SRS-FR traceability references; aligned with SRS v0.4.0 |
 | 0.5.0 | 2026-02-11 | Development Team | Added SDS-MOD-007 Flow Analysis Module with 4D Flow MRI support |
+| 0.6.0 | 2026-02-12 | Development Team | Added SDS-MOD-008 (Enhanced DICOM Module, 4 components), SDS-MOD-009 (Cardiac CT Analysis Module, 5 components); updated traceability matrices for SRS-FR-049~053 |
+| 0.7.0 | 2026-02-20 | Development Team | Updated implementation statuses for MOD-007/008/009 to Implemented; added SDS-MOD-010 Export Service Module (8 components); expanded MOD-002 with advanced segmentation tools, MOD-003 with hemodynamic renderers, MOD-006 with 20 additional UI components; updated traceability matrices |
 
 ### Referenced Documents
 
@@ -701,9 +703,9 @@ classDiagram
 
 ### SDS-MOD-002: Image Service Module
 
-**Traces to**: SRS-FR-001 ~ SRS-FR-004, SRS-FR-016 ~ SRS-FR-025, SRS-FR-041, SRS-FR-042
+**Traces to**: SRS-FR-001 ~ SRS-FR-004, SRS-FR-016 ~ SRS-FR-025, SRS-FR-041, SRS-FR-042, SRS-FR-055
 
-**Purpose**: Provide DICOM loading, preprocessing, segmentation, and conversion functionality
+**Purpose**: Provide DICOM loading, preprocessing, segmentation (including advanced tools), and conversion functionality
 
 **Components**:
 
@@ -724,6 +726,16 @@ classDiagram
 | ManualSegmentationController | Brush, eraser, fill, smart scissors | SRS-FR-023 |
 | MorphologicalProcessor | Erosion, dilation, opening, closing | SRS-FR-025 |
 | LabelManager | Multi-label management and merging | SRS-FR-024 |
+| CenterlineTracer | Vessel centerline extraction between seed points | SRS-FR-055 |
+| LevelTracingTool | Edge-following contour at intensity boundary | SRS-FR-055 |
+| HollowTool | Hollow shell creation with configurable wall thickness | SRS-FR-055 |
+| MaskSmoother | Binary mask smoothing via morphological operations | SRS-FR-055 |
+| SliceInterpolator | Morphological interpolation between annotated slices | SRS-FR-055 |
+| MaskBooleanOperations | Union, intersection, difference, XOR on masks | SRS-FR-055 |
+| SegmentationCommand | Command pattern for undo/redo segmentation actions | SRS-FR-055 |
+| SnapshotCommand | Snapshot-based undo stack for segmentation state | SRS-FR-055 |
+| PhaseTracker | Phase-aware segmentation tracking | SRS-FR-055 |
+| EllipseROI | Elliptical region of interest tool | SRS-FR-055 |
 
 **Class Diagram**:
 
@@ -873,6 +885,10 @@ classDiagram
 | ObliquResliceRenderer | Arbitrary angle reslicing | SRS-FR-011 |
 | TransferFunctionManager | Transfer function preset management | SRS-FR-006 |
 | DRViewer | Dedicated DR/CR 2D viewer | SRS-FR-033 |
+| HemodynamicOverlayRenderer | WSS/pressure overlay on volume rendering | SRS-FR-047 |
+| StreamlineOverlayRenderer | Streamline tubes in volume viewer | SRS-FR-046 |
+| HemodynamicSurfaceManager | Vessel surface hemodynamic mapping | SRS-FR-047 |
+| ASCViewController | Multi-phase cardiac view control | SRS-FR-050 |
 
 > **Implementation Note**: The class diagram below shows an `IRenderService` interface from the original design.
 > This interface is **not implemented** — components are accessed directly. See SDS-IF-001 for details.
@@ -1147,9 +1163,9 @@ classDiagram
 
 ### SDS-MOD-006: UI Module
 
-**Traces to**: SRS-FR-039, SRS-FR-040
+**Traces to**: SRS-FR-039, SRS-FR-040, SRS-FR-056
 
-**Purpose**: Provide Qt6-based user interface
+**Purpose**: Provide Qt6-based user interface with comprehensive panels, dialogs, and widgets
 
 **Components**:
 
@@ -1161,6 +1177,25 @@ classDiagram
 | ToolsPanel | Window/level controls, presets, visualization modes | SRS-FR-039 | ✅ Implemented |
 | SegmentationPanel | Segmentation tools panel (brush, eraser, fill, polygon, smart scissors) | SRS-FR-024 | ✅ Implemented |
 | StatisticsPanel | ROI statistics display, histogram, multi-ROI comparison, CSV export | SRS-FR-028 | ✅ Implemented |
+| OverlayControlPanel | Overlay visibility and parameter controls | SRS-FR-039 | ✅ Implemented |
+| FlowToolPanel | 4D Flow analysis tool controls (streamlines, planes, quantification) | SRS-FR-046 | ✅ Implemented |
+| WorkflowPanel | Workflow step management panel | SRS-FR-039 | ✅ Implemented |
+| ReportPanel | Report generation and preview panel | SRS-FR-054 | ✅ Implemented |
+| SettingsDialog | Application settings dialog (rendering, memory, paths) | SRS-FR-040 | ✅ Implemented |
+| PacsConfigDialog | PACS server configuration and connection test | SRS-FR-038 | ✅ Implemented |
+| QuantificationWindow | Flow quantification results window with contour editing | SRS-FR-047 | ✅ Implemented |
+| MaskWizard | Step-by-step mask creation wizard | SRS-FR-055 | ✅ Implemented |
+| VideoExportDialog | Video export configuration (format, FPS, codec) | SRS-FR-054 | ✅ Implemented |
+| PhaseSliderWidget | Cardiac/temporal phase slider widget | SRS-FR-048 | ✅ Implemented |
+| SPModeToggle | Single-phase / multi-phase mode toggle | SRS-FR-050 | ✅ Implemented |
+| FlowGraphWidget | Time-velocity curve and flow rate graph display | SRS-FR-047 | ✅ Implemented |
+| WorkflowTabBar | Workflow tab navigation bar | SRS-FR-039 | ✅ Implemented |
+| MPRViewWidget | Dedicated MPR view widget with crosshair sync | SRS-FR-008 | ✅ Implemented |
+| ViewportLayoutManager | Multi-viewport layout management (1x1, 2x2, 1x3) | SRS-FR-039 | ✅ Implemented |
+| Display3DController | 3D display parameter control (lighting, clipping, orientation) | SRS-FR-005 | ✅ Implemented |
+| DropHandler | Drag-and-drop DICOM and project file import handler | SRS-FR-039 | ✅ Implemented |
+| IntroPage | Application intro/welcome page | SRS-FR-039 | ✅ Implemented |
+| MaskWizardController | Controller for mask wizard workflow logic | SRS-FR-055 | ✅ Implemented |
 
 **Widget Hierarchy**:
 
@@ -1271,17 +1306,17 @@ classDiagram
 
 **Components**:
 
-> **Implementation Note**: This module is designed as a new service layer (`flow_service`) with dependencies on `image_service` (for DICOM loading) and `render_service` (for VTK integration). All components are planned for implementation in Phase 4.
+> **Implementation Note**: This module is implemented as a service layer (`flow_service`) with dependencies on `image_service` (for DICOM loading) and `render_service` (for VTK integration). All components were implemented in Phase 4 (v0.6.0).
 
 | Component | Description | Traces to | Status |
 |-----------|-------------|-----------|--------|
-| FlowDicomParser | Vendor-specific 4D Flow DICOM parsing (Siemens, Philips, GE) | SRS-FR-043 | ⬜ Planned |
-| VelocityFieldAssembler | Vector field construction from velocity-encoded components with VENC scaling | SRS-FR-044 | ⬜ Planned |
-| PhaseCorrector | Velocity aliasing unwrap, eddy current correction, Maxwell term correction | SRS-FR-045 | ⬜ Planned |
-| FlowVisualizer | Streamline, pathline, and vector glyph rendering via VTK | SRS-FR-046 | ⬜ Planned |
-| FlowQuantifier | Flow rate, time-velocity curves, pressure gradient calculations | SRS-FR-047 | ⬜ Planned |
-| VesselAnalyzer | WSS, OSI, TKE, vorticity, and helicity analysis | SRS-FR-047 | ⬜ Planned |
-| TemporalNavigator | Cardiac phase navigation, cine playback, sliding window cache | SRS-FR-048 | ⬜ Planned |
+| FlowDicomParser | Vendor-specific 4D Flow DICOM parsing (Siemens, Philips, GE) | SRS-FR-043 | ✅ Implemented |
+| VelocityFieldAssembler | Vector field construction from velocity-encoded components with VENC scaling | SRS-FR-044 | ✅ Implemented |
+| PhaseCorrector | Velocity aliasing unwrap, eddy current correction, Maxwell term correction | SRS-FR-045 | ✅ Implemented |
+| FlowVisualizer | Streamline, pathline, and vector glyph rendering via VTK | SRS-FR-046 | ✅ Implemented |
+| FlowQuantifier | Flow rate, time-velocity curves, pressure gradient calculations | SRS-FR-047 | ✅ Implemented |
+| VesselAnalyzer | WSS, OSI, TKE, vorticity, and helicity analysis | SRS-FR-047 | ✅ Implemented |
+| TemporalNavigator | Cardiac phase navigation, cine playback, sliding window cache | SRS-FR-048 | ✅ Implemented |
 
 **Class Diagram**:
 
@@ -1486,10 +1521,11 @@ classDiagram
 
 | Component | Description | Traces to | Status |
 |-----------|-------------|-----------|--------|
-| EnhancedDicomParser | Detect and parse Enhanced CT/MR IODs | SRS-FR-049 | ⬜ Planned |
-| FrameExtractor | Extract individual frames from multi-frame pixel data | SRS-FR-049 | ⬜ Planned |
-| FunctionalGroupParser | Parse Shared/PerFrame FunctionalGroupsSequence | SRS-FR-049 | ⬜ Planned |
-| DimensionIndexSorter | Sort frames by DimensionIndexSequence | SRS-FR-049 | ⬜ Planned |
+| EnhancedDicomParser | Detect and parse Enhanced CT/MR IODs | SRS-FR-049 | ✅ Implemented |
+| FrameExtractor | Extract individual frames from multi-frame pixel data | SRS-FR-049 | ✅ Implemented |
+| FunctionalGroupParser | Parse Shared/PerFrame FunctionalGroupsSequence | SRS-FR-049 | ✅ Implemented |
+| DimensionIndexSorter | Sort frames by DimensionIndexSequence | SRS-FR-049 | ✅ Implemented |
+| SeriesClassifier | Classify Enhanced series by type | SRS-FR-049 | ✅ Implemented |
 
 **Class Diagram**:
 
@@ -1573,11 +1609,11 @@ struct EnhancedSeriesInfo {
 
 | Component | Description | Traces to | Status |
 |-----------|-------------|-----------|--------|
-| CardiacPhaseDetector | Detect and separate ECG-gated cardiac phases | SRS-FR-050 | ⬜ Planned |
-| CoronaryCenterlineExtractor | Extract coronary artery centerlines (Frangi vesselness + minimal path) | SRS-FR-051 | ⬜ Planned |
-| CurvedPlanarReformatter | Generate CPR views along extracted centerlines | SRS-FR-051 | ⬜ Planned |
-| CalciumScorer | Compute Agatston, volume, and mass calcium scores | SRS-FR-052 | ⬜ Planned |
-| CineOrganizer | Detect and organize multi-phase cine MRI series | SRS-FR-053 | ⬜ Planned |
+| CardiacPhaseDetector | Detect and separate ECG-gated cardiac phases | SRS-FR-050 | ✅ Implemented |
+| CoronaryLineCenterlineExtractor | Extract coronary artery centerlines (Frangi vesselness + minimal path) | SRS-FR-051 | ✅ Implemented |
+| CurvedPlanarReformatter | Generate CPR views along extracted centerlines | SRS-FR-051 | ✅ Implemented |
+| CalciumScorer | Compute Agatston, volume, and mass calcium scores | SRS-FR-052 | ✅ Implemented |
+| CineOrganizer | Detect and organize multi-phase cine MRI series | SRS-FR-053 | ✅ Implemented |
 
 **Class Diagram**:
 
@@ -1587,7 +1623,7 @@ struct EnhancedSeriesInfo {
 ├─────────────────────────────────────────────────────────────────────────────┤
 │                                                                               │
 │   ┌────────────────────────┐   ┌────────────────────────────────────────┐  │
-│   │ CardiacPhaseDetector   │   │ CoronaryCenterlineExtractor            │  │
+│   │ CardiacPhaseDetector   │   │ CoronaryLineCenterlineExtractor            │  │
 │   │                        │   │                                        │  │
 │   │ • detectECGGating()    │   │ • computeVesselness(image)             │  │
 │   │ • separatePhases()     │   │ • extractCenterline(seed, vesselness)  │  │
@@ -1657,6 +1693,111 @@ struct CineSeriesInfo {
 | Phase Separation | Trigger Time grouping | Standard ECG-gated CT acquisition metadata |
 | TemporalNavigator Reuse | Composition (not inheritance) | Cardiac CT phases share same navigation pattern as 4D Flow |
 | Calcium Threshold | Fixed 130 HU (Agatston standard) | Clinical standard, non-configurable for reproducibility |
+
+---
+
+### SDS-MOD-010: Export Service Module
+
+**Traces to**: SRS-FR-054
+
+**Purpose**: Provide multi-format data export including medical reports, 3D meshes, measurement data, DICOM Structured Reports, CFD interoperability, research data formats, and video generation.
+
+**Components**:
+
+| Component | Description | Traces to | Status |
+|-----------|-------------|-----------|--------|
+| ReportGenerator | PDF/HTML medical imaging reports with customizable templates | SRS-FR-054.8 | ✅ Implemented |
+| DataExporter | NRRD/DICOM volumetric data export with metadata preservation | SRS-FR-054.1 | ✅ Implemented |
+| MeasurementSerializer | JSON/CSV measurement serialization with schema validation | SRS-FR-054.3 | ✅ Implemented |
+| MeshExporter | STL (binary/ASCII), OBJ (with materials), PLY mesh export | SRS-FR-054.2 | ✅ Implemented |
+| DicomSRWriter | DICOM Structured Report generation (SR IOD compliant) | SRS-FR-054.4 | ✅ Implemented |
+| EnsightExporter | CFD Ensight Gold format export for external analysis tools | SRS-FR-054.5 | ✅ Implemented |
+| MatlabExporter | MATLAB .mat v5 format export for research data | SRS-FR-054.6 | ✅ Implemented |
+| VideoExporter | AVI/MP4/MOV video generation from temporal sequences | SRS-FR-054.7 | ✅ Implemented |
+
+**Class Diagram**:
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                   SDS-MOD-010: Export Service Module                         │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                               │
+│   ┌──────────────────────────┐   ┌──────────────────────────────────────┐  │
+│   │ ReportGenerator          │   │ DataExporter                         │  │
+│   │                          │   │                                      │  │
+│   │ • generatePDF(data)      │   │ • exportNRRD(image, path)            │  │
+│   │ • generateHTML(data)     │   │ • exportDICOM(image, metadata, path) │  │
+│   │ • loadTemplate(name)     │   │ • exportWithMetadata(image, meta)    │  │
+│   │ • embedImages(images)    │   │                                      │  │
+│   └──────────────────────────┘   └──────────────────────────────────────┘  │
+│                                                                               │
+│   ┌──────────────────────────┐   ┌──────────────────────────────────────┐  │
+│   │ MeasurementSerializer    │   │ MeshExporter                         │  │
+│   │                          │   │                                      │  │
+│   │ • toJSON(measurements)   │   │ • exportSTL(mesh, path, binary)      │  │
+│   │ • toCSV(measurements)    │   │ • exportOBJ(mesh, materials, path)   │  │
+│   │ • fromJSON(json)         │   │ • exportPLY(mesh, path)              │  │
+│   │ • validateSchema(json)   │   │ • setCoordinateTransform(matrix)     │  │
+│   └──────────────────────────┘   └──────────────────────────────────────┘  │
+│                                                                               │
+│   ┌──────────────────────────┐   ┌──────────────────────────────────────┐  │
+│   │ DicomSRWriter            │   │ EnsightExporter                      │  │
+│   │                          │   │                                      │  │
+│   │ • createSR(measurements) │   │ • exportCase(velocity, mesh, path)   │  │
+│   │ • addCodedTerm(code)     │   │ • writeGeometry(mesh)                │  │
+│   │ • addMeasurement(data)   │   │ • writeVariable(field, name)         │  │
+│   │ • writeDICOM(path)       │   │ • writeTimesteps(times)              │  │
+│   └──────────────────────────┘   └──────────────────────────────────────┘  │
+│                                                                               │
+│   ┌──────────────────────────┐   ┌──────────────────────────────────────┐  │
+│   │ MatlabExporter           │   │ VideoExporter                        │  │
+│   │                          │   │                                      │  │
+│   │ • exportMat(data, path)  │   │ • setFormat(AVI/MP4/MOV)             │  │
+│   │ • addMatrix(name, data)  │   │ • setFPS(fps)                        │  │
+│   │ • addStruct(name, fields)│   │ • setCodec(codec)                    │  │
+│   │ • addCellArray(name, arr)│   │ • addFrame(image)                    │  │
+│   └──────────────────────────┘   │ • addOverlay(overlay)                │  │
+│                                   │ • finalize(path)                     │  │
+│                                   └──────────────────────────────────────┘  │
+│                                                                               │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Key Data Structures**:
+
+```cpp
+struct ExportConfig {
+    std::string outputPath;
+    std::string format;        // "nrrd", "dicom", "stl", "obj", "ply", "json", "csv"
+    bool preserveMetadata;
+    std::optional<std::array<std::array<double, 4>, 4>> coordinateTransform;
+};
+
+struct ReportConfig {
+    std::string templateName;  // "standard", "cardiac", "flow"
+    std::string outputFormat;  // "pdf", "html"
+    bool embedImages;
+    std::vector<std::string> sections;  // sections to include
+};
+
+struct VideoConfig {
+    std::string format;        // "avi", "mp4", "mov"
+    int fps;                   // 1-60
+    std::string codec;         // "h264", "mjpeg", "raw"
+    int width, height;
+    bool includeOverlays;
+};
+```
+
+**Key Design Decisions**:
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Export Architecture | Strategy pattern per format | Each format has unique requirements; isolates format-specific logic |
+| DICOM SR | IOD-compliant generation | Ensures interoperability with clinical systems |
+| STL Binary/ASCII | User-selectable mode | Binary for efficiency, ASCII for debugging and compatibility |
+| Video Encoding | FFmpeg-based pipeline | Industry standard, wide codec support, cross-platform |
+| MATLAB Format | .mat v5 specification | Broad MATLAB/Octave compatibility |
 
 ---
 
@@ -3109,11 +3250,14 @@ sequenceDiagram
 | SRS-FR-046 | SDS-MOD-007 (FlowVisualizer), SDS-SEQ-006 | Flow Analysis |
 | SRS-FR-047 | SDS-MOD-007 (FlowQuantifier, VesselAnalyzer), SDS-SEQ-007 | Flow Analysis |
 | SRS-FR-048 | SDS-MOD-007 (TemporalNavigator), SDS-DATA-006, SDS-SEQ-006, SDS-SEQ-007 | Flow Analysis |
-| SRS-FR-049 | SDS-MOD-008 (EnhancedDicomParser, FrameExtractor, FunctionalGroupParser, DimensionIndexSorter) | Enhanced DICOM |
+| SRS-FR-049 | SDS-MOD-008 (EnhancedDicomParser, FrameExtractor, FunctionalGroupParser, DimensionIndexSorter, SeriesClassifier) | Enhanced DICOM |
 | SRS-FR-050 | SDS-MOD-009 (CardiacPhaseDetector) | Cardiac CT |
-| SRS-FR-051 | SDS-MOD-009 (CoronaryCenterlineExtractor, CurvedPlanarReformatter) | Cardiac CT |
+| SRS-FR-051 | SDS-MOD-009 (CoronaryLineCenterlineExtractor, CurvedPlanarReformatter) | Cardiac CT |
 | SRS-FR-052 | SDS-MOD-009 (CalciumScorer) | Cardiac CT |
 | SRS-FR-053 | SDS-MOD-009 (CineOrganizer) + SDS-MOD-007 (TemporalNavigator) | Cardiac CT / Cine MRI |
+| SRS-FR-054 | SDS-MOD-010 (ReportGenerator, DataExporter, MeasurementSerializer, MeshExporter, DicomSRWriter, EnsightExporter, MatlabExporter, VideoExporter) | Export Service |
+| SRS-FR-055 | SDS-MOD-002 (CenterlineTracer, LevelTracingTool, HollowTool, MaskSmoother, SliceInterpolator, MaskBooleanOperations, SegmentationCommand, SnapshotCommand) | Image Service |
+| SRS-FR-056 | SDS-MOD-006 (ProjectManager) | UI Module |
 
 ---
 
@@ -3158,22 +3302,27 @@ sequenceDiagram
 | FR-007.15~20 | SRS-FR-028 | SDS-MOD-004 | Measurement (ROIStatistics) | ✅ Implemented |
 | FR-007.21~25 | SRS-FR-030 | SDS-MOD-004 | Measurement (ShapeAnalyzer) | ✅ Implemented |
 | FR-010.1~5 | SRS-FR-034~038 | SDS-MOD-005 | PACS (DicomFindSCU, DicomMoveSCU, DicomStoreSCP, DicomEchoSCU, PacsConfigManager) | ✅ Implemented |
-| FR-011.1~6 | SRS-FR-039, SRS-FR-040 | SDS-MOD-006 | UI (MainWindow, ViewportWidget, Panels, Dialogs) | 🟡 Partially Implemented |
+| FR-011.1~6 | SRS-FR-039, SRS-FR-040 | SDS-MOD-006 | UI (MainWindow, ViewportWidget, Panels, Dialogs) | ✅ Implemented |
 | FR-012.1~8 | SRS-FR-031 | SDS-MOD-004 | Measurement (ROIManager) | ✅ Implemented |
 | FR-013.1~6 | SRS-FR-032 | SDS-MOD-004 | Measurement (ReportGenerator) | ✅ Implemented |
-| FR-014.1~2 | SRS-FR-043 | SDS-MOD-007, SDS-SEQ-005 | Flow (FlowDicomParser) | ⬜ Planned |
-| FR-014.3 | SRS-FR-044 | SDS-MOD-007, SDS-SEQ-005 | Flow (VelocityFieldAssembler) | ⬜ Planned |
-| FR-014.4 | SRS-FR-045 | SDS-MOD-007, SDS-SEQ-005 | Flow (PhaseCorrector) | ⬜ Planned |
-| FR-014.5~8 | SRS-FR-046 | SDS-MOD-007, SDS-SEQ-006 | Flow (FlowVisualizer) | ⬜ Planned |
-| FR-014.9~11 | SRS-FR-048 | SDS-MOD-007, SDS-DATA-006 | Flow (TemporalNavigator) | ⬜ Planned |
-| FR-014.12~18 | SRS-FR-047 | SDS-MOD-007, SDS-SEQ-007 | Flow (FlowQuantifier) | ⬜ Planned |
-| FR-014.19~21 | SRS-FR-047 | SDS-MOD-007, SDS-SEQ-007 | Flow (VesselAnalyzer, Export) | ⬜ Planned |
-| FR-015.1~6 | SRS-FR-049 | SDS-MOD-008 | Enhanced DICOM (EnhancedDicomParser, FrameExtractor, FunctionalGroupParser, DimensionIndexSorter) | ⬜ Planned |
-| FR-016.1~4 | SRS-FR-050 | SDS-MOD-009 | Cardiac CT (CardiacPhaseDetector) | ⬜ Planned |
-| FR-016.5~8 | SRS-FR-051 | SDS-MOD-009 | Cardiac CT (CoronaryCenterlineExtractor, CurvedPlanarReformatter) | ⬜ Planned |
-| FR-016.9~12 | SRS-FR-052 | SDS-MOD-009 | Cardiac CT (CalciumScorer) | ⬜ Planned |
-| FR-016.13~14 | SRS-FR-050 | SDS-MOD-009 | Cardiac CT (CardiacPhaseDetector - EF) | ⬜ Planned |
-| FR-017.1~4 | SRS-FR-053 | SDS-MOD-009, SDS-MOD-007 | Cine MRI (CineOrganizer + TemporalNavigator) | ⬜ Planned |
+| FR-014.1~2 | SRS-FR-043 | SDS-MOD-007, SDS-SEQ-005 | Flow (FlowDicomParser) | ✅ Implemented |
+| FR-014.3 | SRS-FR-044 | SDS-MOD-007, SDS-SEQ-005 | Flow (VelocityFieldAssembler) | ✅ Implemented |
+| FR-014.4 | SRS-FR-045 | SDS-MOD-007, SDS-SEQ-005 | Flow (PhaseCorrector) | ✅ Implemented |
+| FR-014.5~8 | SRS-FR-046 | SDS-MOD-007, SDS-SEQ-006 | Flow (FlowVisualizer) | ✅ Implemented |
+| FR-014.9~11 | SRS-FR-048 | SDS-MOD-007, SDS-DATA-006 | Flow (TemporalNavigator) | ✅ Implemented |
+| FR-014.12~18 | SRS-FR-047 | SDS-MOD-007, SDS-SEQ-007 | Flow (FlowQuantifier) | ✅ Implemented |
+| FR-014.19~21 | SRS-FR-047 | SDS-MOD-007, SDS-SEQ-007 | Flow (VesselAnalyzer, Export) | ✅ Implemented |
+| FR-015.1~6 | SRS-FR-049 | SDS-MOD-008 | Enhanced DICOM (EnhancedDicomParser, FrameExtractor, FunctionalGroupParser, DimensionIndexSorter, SeriesClassifier) | ✅ Implemented |
+| FR-016.1~4 | SRS-FR-050 | SDS-MOD-009 | Cardiac CT (CardiacPhaseDetector) | ✅ Implemented |
+| FR-016.5~8 | SRS-FR-051 | SDS-MOD-009 | Cardiac CT (CoronaryLineCenterlineExtractor, CurvedPlanarReformatter) | ✅ Implemented |
+| FR-016.9~12 | SRS-FR-052 | SDS-MOD-009 | Cardiac CT (CalciumScorer) | ✅ Implemented |
+| FR-016.13~14 | SRS-FR-050 | SDS-MOD-009 | Cardiac CT (CardiacPhaseDetector - EF) | ✅ Implemented |
+| FR-017.1~4 | SRS-FR-053 | SDS-MOD-009, SDS-MOD-007 | Cine MRI (CineOrganizer + TemporalNavigator) | ✅ Implemented |
+| FR-018.1~2 | SRS-FR-054 | SDS-MOD-010 | Export (DataExporter, MeshExporter) | ✅ Implemented |
+| FR-018.3 | SRS-FR-054 | SDS-MOD-010 | Export (MeasurementSerializer, DicomSRWriter) | ✅ Implemented |
+| FR-018.4~5 | SRS-FR-054 | SDS-MOD-010 | Export (EnsightExporter, MatlabExporter) | ✅ Implemented |
+| FR-018.6 | SRS-FR-054 | SDS-MOD-010 | Export (VideoExporter) | ✅ Implemented |
+| FR-018.7 | SRS-FR-054 | SDS-MOD-010 | Export (ReportGenerator) | ✅ Implemented |
 
 ---
 
@@ -3226,7 +3375,16 @@ dicom_viewer/
 │       │   │   ├── label_manager.hpp
 │       │   │   ├── label_map_overlay.hpp
 │       │   │   ├── slice_interpolator.hpp
-│       │   │   └── mpr_segmentation_renderer.hpp
+│       │   │   ├── mpr_segmentation_renderer.hpp
+│       │   │   ├── centerline_tracer.hpp
+│       │   │   ├── level_tracing_tool.hpp
+│       │   │   ├── hollow_tool.hpp
+│       │   │   ├── mask_smoother.hpp
+│       │   │   ├── mask_boolean_operations.hpp
+│       │   │   ├── segmentation_command.hpp
+│       │   │   ├── snapshot_command.hpp
+│       │   │   ├── phase_tracker.hpp
+│       │   │   └── ellipse_roi.hpp
 │       │   ├── render/                 # SDS-MOD-003
 │       │   │   ├── volume_renderer.hpp
 │       │   │   └── surface_renderer.hpp
@@ -3244,12 +3402,15 @@ dicom_viewer/
 │       │   │   ├── dicom_move_scu.hpp
 │       │   │   ├── dicom_store_scp.hpp
 │       │   │   └── pacs_config_manager.hpp
-│       │   ├── export/
+│       │   ├── export/                 # SDS-MOD-010
 │       │   │   ├── report_generator.hpp
 │       │   │   ├── data_exporter.hpp
 │       │   │   ├── measurement_serializer.hpp
 │       │   │   ├── mesh_exporter.hpp
-│       │   │   └── dicom_sr_writer.hpp
+│       │   │   ├── dicom_sr_writer.hpp
+│       │   │   ├── ensight_exporter.hpp
+│       │   │   ├── matlab_exporter.hpp
+│       │   │   └── video_exporter.hpp
 │       │   ├── enhanced_dicom/           # SDS-MOD-008
 │       │   │   ├── enhanced_dicom_parser.hpp
 │       │   │   ├── frame_extractor.hpp
@@ -3285,15 +3446,31 @@ dicom_viewer/
 │           │   ├── viewport_widget.hpp
 │           │   ├── mpr_widget.hpp
 │           │   ├── mpr_view_widget.hpp
-│           │   └── dr_viewer.hpp
+│           │   ├── dr_viewer.hpp
+│           │   ├── phase_slider_widget.hpp
+│           │   ├── sp_mode_toggle.hpp
+│           │   ├── flow_graph_widget.hpp
+│           │   ├── workflow_tab_bar.hpp
+│           │   ├── viewport_layout_manager.hpp
+│           │   ├── display_3d_controller.hpp
+│           │   ├── drop_handler.hpp
+│           │   └── intro_page.hpp
 │           ├── panels/
 │           │   ├── patient_browser.hpp
 │           │   ├── tools_panel.hpp
 │           │   ├── statistics_panel.hpp
-│           │   └── segmentation_panel.hpp
+│           │   ├── segmentation_panel.hpp
+│           │   ├── overlay_control_panel.hpp
+│           │   ├── flow_tool_panel.hpp
+│           │   ├── workflow_panel.hpp
+│           │   └── report_panel.hpp
 │           └── dialogs/
 │               ├── settings_dialog.hpp
-│               └── pacs_config_dialog.hpp
+│               ├── pacs_config_dialog.hpp
+│               ├── quantification_window.hpp
+│               ├── mask_wizard.hpp
+│               ├── mask_wizard_controller.hpp
+│               └── video_export_dialog.hpp
 │
 ├── src/
 │   ├── app/
@@ -3355,7 +3532,10 @@ dicom_viewer/
 │   │   │   ├── data_exporter.cpp
 │   │   │   ├── measurement_serializer.cpp
 │   │   │   ├── mesh_exporter.cpp
-│   │   │   └── dicom_sr_writer.cpp
+│   │   │   ├── dicom_sr_writer.cpp
+│   │   │   ├── ensight_exporter.cpp
+│   │   │   ├── matlab_exporter.cpp
+│   │   │   └── video_exporter.cpp
 │   │   └── flow/
 │   │       ├── flow_dicom_parser.cpp
 │   │       ├── vendor_parsers/
@@ -3459,6 +3639,7 @@ dicom_viewer/
 | 0.4.0 | 2026-02-11 | Development Team | Fixed SRS-FR traceability references throughout (SRS has 42 requirements, not 60); aligned with SRS v0.4.0 |
 | 0.5.0 | 2026-02-11 | Development Team | Added SDS-MOD-007 Flow Analysis Module (7 components), SDS-DATA-006 flow data structures, SDS-SEQ-005~007 flow sequence diagrams; updated ARCH-002/003 and traceability matrices for SRS-FR-043~048 |
 | 0.6.0 | 2026-02-12 | Development Team | Added SDS-MOD-008 (Enhanced DICOM Module, 4 components), SDS-MOD-009 (Cardiac CT Analysis Module, 5 components); updated traceability matrices for SRS-FR-049~053 |
+| 0.7.0 | 2026-02-20 | Development Team | Updated implementation statuses for MOD-007/008/009 to Implemented; added SDS-MOD-010 Export Service Module (8 components); expanded MOD-002 with advanced segmentation tools, MOD-003 with hemodynamic renderers, MOD-006 with 20 additional UI components; updated traceability matrices |
 
 > **Note**: v0.x.x versions are pre-release. Official release starts from v1.0.0.
 

--- a/docs/SRS.md
+++ b/docs/SRS.md
@@ -1,11 +1,11 @@
 # DICOM Viewer - Software Requirements Specification (SRS)
 
-> **Version**: 0.6.0
+> **Version**: 0.7.0
 > **Created**: 2025-12-31
-> **Last Updated**: 2026-02-12
+> **Last Updated**: 2026-02-20
 > **Status**: Draft (Pre-release)
 > **Author**: Development Team
-> **Based on**: [PRD v0.5.0](PRD.md)
+> **Based on**: [PRD v0.6.0](PRD.md)
 
 ---
 
@@ -20,6 +20,8 @@
 | 0.3.0 | 2026-02-11 | Development Team | Replaced DCMTK with pacs_system for DICOM network operations; version sync with build system |
 | 0.4.0 | 2026-02-11 | Development Team | Added SRS-FR-041, SRS-FR-042; fixed PRD traceability gaps |
 | 0.5.0 | 2026-02-11 | Development Team | Added SRS-FR-043~048 (4D Flow MRI), SRS-NFR-021~026; updated traceability |
+| 0.6.0 | 2026-02-12 | Development Team | Added SRS-FR-049~053 (Enhanced DICOM, Cardiac CT, Cine MRI); added SRS-NFR-027~030 |
+| 0.7.0 | 2026-02-20 | Development Team | Added SRS-FR-054 (Data Export Service), SRS-FR-055 (Advanced Segmentation Tools), SRS-FR-056 (Project Management); updated traceability matrices |
 
 ### Referenced Documents
 
@@ -1768,6 +1770,48 @@ struct CineSeriesInfo {
 
 ---
 
+#### SRS-FR-054: Data Export Service
+
+**Traces to**: PRD FR-018
+
+| Sub-ID | Requirement | Description |
+|--------|-------------|-------------|
+| SRS-FR-054.1 | Multi-format image export | Export volumetric data in NRRD format with full metadata preservation; export as DICOM series with proper SOP Instance UID generation |
+| SRS-FR-054.2 | 3D mesh export | Export surface meshes in STL (binary and ASCII modes), OBJ (with material files), and PLY formats; support coordinate system transformation |
+| SRS-FR-054.3 | Measurement serialization | Serialize measurement data to JSON (with schema validation) and CSV (tabular format); support batch export of all measurements |
+| SRS-FR-054.4 | DICOM Structured Report | Generate DICOM SR IOD compliant reports with measurement references and coded terminology |
+| SRS-FR-054.5 | CFD interoperability export | Export velocity fields and mesh data in Ensight Gold format for external CFD analysis tools |
+| SRS-FR-054.6 | Research data export | Export analysis results in MATLAB .mat v5 format including velocity fields, segmentation masks, and measurement data |
+| SRS-FR-054.7 | Video generation | Generate video files (AVI/MP4/MOV) from temporal sequences with configurable FPS (1-60), codec selection, and optional overlay rendering |
+| SRS-FR-054.8 | Report generation | Generate medical imaging reports in PDF and HTML formats with customizable templates, embedded images, and measurement summaries |
+
+#### SRS-FR-055: Advanced Segmentation Tools
+
+**Traces to**: PRD FR-006
+
+| Sub-ID | Requirement | Description |
+|--------|-------------|-------------|
+| SRS-FR-055.1 | Centerline Tracing | Extract vessel centerline between two user-defined seed points using minimal path algorithm on vesselness-enhanced image |
+| SRS-FR-055.2 | Level Tracing | Generate contour by following intensity edge boundary from a seed point; output closed contour at iso-intensity level |
+| SRS-FR-055.3 | Hollow Tool | Create hollow shell from solid segmentation mask with user-configurable wall thickness (1-10 voxels) |
+| SRS-FR-055.4 | Mask Smoothing | Smooth binary segmentation masks using morphological opening/closing with configurable kernel radius |
+| SRS-FR-055.5 | Slice Interpolation | Interpolate segmentation masks between annotated slices using morphological interpolation algorithm |
+| SRS-FR-055.6 | Mask Boolean Operations | Perform union, intersection, difference, and XOR operations between two segmentation masks |
+| SRS-FR-055.7 | Undo/Redo | Command pattern with snapshot-based undo stack; support unlimited undo depth with memory-managed snapshot pruning |
+
+#### SRS-FR-056: Project Management
+
+**Traces to**: PRD FR-011
+
+| Sub-ID | Requirement | Description |
+|--------|-------------|-------------|
+| SRS-FR-056.1 | Project file format | Define .flo project file format as ZIP-based container with manifest, settings, and data references |
+| SRS-FR-056.2 | Project save | Persist patient info, DICOM file references, display settings (window/level, presets), view state (camera, layout), velocity fields, segmentation masks, and analysis results |
+| SRS-FR-056.3 | Project load | Restore complete application state from .flo project file with validation of referenced DICOM data availability |
+| SRS-FR-056.4 | Recent projects | Maintain list of recently opened projects with quick access from File menu and intro page |
+
+---
+
 ## 3. Non-Functional Requirements
 
 ### 3.1 Performance Requirements
@@ -2271,6 +2315,11 @@ See SRS-FR-039 for detailed layout specification.
 | FR-016.9~12 | Calcium scoring | SRS-FR-052 |
 | FR-016.13~14 | Cardiac function (EF) | SRS-FR-050 |
 | FR-017.1~4 | Cine MRI temporal display | SRS-FR-053 |
+| FR-018.1~2 | Data export (image, mesh) | SRS-FR-054 |
+| FR-018.3 | Measurement serialization | SRS-FR-054 |
+| FR-018.4~5 | CFD and research export | SRS-FR-054 |
+| FR-018.6 | Video export | SRS-FR-054 |
+| FR-018.7 | Medical report generation | SRS-FR-054 |
 | NFR-001 | Loading time | SRS-NFR-001 |
 | NFR-002 | Rendering FPS | SRS-NFR-002 |
 | NFR-003 | Slice transition response | SRS-NFR-003 |
@@ -2318,6 +2367,9 @@ See SRS-FR-039 for detailed layout specification.
 | SRS-FR-051 | REF-001, REF-002 |
 | SRS-FR-052 | REF-004 |
 | SRS-FR-053 | REF-004, REF-006 |
+| SRS-FR-054 | REF-004, REF-005 |
+| SRS-FR-055 | REF-001 |
+| SRS-FR-056 | — |
 
 ---
 
@@ -2360,6 +2412,7 @@ See SRS-FR-039 for detailed layout specification.
 | 0.4.0 | 2026-02-11 | Development Team | Added SRS-FR-041 (Histogram Equalization), SRS-FR-042 (Watershed Segmentation); fixed PRD traceability gaps for FR-005.3 and FR-006.6 |
 | 0.5.0 | 2026-02-11 | Development Team | Added SRS-FR-043~048 (4D Flow MRI: DICOM parsing, velocity assembly, phase correction, visualization, quantification, temporal navigation); added SRS-NFR-021~026 (tiered performance targets); updated PRD→SRS and SRS→Reference traceability |
 | 0.6.0 | 2026-02-12 | Development Team | Added SRS-FR-049 (Enhanced DICOM IOD), SRS-FR-050 (ECG-Gated Phase Separation), SRS-FR-051 (Coronary CTA), SRS-FR-052 (Calcium Scoring), SRS-FR-053 (Cine MRI); added SRS-NFR-027~030; updated traceability matrices |
+| 0.7.0 | 2026-02-20 | Development Team | Added SRS-FR-054 (Data Export Service), SRS-FR-055 (Advanced Segmentation Tools), SRS-FR-056 (Project Management); updated traceability matrices |
 
 ---
 


### PR DESCRIPTION
## Summary

- Synchronize all English documentation (SDS, PRD, SRS, README) with the current implementation state
- Update 16 module components from `Planned` to `Implemented` across SDS MOD-007/008/009
- Add SDS-MOD-010 Export Service Module with 8 components (ReportGenerator, DataExporter, MeshExporter, DicomSRWriter, EnsightExporter, MatlabExporter, VideoExporter, MeasurementSerializer)
- Expand SDS MOD-002 (+10 advanced segmentation), MOD-003 (+4 hemodynamic renderers), MOD-006 (+20 UI components)
- Add PRD FR-018 (Data Export, 7 sub-requirements) and UC-17
- Add SRS-FR-054 (Data Export), SRS-FR-055 (Advanced Segmentation), SRS-FR-056 (Project Management)
- Update all traceability matrices and version numbers (PRD 0.6.0, SRS 0.7.0, SDS 0.7.0)

## Changes by Document

| Document | Version | Key Changes |
|----------|---------|-------------|
| SDS.md | 0.6.0 → 0.7.0 | Status updates, MOD-010 Export, expanded MOD-002/003/006, traceability |
| PRD.md | 0.5.0 → 0.6.0 | FR-018, UC-17, roadmap completion status |
| SRS.md | 0.6.0 → 0.7.0 | SRS-FR-054/055/056, traceability matrices |
| README.md | 0.3.0 → 0.7.0 | Feature sections, architecture diagram, roadmap |

## Cross-Document Verification

25/25 consistency checks passed:
- Version references align (PRD 0.6.0 → SRS 0.7.0 → SDS 0.7.0)
- All implemented features show ✅ across documents
- PRD FR → SRS FR → SDS MOD traceability chain complete
- Class names match actual codebase (CoronaryLineCenterlineExtractor, SeriesClassifier)

## Test Plan

- [x] Cross-document version consistency verified
- [x] No remaining Planned markers for implemented modules
- [x] Traceability chain FR-018 → SRS-FR-054 → SDS-MOD-010 verified
- [x] Naming consistency (CoronaryLineCenterlineExtractor) verified
- [x] Visual review of Markdown rendering on GitHub