### PR TITLE
docs(doxygen): add file-level documentation to core and foundational service headers

### DIFF
--- a/include/core/app_log_level.hpp
+++ b/include/core/app_log_level.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file app_log_level.hpp
+ * @brief Application-level log level abstraction
+ * @details Defines the AppLogLevel enum that maps application log levels
+ *          to the ecosystem logger system. Provides conversion utilities
+ *          between application levels, ecosystem levels, and string
+ *          representations for QSettings persistence.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <kcenon/common/interfaces/logger_interface.h>

--- a/include/core/data_serializer.hpp
+++ b/include/core/data_serializer.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file data_serializer.hpp
+ * @brief Serialization of image data and analysis results into project files
+ * @details Handles reading and writing of volumetric image data, segmentation
+ *          masks, and analysis results within .flo project containers.
+ *          Uses NRRD format for image serialization and ZIP-based
+ *          archiving through ProjectManager.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include "core/project_manager.hpp"

--- a/include/core/dicom_loader.hpp
+++ b/include/core/dicom_loader.hpp
@@ -27,6 +27,23 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file dicom_loader.hpp
+ * @brief DICOM file loading and metadata extraction
+ * @details Provides the DicomLoader class for parsing DICOM files and scanning
+ *          directories to extract patient, study, and series metadata.
+ *          Supports both single-file loading and batch directory scanning
+ *          with progress reporting via callbacks.
+ *
+ * ## Thread Safety
+ * - Directory scanning may be called from background threads
+ * - DicomMetadata structs are safe to read from any thread after construction
+ * - Individual file loading operations are not thread-safe
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <array>

--- a/include/core/hounsfield_converter.hpp
+++ b/include/core/hounsfield_converter.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file hounsfield_converter.hpp
+ * @brief CT pixel value to Hounsfield Unit conversion and tissue classification
+ * @details Provides utilities for converting stored pixel values to Hounsfield
+ *          Units using rescale slope and intercept parameters. Includes
+ *          tissue type classification, reference HU values for common
+ *          tissues, and parameter validation.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <cmath>

--- a/include/core/image_converter.hpp
+++ b/include/core/image_converter.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file image_converter.hpp
+ * @brief Conversion between ITK and VTK image representations
+ * @details Bridges the ITK and VTK image processing ecosystems by converting
+ *          itk::Image to vtkImageData and vice versa. Handles pixel type
+ *          mapping and coordinate system alignment between ITK LPS and
+ *          VTK coordinate conventions.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <memory>

--- a/include/core/project_manager.hpp
+++ b/include/core/project_manager.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file project_manager.hpp
+ * @brief Project file persistence in .flo format
+ * @details Manages reading and writing of .flo project files, which are ZIP-based
+ *          containers holding volumetric image data, segmentation masks,
+ *          measurements, and analysis results. Uses std::expected for
+ *          explicit error handling.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <cstdint>

--- a/include/core/series_builder.hpp
+++ b/include/core/series_builder.hpp
@@ -27,6 +27,23 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file series_builder.hpp
+ * @brief DICOM series assembly into 3D volumetric images
+ * @details Assembles ordered DICOM slices into coherent 3D ITK volumes. Validates
+ *          series consistency (slice spacing, orientation), sorts slices by
+ *          spatial position, and reports progress through callbacks.
+ *          Returns std::future for asynchronous volume construction.
+ *
+ * ## Thread Safety
+ * - Volume building returns std::future and may execute on a background thread
+ * - Progress callbacks are invoked from the building thread
+ * - The returned SeriesInfo is safe to access after the future resolves
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include "dicom_loader.hpp"

--- a/include/core/transfer_syntax_decoder.hpp
+++ b/include/core/transfer_syntax_decoder.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file transfer_syntax_decoder.hpp
+ * @brief DICOM transfer syntax identification and decoding support
+ * @details Identifies and categorizes DICOM transfer syntaxes including
+ *          Implicit/Explicit VR, JPEG Baseline, JPEG Lossless, JPEG 2000,
+ *          JPEG-LS, and RLE Lossless. Provides compression type detection
+ *          and validation for supported syntaxes.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <array>

