### PR TITLE
fix(docs): escape Liquid syntax in SDS code blocks for Jekyll build

### DIFF
--- a/docs/SDS.kr.md
+++ b/docs/SDS.kr.md
@@ -1484,6 +1484,7 @@ struct AnalysisReport {
 
 **Traces to**: SRS-DR-021 ~ SRS-DR-025
 
+{% raw %}
 ```cpp
 // Transfer Function Structures (include/core/transfer_function.hpp)
 namespace dicom_viewer {
@@ -1538,6 +1539,7 @@ const std::vector<TransferFunctionPreset> CT_PRESETS = {
 
 } // namespace dicom_viewer
 ```
+{% endraw %}
 
 ---
 

--- a/docs/SDS.md
+++ b/docs/SDS.md
@@ -2058,6 +2058,7 @@ struct AnalysisReport {
 
 **Traces to**: SRS-DR-021 ~ SRS-DR-025
 
+{% raw %}
 ```cpp
 // Transfer Function Structures (include/core/transfer_function.hpp)
 namespace dicom_viewer {
@@ -2112,6 +2113,7 @@ const std::vector<TransferFunctionPreset> CT_PRESETS = {
 
 } // namespace dicom_viewer
 ```
+{% endraw %}
 
 ---
 


### PR DESCRIPTION
## Summary
- Wrap C++ transfer function preset code blocks in `{% raw %}`/`{% endraw %}` Liquid tags in both `docs/SDS.kr.md` and `docs/SDS.md`
- Fixes GitHub Pages build failure caused by Jekyll's Liquid engine interpreting C++ double-brace initializers (`{{-1000, 0, 0, 0}}`) as Liquid template variables

## Root Cause
Jekyll processes all `.md` files through the Liquid template engine before rendering. C++ aggregate initialization syntax like `{{-1000, 0, 0, 0}` starts with `{{`, which Liquid interprets as a variable interpolation start. Since there's no matching `}}`, the build fails with:
```
Liquid syntax error (line 1519): Variable '{{-1000, 0, 0, 0}' was not properly terminated
```

## Changes
| File | Change |
|------|--------|
| `docs/SDS.kr.md` | Added `{% raw %}`/`{% endraw %}` around transfer function preset code block |
| `docs/SDS.md` | Added `{% raw %}`/`{% endraw %}` around transfer function preset code block |

## Test Plan
- [x] GitHub Pages build succeeds without Liquid syntax errors
- [x] SDS documentation pages render correctly with code blocks intact