### PR TITLE
feat(core): initialize ecosystem logger with AppLogLevel enum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,15 @@ if(EXISTS "${THREAD_SYSTEM_ROOT}/include")
     message(STATUS "Found thread_system at: ${THREAD_SYSTEM_ROOT}")
 endif()
 
+# logger_system for ecosystem logging
+if(NOT LOGGER_SYSTEM_ROOT)
+    set(LOGGER_SYSTEM_ROOT "${CMAKE_SOURCE_DIR}/../logger_system" CACHE PATH "Path to logger_system source")
+endif()
+if(EXISTS "${LOGGER_SYSTEM_ROOT}/include")
+    set(LOGGER_SYSTEM_INCLUDE_DIR "${LOGGER_SYSTEM_ROOT}/include")
+    message(STATUS "Found logger_system at: ${LOGGER_SYSTEM_ROOT}")
+endif()
+
 if(EXISTS "${PACS_SYSTEM_ROOT}" AND EXISTS "${PACS_SYSTEM_BUILD_DIR}/lib")
     message(STATUS "Found pacs_system at: ${PACS_SYSTEM_ROOT}")
     message(STATUS "pacs_system build directory: ${PACS_SYSTEM_BUILD_DIR}")
@@ -369,6 +378,9 @@ add_library(dicom_viewer_core STATIC
 
 target_include_directories(dicom_viewer_core PUBLIC
     ${CMAKE_SOURCE_DIR}/include/core
+    ${COMMON_SYSTEM_INCLUDE_DIR}
+    ${LOGGER_SYSTEM_INCLUDE_DIR}
+    ${THREAD_SYSTEM_INCLUDE_DIR}
 )
 
 target_link_directories(dicom_viewer_core PUBLIC

--- a/include/core/app_log_level.hpp
+++ b/include/core/app_log_level.hpp
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <kcenon/common/interfaces/logger_interface.h>
+
+#include <string>
+
+namespace dicom_viewer {
+
+/**
+ * @brief Application-level log levels with simplified 4-tier model.
+ *
+ * Provides a user-facing log level abstraction that maps to the ecosystem's
+ * common::interfaces::log_level. The levels are hierarchical: setting the
+ * level to Information captures Exception + Error + Information messages.
+ */
+enum class AppLogLevel {
+    Exception = 0,    ///< Unintended errors (crashes, unexpected failures)
+    Error = 1,        ///< Intended error messages (validation, user-facing errors)
+    Information = 2,  ///< Minimal information flow (key operations, state transitions)
+    Debug = 3         ///< Maximum information flow (detailed traces, variable dumps)
+};
+
+/**
+ * @brief Convert AppLogLevel to ecosystem log_level.
+ */
+inline kcenon::common::interfaces::log_level to_ecosystem_level(AppLogLevel level) {
+    using kcenon::common::interfaces::log_level;
+    switch (level) {
+        case AppLogLevel::Exception:   return log_level::critical;
+        case AppLogLevel::Error:       return log_level::error;
+        case AppLogLevel::Information: return log_level::info;
+        case AppLogLevel::Debug:       return log_level::debug;
+    }
+    return log_level::info;
+}
+
+/**
+ * @brief Convert ecosystem log_level to AppLogLevel.
+ */
+inline AppLogLevel from_ecosystem_level(kcenon::common::interfaces::log_level level) {
+    using kcenon::common::interfaces::log_level;
+    switch (level) {
+        case log_level::critical: return AppLogLevel::Exception;  // fatal is alias
+        case log_level::error:    return AppLogLevel::Error;
+        case log_level::warning:  return AppLogLevel::Information; // warn is alias
+        case log_level::info:     return AppLogLevel::Information;
+        case log_level::debug:    return AppLogLevel::Debug;
+        case log_level::trace:    return AppLogLevel::Debug;
+        case log_level::off:      return AppLogLevel::Exception;
+    }
+    return AppLogLevel::Information;
+}
+
+/**
+ * @brief Convert AppLogLevel to display string.
+ */
+inline std::string to_string(AppLogLevel level) {
+    switch (level) {
+        case AppLogLevel::Exception:   return "Exception";
+        case AppLogLevel::Error:       return "Error";
+        case AppLogLevel::Information: return "Information";
+        case AppLogLevel::Debug:       return "Debug";
+    }
+    return "Information";
+}
+
+/**
+ * @brief Convert string to AppLogLevel.
+ */
+inline AppLogLevel app_log_level_from_string(const std::string& str) {
+    if (str == "Exception")   return AppLogLevel::Exception;
+    if (str == "Error")       return AppLogLevel::Error;
+    if (str == "Debug")       return AppLogLevel::Debug;
+    return AppLogLevel::Information;
+}
+
+/**
+ * @brief Convert AppLogLevel to integer for QSettings storage.
+ */
+inline int to_settings_value(AppLogLevel level) {
+    return static_cast<int>(level);
+}
+
+/**
+ * @brief Convert integer from QSettings to AppLogLevel.
+ */
+inline AppLogLevel from_settings_value(int value) {
+    if (value >= 0 && value <= 3) {
+        return static_cast<AppLogLevel>(value);
+    }
+    return AppLogLevel::Information;
+}
+
+}  // namespace dicom_viewer

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1,15 +1,56 @@
+// Ecosystem logger headers must precede Qt to avoid emit() macro conflict
+#include <kcenon/common/interfaces/global_logger_registry.h>
+#include <kcenon/logger/core/logger_builder.h>
+#include <kcenon/logger/writers/console_writer.h>
+
 #include "ui/main_window.hpp"
+#include "core/app_log_level.hpp"
 
 #include <QApplication>
+#include <QSettings>
+#include <QStandardPaths>
 #include <QSurfaceFormat>
 #include <QStyleFactory>
 
 #include <vtkOpenGLRenderWindow.h>
 
+namespace {
+
+/**
+ * @brief Initialize ecosystem logger with persisted settings.
+ *
+ * Creates a logger via logger_builder, registers it in GlobalLoggerRegistry,
+ * and sets the log level from QSettings.
+ */
+void initializeLogging()
+{
+    QSettings settings;
+    const int levelValue = settings.value("logging/level", 2).toInt();
+    const auto appLevel = dicom_viewer::from_settings_value(levelValue);
+    const auto ecoLevel = dicom_viewer::to_ecosystem_level(appLevel);
+
+    const QString logDir = QStandardPaths::writableLocation(
+        QStandardPaths::AppDataLocation) + "/logs";
+
+    auto result = kcenon::logger::logger_builder()
+        .with_min_level(static_cast<kcenon::logger::log_level>(ecoLevel))
+        .add_writer("console", std::make_unique<kcenon::logger::console_writer>())
+        .with_file_output(logDir.toStdString(), "dicom_viewer")
+        .build();
+
+    if (result) {
+        auto logger = std::shared_ptr<kcenon::logger::logger>(result.value().release());
+        auto& registry = kcenon::common::interfaces::GlobalLoggerRegistry::instance();
+        registry.set_default_logger(logger);
+    }
+}
+
+} // anonymous namespace
+
 /**
  * @brief Application entry point
  *
- * Initializes Qt, VTK, and launches the main window.
+ * Initializes Qt, VTK, logging, and launches the main window.
  */
 int main(int argc, char* argv[])
 {
@@ -31,6 +72,9 @@ int main(int argc, char* argv[])
     app.setApplicationVersion("0.3.0");
     app.setOrganizationName("kcenon");
     app.setOrganizationDomain("github.com/kcenon");
+
+    // Initialize ecosystem logger with persisted settings
+    initializeLogging();
 
     // Apply Fusion style (works well with dark theme)
     app.setStyle(QStyleFactory::create("Fusion"));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1969,3 +1969,20 @@ target_include_directories(mask_wizard_controller_test PRIVATE
 )
 
 gtest_discover_tests(mask_wizard_controller_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for AppLogLevel conversion functions
+add_executable(app_log_level_test
+    unit/app_log_level_test.cpp
+)
+
+target_link_libraries(app_log_level_test PRIVATE
+    dicom_viewer_core
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(app_log_level_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(app_log_level_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/app_log_level_test.cpp
+++ b/tests/unit/app_log_level_test.cpp
@@ -1,0 +1,61 @@
+#include "core/app_log_level.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace dicom_viewer;
+using kcenon::common::interfaces::log_level;
+
+TEST(AppLogLevelTest, ToEcosystemLevel) {
+    EXPECT_EQ(to_ecosystem_level(AppLogLevel::Exception), log_level::critical);
+    EXPECT_EQ(to_ecosystem_level(AppLogLevel::Error), log_level::error);
+    EXPECT_EQ(to_ecosystem_level(AppLogLevel::Information), log_level::info);
+    EXPECT_EQ(to_ecosystem_level(AppLogLevel::Debug), log_level::debug);
+}
+
+TEST(AppLogLevelTest, FromEcosystemLevel) {
+    EXPECT_EQ(from_ecosystem_level(log_level::critical), AppLogLevel::Exception);
+    EXPECT_EQ(from_ecosystem_level(log_level::error), AppLogLevel::Error);
+    EXPECT_EQ(from_ecosystem_level(log_level::warning), AppLogLevel::Information);
+    EXPECT_EQ(from_ecosystem_level(log_level::info), AppLogLevel::Information);
+    EXPECT_EQ(from_ecosystem_level(log_level::debug), AppLogLevel::Debug);
+    EXPECT_EQ(from_ecosystem_level(log_level::trace), AppLogLevel::Debug);
+    EXPECT_EQ(from_ecosystem_level(log_level::off), AppLogLevel::Exception);
+}
+
+TEST(AppLogLevelTest, ToString) {
+    EXPECT_EQ(to_string(AppLogLevel::Exception), "Exception");
+    EXPECT_EQ(to_string(AppLogLevel::Error), "Error");
+    EXPECT_EQ(to_string(AppLogLevel::Information), "Information");
+    EXPECT_EQ(to_string(AppLogLevel::Debug), "Debug");
+}
+
+TEST(AppLogLevelTest, FromString) {
+    EXPECT_EQ(app_log_level_from_string("Exception"), AppLogLevel::Exception);
+    EXPECT_EQ(app_log_level_from_string("Error"), AppLogLevel::Error);
+    EXPECT_EQ(app_log_level_from_string("Information"), AppLogLevel::Information);
+    EXPECT_EQ(app_log_level_from_string("Debug"), AppLogLevel::Debug);
+    EXPECT_EQ(app_log_level_from_string("unknown"), AppLogLevel::Information);
+}
+
+TEST(AppLogLevelTest, SettingsValueRoundTrip) {
+    for (int i = 0; i <= 3; ++i) {
+        auto level = from_settings_value(i);
+        EXPECT_EQ(to_settings_value(level), i);
+    }
+}
+
+TEST(AppLogLevelTest, InvalidSettingsValue) {
+    EXPECT_EQ(from_settings_value(-1), AppLogLevel::Information);
+    EXPECT_EQ(from_settings_value(4), AppLogLevel::Information);
+    EXPECT_EQ(from_settings_value(100), AppLogLevel::Information);
+}
+
+TEST(AppLogLevelTest, EcosystemRoundTrip) {
+    // Verify that AppLogLevel -> ecosystem -> AppLogLevel round-trips correctly
+    for (auto level : {AppLogLevel::Exception, AppLogLevel::Error,
+                       AppLogLevel::Information, AppLogLevel::Debug}) {
+        auto eco = to_ecosystem_level(level);
+        auto back = from_ecosystem_level(eco);
+        EXPECT_EQ(back, level);
+    }
+}


### PR DESCRIPTION
Closes #420

## Summary
- Add `AppLogLevel` enum with simplified 4-tier model (Exception/Error/Information/Debug) mapping to ecosystem `log_level`
- Initialize kcenon ecosystem logger in `main.cpp` using `logger_builder` with console and file output
- Persist log level via `QSettings` (key: `logging/level`, default: Information=2)
- Register logger in `GlobalLoggerRegistry` for `LOG_*` macro usage across modules

## Changes
| File | Description |
|------|-------------|
| `include/core/app_log_level.hpp` | New header with AppLogLevel enum and bidirectional conversion functions |
| `src/app/main.cpp` | `initializeLogging()` function using ecosystem logger_builder |
| `CMakeLists.txt` | Add LOGGER_SYSTEM_ROOT and include directories |
| `tests/unit/app_log_level_test.cpp` | 7 unit tests for all conversion functions |
| `tests/CMakeLists.txt` | Register app_log_level_test target |

## Key Design Decisions
- Ecosystem headers included before Qt headers to avoid `emit()` macro conflict
- `log_level::warn`/`warning` and `log_level::fatal`/`critical` aliases handled via comments (not duplicate switch cases)
- `logger` class directly implements `ILogger` — no adapter needed

## Test Plan
- [x] All 7 unit tests pass (ToEcosystemLevel, FromEcosystemLevel, ToString, FromString, SettingsValueRoundTrip, InvalidSettingsValue, EcosystemRoundTrip)
- [x] `dicom_viewer` target builds successfully
- [ ] Manual verification: application starts with logger output