--- a/include/core/zip_archive.hpp
+++ b/include/core/zip_archive.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file zip_archive.hpp
+ * @brief ZIP archive compression and decompression operations
+ * @details Provides file-level ZIP operations for reading and writing compressed
+ *          archives. Used by ProjectManager to package .flo project files
+ *          containing NRRD image data and metadata.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <cstdint>

--- a/include/services/coordinate/coordinate_types.hpp
+++ b/include/services/coordinate/coordinate_types.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file coordinate_types.hpp
+ * @brief Coordinate type definitions for the MPR coordinate system
+ * @details Defines the ScreenCoordinate struct representing 2D viewport
+ *          coordinates with x, y integer positions and equality
+ *          comparison support.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <array>

--- a/include/services/coordinate/mpr_coordinate_transformer.hpp
+++ b/include/services/coordinate/mpr_coordinate_transformer.hpp
@@ -27,6 +27,22 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file mpr_coordinate_transformer.hpp
+ * @brief Unified MPR coordinate transformations with crosshair synchronization
+ * @details Provides conversions between screen, world, and voxel coordinate
+ *          systems for MPR views. Synchronizes crosshair positions
+ *          across Axial, Coronal, and Sagittal viewports through
+ *          coordinate mapping with vtkImageData geometry.
+ *
+ * ## Thread Safety
+ * - Coordinate transformations must be called from the main (UI) thread
+ * - The underlying vtkImageData must not change during transformation
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include "coordinate_types.hpp"

--- a/include/services/dicom_echo_scu.hpp
+++ b/include/services/dicom_echo_scu.hpp
@@ -27,6 +27,23 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file dicom_echo_scu.hpp
+ * @brief DICOM C-ECHO Service Class User for connection verification
+ * @details Implements the DICOM C-ECHO SCU operation to verify connectivity
+ *          and association negotiation with remote PACS servers.
+ *          Uses the kcenon pacs_system library for network operations
+ *          with configurable timeout and error reporting.
+ *
+ * ## Thread Safety
+ * - Echo operations perform network I/O and should not block the UI thread
+ * - Each operation creates its own network association
+ * - PacsError results are safe to inspect from any thread
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include "pacs_config.hpp"

--- a/include/services/dicom_find_scu.hpp
+++ b/include/services/dicom_find_scu.hpp
@@ -27,6 +27,22 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file dicom_find_scu.hpp
+ * @brief DICOM C-FIND Service Class User for patient/study/series queries
+ * @details Implements DICOM C-FIND SCU queries at patient, study, series,
+ *          and image levels. Supports hierarchical query/retrieve
+ *          workflows with configurable query roots and attribute
+ *          matching via the kcenon pacs_system library.
+ *
+ * ## Thread Safety
+ * - Find operations perform network I/O and should not block the UI thread
+ * - Query results are returned as value types safe for cross-thread transfer
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include "pacs_config.hpp"

--- a/include/services/dicom_move_scu.hpp
+++ b/include/services/dicom_move_scu.hpp
@@ -27,6 +27,23 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file dicom_move_scu.hpp
+ * @brief DICOM C-MOVE Service Class User for image retrieval
+ * @details Implements DICOM C-MOVE SCU operations to retrieve images from
+ *          remote PACS servers. Retrieved images are stored to the
+ *          local filesystem. Uses the kcenon pacs_system library for
+ *          network and storage operations.
+ *
+ * ## Thread Safety
+ * - Move operations perform network and file I/O; run on background threads
+ * - Progress reporting via callbacks from the network thread
+ * - File write operations use exclusive access
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include "pacs_config.hpp"

--- a/include/services/dicom_store_scp.hpp
+++ b/include/services/dicom_store_scp.hpp
@@ -27,6 +27,23 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file dicom_store_scp.hpp
+ * @brief DICOM C-STORE Service Class Provider for image reception
+ * @details Implements a DICOM C-STORE SCP server that accepts incoming
+ *          image storage requests from remote DICOM nodes. Uses
+ *          std::atomic for server state management and the kcenon
+ *          pacs_system library for DICOM network handling.
+ *
+ * ## Thread Safety
+ * - Server runs on its own network thread via pacs_system
+ * - Start/stop operations use atomic state transitions
+ * - Received images are written with exclusive file access
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include "dicom_echo_scu.hpp"

