### PR TITLE
feat(ui): add log level configuration to SettingsDialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -666,6 +666,7 @@ add_library(dicom_viewer_ui STATIC
     include/ui/panels/segmentation_panel.hpp
     include/ui/panels/overlay_control_panel.hpp
     include/ui/panels/flow_tool_panel.hpp
+    include/ui/dialogs/settings_dialog.hpp
     include/ui/dialogs/pacs_config_dialog.hpp
     include/ui/quantification_window.hpp
     include/ui/dialogs/mask_wizard.hpp

--- a/include/ui/dialogs/settings_dialog.hpp
+++ b/include/ui/dialogs/settings_dialog.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <memory>
+#include <QDialog>
+
+namespace dicom_viewer::ui {
+
+/**
+ * @brief Application settings dialog
+ *
+ * Provides UI for configuring application settings, starting with
+ * log level configuration. Users can select from four log levels
+ * with descriptions, and changes are persisted via QSettings.
+ *
+ * @trace SRS-FR-041
+ */
+class SettingsDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit SettingsDialog(QWidget* parent = nullptr);
+    ~SettingsDialog() override;
+
+    // Non-copyable
+    SettingsDialog(const SettingsDialog&) = delete;
+    SettingsDialog& operator=(const SettingsDialog&) = delete;
+
+public slots:
+    void accept() override;
+
+private slots:
+    void onLogLevelChanged(int index);
+
+private:
+    void setupUI();
+    void loadSettings();
+    void saveSettings();
+    void applyLogLevel();
+
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::ui

--- a/src/ui/dialogs/settings_dialog.cpp
+++ b/src/ui/dialogs/settings_dialog.cpp
@@ -1,4 +1,138 @@
-// Stub implementation - to be completed
+// Ecosystem logger headers must precede Qt to avoid emit() macro conflict
+#include <kcenon/common/interfaces/global_logger_registry.h>
+
+#include "ui/dialogs/settings_dialog.hpp"
+#include "core/app_log_level.hpp"
+
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QGroupBox>
+#include <QLabel>
+#include <QSettings>
+#include <QVBoxLayout>
+
 namespace dicom_viewer::ui {
-// SettingsDialog implementation will be added here
+
+namespace {
+
+struct LogLevelEntry {
+    AppLogLevel level;
+    const char* name;
+    const char* description;
+};
+
+constexpr LogLevelEntry kLogLevels[] = {
+    {AppLogLevel::Exception,   "Exception",   "Unintended errors only (crashes, unexpected failures)"},
+    {AppLogLevel::Error,       "Error",       "Exception + intended error messages (validation failures)"},
+    {AppLogLevel::Information, "Information", "Exception + Error + minimal information flow (default)"},
+    {AppLogLevel::Debug,       "Debug",       "All messages including detailed traces"},
+};
+
+} // anonymous namespace
+
+class SettingsDialog::Impl {
+public:
+    QComboBox* logLevelCombo = nullptr;
+    QLabel* descriptionLabel = nullptr;
+    int initialLevelIndex = 2; // Information
+};
+
+SettingsDialog::SettingsDialog(QWidget* parent)
+    : QDialog(parent)
+    , impl_(std::make_unique<Impl>())
+{
+    setupUI();
+    loadSettings();
+}
+
+SettingsDialog::~SettingsDialog() = default;
+
+void SettingsDialog::setupUI()
+{
+    setWindowTitle(tr("Preferences"));
+    setMinimumWidth(400);
+
+    auto* mainLayout = new QVBoxLayout(this);
+
+    // Logging group box
+    auto* loggingGroup = new QGroupBox(tr("Logging"));
+    auto* loggingLayout = new QVBoxLayout(loggingGroup);
+
+    auto* levelLayout = new QHBoxLayout;
+    levelLayout->addWidget(new QLabel(tr("Log Level:")));
+
+    impl_->logLevelCombo = new QComboBox;
+    for (const auto& entry : kLogLevels) {
+        impl_->logLevelCombo->addItem(tr(entry.name));
+    }
+    levelLayout->addWidget(impl_->logLevelCombo, 1);
+    loggingLayout->addLayout(levelLayout);
+
+    impl_->descriptionLabel = new QLabel;
+    impl_->descriptionLabel->setWordWrap(true);
+    impl_->descriptionLabel->setStyleSheet("color: gray; font-style: italic;");
+    loggingLayout->addWidget(impl_->descriptionLabel);
+
+    mainLayout->addWidget(loggingGroup);
+    mainLayout->addStretch();
+
+    // Dialog buttons
+    auto* buttons = new QDialogButtonBox(
+        QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+    mainLayout->addWidget(buttons);
+
+    connect(buttons, &QDialogButtonBox::accepted, this, &SettingsDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    connect(impl_->logLevelCombo, &QComboBox::currentIndexChanged,
+            this, &SettingsDialog::onLogLevelChanged);
+}
+
+void SettingsDialog::loadSettings()
+{
+    QSettings settings;
+    const int levelValue = settings.value("logging/level", 2).toInt();
+    const auto appLevel = from_settings_value(levelValue);
+
+    int index = static_cast<int>(appLevel);
+    impl_->logLevelCombo->setCurrentIndex(index);
+    impl_->initialLevelIndex = index;
+    onLogLevelChanged(index);
+}
+
+void SettingsDialog::saveSettings()
+{
+    int index = impl_->logLevelCombo->currentIndex();
+    auto level = kLogLevels[index].level;
+
+    QSettings settings;
+    settings.setValue("logging/level", to_settings_value(level));
+}
+
+void SettingsDialog::applyLogLevel()
+{
+    int index = impl_->logLevelCombo->currentIndex();
+    auto appLevel = kLogLevels[index].level;
+    auto ecoLevel = to_ecosystem_level(appLevel);
+
+    auto& registry = kcenon::common::interfaces::GlobalLoggerRegistry::instance();
+    auto logger = registry.get_default_logger();
+    if (logger) {
+        logger->set_level(ecoLevel);
+    }
+}
+
+void SettingsDialog::accept()
+{
+    saveSettings();
+    applyLogLevel();
+    QDialog::accept();
+}
+
+void SettingsDialog::onLogLevelChanged(int index)
+{
+    if (index >= 0 && index < static_cast<int>(std::size(kLogLevels))) {
+        impl_->descriptionLabel->setText(tr(kLogLevels[index].description));
+    }
+}
+
 } // namespace dicom_viewer::ui

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -15,6 +15,7 @@
 #include "ui/drop_handler.hpp"
 #include "ui/display_3d_controller.hpp"
 #include "ui/dialogs/pacs_config_dialog.hpp"
+#include "ui/dialogs/settings_dialog.hpp"
 #include "ui/dialogs/mask_wizard.hpp"
 #include "ui/mask_wizard_controller.hpp"
 #include "ui/quantification_window.hpp"
@@ -1767,8 +1768,8 @@ void MainWindow::onToggleStorageSCP()
 
 void MainWindow::onShowSettings()
 {
-    QMessageBox::information(this, tr("Settings"),
-        tr("Settings dialog will be implemented in a future version."));
+    SettingsDialog dialog(this);
+    dialog.exec();
 }
 
 void MainWindow::onShowAbout()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1986,3 +1986,21 @@ target_include_directories(app_log_level_test PRIVATE
 )
 
 gtest_discover_tests(app_log_level_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for SettingsDialog (log level configuration)
+add_executable(settings_dialog_test
+    unit/settings_dialog_test.cpp
+)
+
+target_link_libraries(settings_dialog_test PRIVATE
+    dicom_viewer_ui
+    Qt6::Test
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(settings_dialog_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(settings_dialog_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/settings_dialog_test.cpp
+++ b/tests/unit/settings_dialog_test.cpp
@@ -1,0 +1,152 @@
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QPushButton>
+#include <QSettings>
+
+#include "ui/dialogs/settings_dialog.hpp"
+#include "core/app_log_level.hpp"
+
+using namespace dicom_viewer;
+using namespace dicom_viewer::ui;
+
+namespace {
+
+// QApplication must exist for QWidget instantiation
+int argc = 0;
+char* argv[] = {nullptr};
+QApplication app(argc, argv);
+
+} // anonymous namespace
+
+// =============================================================================
+// Construction and defaults
+// =============================================================================
+
+TEST(SettingsDialogTest, DefaultConstruction) {
+    SettingsDialog dialog;
+    EXPECT_NE(dialog.windowTitle(), QString());
+}
+
+TEST(SettingsDialogTest, ComboBoxHasFourLevels) {
+    SettingsDialog dialog;
+    auto* combo = dialog.findChild<QComboBox*>();
+    ASSERT_NE(combo, nullptr);
+    EXPECT_EQ(combo->count(), 4);
+    EXPECT_EQ(combo->itemText(0), "Exception");
+    EXPECT_EQ(combo->itemText(1), "Error");
+    EXPECT_EQ(combo->itemText(2), "Information");
+    EXPECT_EQ(combo->itemText(3), "Debug");
+}
+
+TEST(SettingsDialogTest, HasDialogButtons) {
+    SettingsDialog dialog;
+    auto* buttons = dialog.findChild<QDialogButtonBox*>();
+    ASSERT_NE(buttons, nullptr);
+    EXPECT_NE(buttons->button(QDialogButtonBox::Ok), nullptr);
+    EXPECT_NE(buttons->button(QDialogButtonBox::Cancel), nullptr);
+}
+
+// =============================================================================
+// QSettings persistence
+// =============================================================================
+
+TEST(SettingsDialogTest, LoadsFromQSettings) {
+    // Set a known value
+    QSettings settings;
+    settings.setValue("logging/level", to_settings_value(AppLogLevel::Debug));
+    settings.sync();
+
+    SettingsDialog dialog;
+    auto* combo = dialog.findChild<QComboBox*>();
+    ASSERT_NE(combo, nullptr);
+    EXPECT_EQ(combo->currentIndex(), static_cast<int>(AppLogLevel::Debug));
+
+    // Clean up
+    settings.remove("logging/level");
+}
+
+TEST(SettingsDialogTest, DefaultLevelIsInformation) {
+    QSettings settings;
+    settings.remove("logging/level");
+    settings.sync();
+
+    SettingsDialog dialog;
+    auto* combo = dialog.findChild<QComboBox*>();
+    ASSERT_NE(combo, nullptr);
+    EXPECT_EQ(combo->currentIndex(), static_cast<int>(AppLogLevel::Information));
+}
+
+TEST(SettingsDialogTest, AcceptSavesToQSettings) {
+    QSettings settings;
+    settings.remove("logging/level");
+    settings.sync();
+
+    SettingsDialog dialog;
+    auto* combo = dialog.findChild<QComboBox*>();
+    ASSERT_NE(combo, nullptr);
+
+    combo->setCurrentIndex(static_cast<int>(AppLogLevel::Error));
+    dialog.accept();
+
+    settings.sync();
+    int saved = settings.value("logging/level", -1).toInt();
+    EXPECT_EQ(saved, to_settings_value(AppLogLevel::Error));
+
+    // Clean up
+    settings.remove("logging/level");
+}
+
+// =============================================================================
+// Description label updates
+// =============================================================================
+
+TEST(SettingsDialogTest, DescriptionUpdatesOnSelection) {
+    SettingsDialog dialog;
+    auto* combo = dialog.findChild<QComboBox*>();
+    ASSERT_NE(combo, nullptr);
+
+    // Find the description label (the italic gray one)
+    auto labels = dialog.findChildren<QLabel*>();
+    QLabel* descLabel = nullptr;
+    for (auto* label : labels) {
+        if (label->styleSheet().contains("italic")) {
+            descLabel = label;
+            break;
+        }
+    }
+    ASSERT_NE(descLabel, nullptr);
+
+    combo->setCurrentIndex(0); // Exception
+    EXPECT_TRUE(descLabel->text().contains("Unintended"));
+
+    combo->setCurrentIndex(3); // Debug
+    EXPECT_TRUE(descLabel->text().contains("detailed traces"));
+}
+
+// =============================================================================
+// Cancel discards changes
+// =============================================================================
+
+TEST(SettingsDialogTest, CancelDoesNotSave) {
+    QSettings settings;
+    settings.setValue("logging/level", to_settings_value(AppLogLevel::Information));
+    settings.sync();
+
+    SettingsDialog dialog;
+    auto* combo = dialog.findChild<QComboBox*>();
+    ASSERT_NE(combo, nullptr);
+
+    combo->setCurrentIndex(static_cast<int>(AppLogLevel::Debug));
+    dialog.reject();
+
+    settings.sync();
+    int saved = settings.value("logging/level", -1).toInt();
+    EXPECT_EQ(saved, to_settings_value(AppLogLevel::Information));
+
+    // Clean up
+    settings.remove("logging/level");
+}


### PR DESCRIPTION
Closes #422

## Summary
- Implement `SettingsDialog` with log level combo box (Exception, Error, Information, Debug)
- Wire Apply/OK to `ILogger::set_level()` via `GlobalLoggerRegistry` for immediate runtime effect
- Persist selected level to `QSettings` on accept; Cancel discards changes
- Replace placeholder `QMessageBox` stub in `MainWindow::onShowSettings()` with actual dialog
- Add 8 unit tests covering UI structure, QSettings persistence, description label updates, and cancel behavior

## Test Plan
- [x] 3071 tests pass (including 8 new SettingsDialog tests)
- [x] Build succeeds with no errors
- [x] Combo box displays 4 log levels with descriptive text
- [x] Accept saves to QSettings and applies to runtime logger
- [x] Cancel does not persist changes
- [x] Settings menu → Preferences... (Ctrl+,) opens dialog