### PR TITLE
refactor(build): replace hardcoded /opt/homebrew paths with platform-independent discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,9 +94,7 @@ find_package(ITK REQUIRED COMPONENTS
 )
 
 # GDCM library for low-level DICOM parsing (Enhanced DICOM, raw tag access)
-find_package(GDCM REQUIRED
-    PATHS /opt/homebrew/lib/gdcm-3.2
-)
+find_package(GDCM REQUIRED)
 include(${GDCM_USE_FILE})
 
 # pacs_system for DICOM network operations (required)
@@ -310,8 +308,8 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
 # Find FFTW for ITK's FFT operations (required by N4 bias correction and other filters)
-find_library(FFTW3_LIBRARY fftw3 HINTS /opt/homebrew/lib)
-find_library(FFTW3_THREADS_LIBRARY fftw3_threads HINTS /opt/homebrew/lib)
+find_library(FFTW3_LIBRARY fftw3)
+find_library(FFTW3_THREADS_LIBRARY fftw3_threads)
 
 # Core library
 find_package(ZLIB REQUIRED)
@@ -332,10 +330,6 @@ target_include_directories(dicom_viewer_core PUBLIC
     ${COMMON_SYSTEM_INCLUDE_DIR}
     ${LOGGER_SYSTEM_INCLUDE_DIR}
     ${THREAD_SYSTEM_INCLUDE_DIR}
-)
-
-target_link_directories(dicom_viewer_core PUBLIC
-    /opt/homebrew/lib
 )
 
 target_link_libraries(dicom_viewer_core PUBLIC
@@ -447,10 +441,6 @@ target_include_directories(pacs_service PUBLIC
     ${PACS_SYSTEM_INCLUDE_DIR}
 )
 
-target_link_directories(pacs_service PUBLIC
-    /opt/homebrew/lib
-)
-
 target_link_libraries(pacs_service PUBLIC
     pacs::core
     pacs::network
@@ -503,10 +493,6 @@ add_library(export_service STATIC
 target_include_directories(export_service PUBLIC
     ${CMAKE_SOURCE_DIR}/include
     ${PACS_SYSTEM_INCLUDE_DIR}
-)
-
-target_link_directories(export_service PUBLIC
-    /opt/homebrew/lib
 )
 
 target_link_libraries(export_service PUBLIC

--- a/build.sh
+++ b/build.sh
@@ -77,12 +77,25 @@ if [[ "${CLEAN}" == true ]]; then
     rm -rf "${BUILD_DIR}"
 fi
 
+# Platform-specific prefix path for dependency discovery
+CMAKE_PREFIX_PATH_ARG=""
+if [[ -z "${CMAKE_PREFIX_PATH:-}" ]]; then
+    if [[ "$(uname)" == "Darwin" ]]; then
+        if [[ "$(uname -m)" == "arm64" ]]; then
+            CMAKE_PREFIX_PATH_ARG="-DCMAKE_PREFIX_PATH=/opt/homebrew"
+        else
+            CMAKE_PREFIX_PATH_ARG="-DCMAKE_PREFIX_PATH=/usr/local"
+        fi
+    fi
+fi
+
 # Configure
 if [[ ! -f "${BUILD_DIR}/CMakeCache.txt" ]]; then
     echo "--- Configuring (CMake) ---"
     cmake -S "${PROJECT_DIR}" -B "${BUILD_DIR}" \
         -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
-        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+        ${CMAKE_PREFIX_PATH_ARG}
     echo ""
 fi
 


### PR DESCRIPTION
Closes #429

## Summary
- Remove all 6 hardcoded `/opt/homebrew` references from `CMakeLists.txt`
- Remove 3 `target_link_directories()` calls (anti-pattern — `find_library()` returns absolute paths)
- Replace GDCM `PATHS` and FFTW3 `HINTS` with standard `CMAKE_PREFIX_PATH`-based discovery
- Add platform-specific `CMAKE_PREFIX_PATH` detection to `build.sh` (ARM: `/opt/homebrew`, Intel: `/usr/local`)

## Motivation
Hardcoded `/opt/homebrew` paths fail on:
- Intel Macs (Homebrew uses `/usr/local`)
- Linux (packages in `/usr/lib` or `/usr/local/lib`)
- Windows (entirely different path structure)
- vcpkg users (`CMAKE_PREFIX_PATH` for discovery)

## Test Plan
- [x] `./build.sh --clean --test` — 3071/3071 tests pass
- [x] `grep -r "/opt/homebrew" CMakeLists.txt` returns zero matches
- [x] No `target_link_directories` calls remain in CMakeLists.txt
- [x] All dependencies discovered via `CMAKE_PREFIX_PATH`
- [x] User-set `CMAKE_PREFIX_PATH` environment variable is respected