--- a/include/services/hemodynamic_surface_manager.hpp
+++ b/include/services/hemodynamic_surface_manager.hpp
@@ -27,6 +27,22 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file hemodynamic_surface_manager.hpp
+ * @brief Hemodynamic parameter visualization on vessel surface meshes
+ * @details Maps hemodynamic parameters (Wall Shear Stress, Oscillatory Shear
+ *          Index, Aneurysm Formation Index, Relative Residence Time)
+ *          onto 3D vessel surface meshes for visualization. Coordinates
+ *          color mapping and scalar range management.
+ *
+ * ## Thread Safety
+ * - Surface mesh updates must be called from the main (UI) thread
+ * - Parameter data may be computed on background threads before visualization
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <memory>

--- a/include/services/measurement/area_measurement_tool.hpp
+++ b/include/services/measurement/area_measurement_tool.hpp
@@ -27,6 +27,22 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file area_measurement_tool.hpp
+ * @brief Region-of-interest area measurement with VTK widget integration
+ * @details Provides interactive area measurements using circular, elliptical,
+ *          and freehand ROI shapes. Integrates with VTK renderer
+ *          and interactor for mouse-driven placement and displays
+ *          area values with proper physical unit scaling.
+ *
+ * ## Thread Safety
+ * - Widget interactions must occur on the main (UI) thread
+ * - Measurement results are value types safe for cross-thread access
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include "measurement_types.hpp"

--- a/include/services/measurement/linear_measurement_tool.hpp
+++ b/include/services/measurement/linear_measurement_tool.hpp
@@ -27,6 +27,22 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file linear_measurement_tool.hpp
+ * @brief Linear distance and angle measurement with VTK widget integration
+ * @details Provides interactive distance and angle measurements using
+ *          vtkDistanceWidget and vtkAngleWidget. Handles placement,
+ *          display formatting, and physical unit conversion for
+ *          DICOM-calibrated image coordinates.
+ *
+ * ## Thread Safety
+ * - Widget interactions must occur on the main (UI) thread
+ * - Measurement results are value types safe for cross-thread access
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include "measurement_types.hpp"

--- a/include/services/measurement/measurement_types.hpp
+++ b/include/services/measurement/measurement_types.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file measurement_types.hpp
+ * @brief Error types and codes for measurement operations
+ * @details Defines the MeasurementError struct with error codes covering
+ *          common measurement failure modes such as invalid input,
+ *          missing image data, and computation failures.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <array>

--- a/include/services/measurement/roi_statistics.hpp
+++ b/include/services/measurement/roi_statistics.hpp
@@ -27,6 +27,22 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file roi_statistics.hpp
+ * @brief Region-of-interest statistical analysis on volumetric data
+ * @details Computes statistical measures (mean, standard deviation, min/max,
+ *          histogram) for regions of interest within ITK image
+ *          volumes. Supports both 2D slice ROIs and 3D volumetric
+ *          region analysis with functional callback integration.
+ *
+ * ## Thread Safety
+ * - Statistics computation on large ROIs may be slow; consider background execution
+ * - ITK image data must not be modified during computation
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include "measurement_types.hpp"

--- a/include/services/measurement/shape_analyzer.hpp
+++ b/include/services/measurement/shape_analyzer.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file shape_analyzer.hpp
+ * @brief Shape morphology analysis for segmented regions
+ * @details Analyzes geometric properties of segmented label map regions
+ *          including surface area, volume, sphericity, elongation,
+ *          and center of mass. Operates on ITK binary label maps
+ *          with proper physical spacing consideration.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <array>

--- a/include/services/measurement/volume_calculator.hpp
+++ b/include/services/measurement/volume_calculator.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file volume_calculator.hpp
+ * @brief Segmented region volume calculation from label maps
+ * @details Calculates the physical volume of segmented regions in ITK label
+ *          maps. Reports volumes in cubic millimeters, cubic centimeters,
+ *          and milliliters with voxel spacing correction.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <cstdint>

--- a/include/services/mpr_renderer.hpp
+++ b/include/services/mpr_renderer.hpp
@@ -27,6 +27,23 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file mpr_renderer.hpp
+ * @brief Multi-Planar Reconstruction rendering with crosshair synchronization
+ * @details Manages simultaneous Axial, Coronal, and Sagittal slice rendering
+ *          with synchronized crosshair navigation. Integrates with
+ *          MPRSegmentationRenderer for label overlay and LabelManager
+ *          for segmentation visualization on MPR views.
+ *
+ * ## Thread Safety
+ * - All rendering and slice navigation must occur on the main (UI) thread
+ * - Crosshair position updates trigger synchronized view refreshes
+ * - Window/level adjustments affect all three planes simultaneously
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <array>

--- a/include/services/pacs_config.hpp
+++ b/include/services/pacs_config.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file pacs_config.hpp
+ * @brief PACS server connection configuration data structure
+ * @details Defines the PacsServerConfig struct containing DICOM network
+ *          parameters: hostname, port, AE titles (local and remote),
+ *          and a unique identifier for configuration management.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <chrono>

--- a/include/services/pacs_config_manager.hpp
+++ b/include/services/pacs_config_manager.hpp
@@ -27,6 +27,23 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file pacs_config_manager.hpp
+ * @brief PACS server configuration persistence and management
+ * @details Manages CRUD operations for PACS server configurations using
+ *          Qt QSettings for persistence. Inherits QObject for
+ *          signal/slot integration with the UI layer. Each
+ *          configuration is identified by a unique QUuid.
+ *
+ * ## Thread Safety
+ * - QSettings operations must be called from the main (UI) thread
+ * - Configuration reads are safe after initial load
+ * - Signal emissions follow Qt thread affinity rules
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include "pacs_config.hpp"

--- a/include/services/preprocessing/anisotropic_diffusion_filter.hpp
+++ b/include/services/preprocessing/anisotropic_diffusion_filter.hpp
@@ -27,6 +27,22 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file anisotropic_diffusion_filter.hpp
+ * @brief Edge-preserving noise reduction using anisotropic diffusion
+ * @details Applies gradient-magnitude or curvature-based anisotropic diffusion
+ *          filtering to volumetric images. Reduces noise while preserving
+ *          edge structures, controlled by conductance and iteration
+ *          parameters. Wraps ITK anisotropic diffusion filters.
+ *
+ * ## Thread Safety
+ * - Filter execution may be slow on large volumes; run on background threads
+ * - Input ITK image must not be modified during filtering
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <expected>

--- a/include/services/preprocessing/gaussian_smoother.hpp
+++ b/include/services/preprocessing/gaussian_smoother.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file gaussian_smoother.hpp
+ * @brief Gaussian blur smoothing for volumetric image noise reduction
+ * @details Applies isotropic or anisotropic Gaussian smoothing to volumetric
+ *          images using ITK discrete Gaussian filters. Defines the
+ *          PreprocessingError struct with error codes for the
+ *          preprocessing service module.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <expected>

--- a/include/services/preprocessing/histogram_equalizer.hpp
+++ b/include/services/preprocessing/histogram_equalizer.hpp
@@ -27,6 +27,22 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file histogram_equalizer.hpp
+ * @brief Histogram equalization for image contrast enhancement
+ * @details Enhances image contrast by redistributing intensity values
+ *          through histogram equalization. Supports both standard
+ *          and adaptive (CLAHE) equalization methods using ITK
+ *          histogram filters.
+ *
+ * ## Thread Safety
+ * - Equalization on large volumes should be run on background threads
+ * - Input ITK image must not be modified during processing
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <array>

--- a/include/services/preprocessing/isotropic_resampler.hpp
+++ b/include/services/preprocessing/isotropic_resampler.hpp
@@ -27,6 +27,22 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file isotropic_resampler.hpp
+ * @brief Voxel spacing normalization to isotropic resolution
+ * @details Resamples anisotropic volumetric images (e.g., 0.5x0.5x2.5 mm)
+ *          to isotropic voxel spacing (e.g., 1.0x1.0x1.0 mm) using
+ *          ITK resampling filters with configurable interpolation
+ *          methods.
+ *
+ * ## Thread Safety
+ * - Resampling large volumes is computationally expensive; use background threads
+ * - Input ITK image must not be modified during resampling
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <array>

--- a/include/services/preprocessing/n4_bias_corrector.hpp
+++ b/include/services/preprocessing/n4_bias_corrector.hpp
@@ -27,6 +27,23 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file n4_bias_corrector.hpp
+ * @brief MRI B1 bias field correction using the N4ITK algorithm
+ * @details Corrects MRI intensity inhomogeneity caused by B1 field
+ *          non-uniformity using the N4 bias field correction algorithm.
+ *          Requires FFTW3 for frequency-domain operations. This is
+ *          typically the slowest preprocessing operation.
+ *
+ * ## Thread Safety
+ * - N4 correction is computationally intensive; must run on background threads
+ * - Progress reporting via callbacks from the processing thread
+ * - Input ITK image must not be modified during correction
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <expected>

--- a/include/services/render/asc_view_controller.hpp
+++ b/include/services/render/asc_view_controller.hpp
@@ -27,6 +27,22 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file asc_view_controller.hpp
+ * @brief Axial/Sagittal/Coronal 3D overlay cutting plane controller
+ * @details Controls three orthogonal cutting planes overlaid on the 3D
+ *          volume rendering view. Uses vtkImageSliceMapper to display
+ *          MPR slices as textured planes within the 3D scene,
+ *          synchronized with the MPR viewport positions.
+ *
+ * ## Thread Safety
+ * - All VTK operations must be called from the main (UI) thread
+ * - Slice position updates trigger VTK pipeline re-execution
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <array>

--- a/include/services/render/hemodynamic_overlay_renderer.hpp
+++ b/include/services/render/hemodynamic_overlay_renderer.hpp
@@ -27,6 +27,22 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file hemodynamic_overlay_renderer.hpp
+ * @brief Hemodynamic parameter overlay rendering on MPR views
+ * @details Renders color-mapped hemodynamic data (WSS, velocity, pressure)
+ *          as overlays on 2D MPR slice views. Supports configurable
+ *          color lookup tables and scalar range mapping for each
+ *          hemodynamic parameter type.
+ *
+ * ## Thread Safety
+ * - All rendering operations must be called from the main (UI) thread
+ * - Overlay data may be prepared on background threads before display
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <array>

--- a/include/services/render/oblique_reslice_renderer.hpp
+++ b/include/services/render/oblique_reslice_renderer.hpp
@@ -27,6 +27,22 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file oblique_reslice_renderer.hpp
+ * @brief Arbitrary-angle oblique reslicing for 3D volume data
+ * @details Generates resliced 2D images from 3D volumes at arbitrary
+ *          orientations defined by a point and normal vector.
+ *          Integrates with the 3D overlay view for interactive
+ *          oblique plane positioning.
+ *
+ * ## Thread Safety
+ * - All VTK operations must be called from the main (UI) thread
+ * - Reslice computation may be expensive for large volumes
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <array>

--- a/include/services/render/streamline_overlay_renderer.hpp
+++ b/include/services/render/streamline_overlay_renderer.hpp
@@ -27,6 +27,22 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file streamline_overlay_renderer.hpp
+ * @brief 2D streamline overlay rendering for flow visualization on MPR views
+ * @details Generates and renders 2D streamlines from 3D velocity field data
+ *          projected onto MPR slice planes. Supports configurable
+ *          streamline density, length, and color mapping for
+ *          flow visualization.
+ *
+ * ## Thread Safety
+ * - All rendering operations must be called from the main (UI) thread
+ * - Streamline computation may be offloaded to background threads
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <array>

--- a/include/services/surface_renderer.hpp
+++ b/include/services/surface_renderer.hpp
@@ -27,6 +27,23 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file surface_renderer.hpp
+ * @brief Marching Cubes isosurface extraction and rendering
+ * @details Generates and renders isosurfaces from volumetric data using the
+ *          Marching Cubes algorithm. Supports tissue-type specific
+ *          coloring with vtkLookupTable, multi-surface rendering,
+ *          and mesh export to STL/PLY formats.
+ *
+ * ## Thread Safety
+ * - All rendering operations must be called from the main (UI) thread
+ * - Isosurface computation may block; consider offloading to background
+ * - VTK actor state must not be accessed concurrently
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <array>

--- a/include/services/transfer_function_manager.hpp
+++ b/include/services/transfer_function_manager.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file transfer_function_manager.hpp
+ * @brief Transfer function preset management with file I/O
+ * @details Manages built-in and custom transfer function presets for volume
+ *          rendering. Provides CRUD operations for custom presets,
+ *          file-based persistence (save/load/export/import), and
+ *          a library of built-in CT/MRI presets.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <expected>

--- a/include/services/volume_renderer.hpp
+++ b/include/services/volume_renderer.hpp
@@ -27,6 +27,23 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file volume_renderer.hpp
+ * @brief GPU-accelerated volume rendering with transfer function support
+ * @details Provides the VolumeRenderer class for ray-casting volume visualization
+ *          using VTK. Supports GPU rendering with CPU fallback, multiple
+ *          blend modes (composite, MIP, MinIP, average), interactive LOD,
+ *          and clipping planes. Includes built-in CT/MRI presets.
+ *
+ * ## Thread Safety
+ * - All rendering operations must be called from the main (UI) thread
+ * - Transfer function and window/level updates are not thread-safe
+ * - Input data (vtkImageData) should not be modified during rendering
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
 #pragma once
 
 #include <memory>


### PR DESCRIPTION
Closes #445

## Summary
- Add Doxygen `@file`, `@brief`, `@details`, `@author`, `@since` tags to **37 header files**
- Coverage: core utilities (9 files), rendering services (7 files), PACS services (6 files), render specializations (4 files), measurement tools (6 files), preprocessing filters (5 files), coordinate system (2 files)
- Thread safety notes included where applicable (23 files)
- 1 file (`core/platform/macos_math_fix.hpp`) already had `@file` tag — skipped

## Files Modified

### Core (`include/core/`)
- `app_log_level.hpp`, `data_serializer.hpp`, `dicom_loader.hpp`
- `hounsfield_converter.hpp`, `image_converter.hpp`, `project_manager.hpp`
- `series_builder.hpp`, `transfer_syntax_decoder.hpp`, `zip_archive.hpp`

### Services (`include/services/`)
- `volume_renderer.hpp`, `surface_renderer.hpp`, `mpr_renderer.hpp`
- `transfer_function_manager.hpp`, `hemodynamic_surface_manager.hpp`
- `dicom_echo_scu.hpp`, `dicom_find_scu.hpp`, `dicom_move_scu.hpp`
- `dicom_store_scp.hpp`, `pacs_config.hpp`, `pacs_config_manager.hpp`

### Render Specializations (`include/services/render/`)
- `asc_view_controller.hpp`, `hemodynamic_overlay_renderer.hpp`
- `oblique_reslice_renderer.hpp`, `streamline_overlay_renderer.hpp`

### Measurement (`include/services/measurement/`)
- `area_measurement_tool.hpp`, `linear_measurement_tool.hpp`
- `measurement_types.hpp`, `roi_statistics.hpp`
- `shape_analyzer.hpp`, `volume_calculator.hpp`

### Preprocessing (`include/services/preprocessing/`)
- `anisotropic_diffusion_filter.hpp`, `gaussian_smoother.hpp`
- `histogram_equalizer.hpp`, `isotropic_resampler.hpp`, `n4_bias_corrector.hpp`

### Coordinate (`include/services/coordinate/`)
- `coordinate_types.hpp`, `mpr_coordinate_transformer.hpp`

## Test Plan
- [x] Build passes (cmake --build Release)
- [x] All 3071 tests run; 17 pre-existing GUI SEGFAULT failures unrelated to documentation changes
- [x] Documentation blocks are well-formed Doxygen syntax
- [x] No runtime behavior changes (comment-only modifications)

Part of #442