### PR TITLE
docs(doxygen): add file-level documentation to domain service headers

### DIFF
--- a/include/services/cardiac/calcium_scorer.hpp
+++ b/include/services/cardiac/calcium_scorer.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file calcium_scorer.hpp
+ * @brief Agatston coronary artery calcium scorer
+ * @details Computes Agatston, volume, and mass calcium scores from non-contrast
+ *          cardiac CT acquisitions. Implements the standard Agatston
+ *          algorithm with threshold at 130 HU, connected component analysis,
+ *          and density-weighted per-slice area scoring.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <expected>

--- a/include/services/cardiac/cardiac_phase_detector.hpp
+++ b/include/services/cardiac/cardiac_phase_detector.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file cardiac_phase_detector.hpp
+ * @brief ECG-gated cardiac phase detection and separation
+ * @details Detects ECG-gated cardiac CT/MR series and separates multi-phase
+ *          data into individual cardiac phase volumes. Supports Enhanced
+ *          and Classic DICOM IODs with automatic best diastolic/systolic
+ *          phase selection and ejection fraction estimation.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <expected>

--- a/include/services/cardiac/cardiac_types.hpp
+++ b/include/services/cardiac/cardiac_types.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file cardiac_types.hpp
+ * @brief Cardiac phase metadata and classification enums
+ * @details Defines PhaseTarget enum (Diastole, Systole, Custom),
+ *          CardiacPhaseInfo struct for single temporal phase metadata,
+ *          and helper methods for diastolic/systolic region classification.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <array>

--- a/include/services/cardiac/cine_organizer.hpp
+++ b/include/services/cardiac/cine_organizer.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file cine_organizer.hpp
+ * @brief Cine MRI acquisition orientation classification and organization
+ * @details Classifies cine MRI orientations (ShortAxis, 2CH, 3CH, 4CH) from
+ *          Image Orientation Patient (0020,0037) cosines. Organizes temporal
+ *          multi-frame data for cardiac cine analysis.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <expected>

--- a/include/services/cardiac/coronary_centerline_extractor.hpp
+++ b/include/services/cardiac/coronary_centerline_extractor.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file coronary_centerline_extractor.hpp
+ * @brief Coronary artery centerline extraction using Frangi vesselness and minimal path
+ * @details Implements multi-scale Frangi vesselness filter for tubular structure
+ *          enhancement, minimal path centerline extraction via FastMarching
+ *          and gradient descent, B-spline smoothing, and vessel radius/
+ *          stenosis measurement for coronary CTA analysis.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <expected>

--- a/include/services/cardiac/curved_planar_reformatter.hpp
+++ b/include/services/cardiac/curved_planar_reformatter.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file curved_planar_reformatter.hpp
+ * @brief Curved Planar Reformation (CPR) view generator from vessel centerlines
+ * @details Generates straightened CPR, cross-sectional CPR, and stretched CPR
+ *          views from vessel centerline and CT volume. Essential for
+ *          coronary CTA visualization allowing complete vessel inspection
+ *          in single 2D image despite tortuous 3D path.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <expected>

--- a/include/services/enhanced_dicom/dimension_index_sorter.hpp
+++ b/include/services/enhanced_dicom/dimension_index_sorter.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file dimension_index_sorter.hpp
+ * @brief Sorts Enhanced DICOM frames using DimensionIndexSequence
+ * @details Parses DimensionIndexSequence (0020,9222) to understand multi-
+ *          dimensional frame organization (temporal position, in-stack
+ *          position, echo number). Falls back to spatial position-based
+ *          sorting when sequence absent.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <expected>

--- a/include/services/enhanced_dicom/enhanced_dicom_parser.hpp
+++ b/include/services/enhanced_dicom/enhanced_dicom_parser.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file enhanced_dicom_parser.hpp
+ * @brief Enhanced DICOM multi-frame IOD parser for modern scanner formats
+ * @details Detects and parses Enhanced DICOM IODs containing multiple image
+ *          frames with shared and per-frame metadata. Supports Enhanced CT,
+ *          Enhanced MR, Enhanced XA with progress callbacks for long
+ *          operations.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <expected>

--- a/include/services/enhanced_dicom/enhanced_dicom_types.hpp
+++ b/include/services/enhanced_dicom/enhanced_dicom_types.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file enhanced_dicom_types.hpp
+ * @brief Data structures and error codes for Enhanced DICOM operations
+ * @details Defines EnhancedDicomError with error code enum (Success,
+ *          InvalidInput, NotEnhancedIOD, ParseFailed) and detailed
+ *          error messages. Core types supporting Enhanced DICOM
+ *          processing pipeline.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <array>

--- a/include/services/enhanced_dicom/frame_extractor.hpp
+++ b/include/services/enhanced_dicom/frame_extractor.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file frame_extractor.hpp
+ * @brief Extracts individual frames from Enhanced DICOM multi-frame pixel data
+ * @details Handles native (uncompressed) and encapsulated (compressed) pixel
+ *          data extraction. Uses Basic Offset Table or Extended Offset
+ *          Table to locate frame boundaries within pixel data element.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <cstdint>

--- a/include/services/enhanced_dicom/functional_group_parser.hpp
+++ b/include/services/enhanced_dicom/functional_group_parser.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file functional_group_parser.hpp
+ * @brief Parser for DICOM Functional Group Sequences in Enhanced IODs
+ * @details Extracts metadata from SharedFunctionalGroupsSequence (5200,9229)
+ *          and PerFrameFunctionalGroupsSequence (5200,9230). Per-frame
+ *          values override shared values for metadata that varies by
+ *          frame (pixel spacing, position, orientation).
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/services/enhanced_dicom/series_classifier.hpp
+++ b/include/services/enhanced_dicom/series_classifier.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file series_classifier.hpp
+ * @brief Classification of DICOM series modality and acquisition type
+ * @details Classifies series type covering 4D Flow components (magnitude,
+ *          phase AP/FH/RL), MRI sequences (CINE, DIXON, Starvibe, TOF,
+ *          VENC), and CT. Returns SeriesType enum and ClassifiedSeries
+ *          metadata.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <string>

--- a/include/services/export/data_exporter.hpp
+++ b/include/services/export/data_exporter.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file data_exporter.hpp
+ * @brief Base framework for data export operations with error handling
+ * @details Defines ExportError structure with error codes (Success,
+ *          FileAccessDenied, InvalidData, EncodingFailed,
+ *          UnsupportedFormat, InternalError) and status checking
+ *          methods for multi-format export pipeline.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "services/export/report_generator.hpp"

--- a/include/services/export/dicom_sr_writer.hpp
+++ b/include/services/export/dicom_sr_writer.hpp
@@ -27,6 +27,23 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file dicom_sr_writer.hpp
+ * @brief DICOM Structured Report (SR) writer with PACS store capability
+ * @details Writes structured report documents from measurement data and
+ *          clinical annotations. Includes PACS connection and store
+ *          operation support with detailed error handling for encoding,
+ *          validation, and connectivity issues.
+ *
+ * ## Thread Safety
+ * - PACS network operations should not be called from the UI thread
+ * - File I/O requires exclusive access during write operations
+ * - GDCM encoding thread-safety depends on library version
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "services/dicom_echo_scu.hpp"

--- a/include/services/export/ensight_exporter.hpp
+++ b/include/services/export/ensight_exporter.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file ensight_exporter.hpp
+ * @brief Ensight Gold format exporter for multi-phase visualization data
+ * @details Produces complete Ensight Gold file sets (.case/.geo/.variable)
+ *          from ITK image data compatible with Ansys Ensight and Paraview.
+ *          Supports per-phase scalar and vector variables with proper
+ *          binary formatting.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "services/export/data_exporter.hpp"

--- a/include/services/export/matlab_exporter.hpp
+++ b/include/services/export/matlab_exporter.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file matlab_exporter.hpp
+ * @brief MAT-file Level 5 writer for MATLAB velocity field export
+ * @details Writes MATLAB .mat files in Level 5 binary format without external
+ *          dependencies. Supports float32/float64 numeric arrays up to 4D
+ *          in column-major (Fortran) order.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "services/export/data_exporter.hpp"

--- a/include/services/export/measurement_serializer.hpp
+++ b/include/services/export/measurement_serializer.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file measurement_serializer.hpp
+ * @brief JSON serialization for measurements and clinical annotations
+ * @details Serializes measurement data, ROI statistics, and segmentation
+ *          labels to/from JSON format with schema validation. Supports
+ *          study-specific versioning and data integrity checking for
+ *          measurement persistence.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "services/export/report_generator.hpp"

--- a/include/services/export/mesh_exporter.hpp
+++ b/include/services/export/mesh_exporter.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file mesh_exporter.hpp
+ * @brief STL and OBJ mesh file exporter with coordinate system conversion
+ * @details Exports segmentation-derived or iso-surface meshes to STL
+ *          (binary/ASCII) and OBJ formats. Supports RAS/LPS coordinate
+ *          system conversion for compatibility with external analysis tools.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <array>

--- a/include/services/export/report_generator.hpp
+++ b/include/services/export/report_generator.hpp
@@ -27,6 +27,23 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file report_generator.hpp
+ * @brief Clinical report PDF generation with measurement and image embedding
+ * @details Generates multi-page PDF reports embedding measurement tables,
+ *          ROI statistics, volume calculations, and captured images.
+ *          Supports customizable page layouts and Qt-based rendering
+ *          for high-quality output.
+ *
+ * ## Thread Safety
+ * - PDF rendering uses Qt and must be called from the UI thread
+ * - Image capture requires synchronized access to render windows
+ * - Report generation is a blocking operation; use background threads for UI
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "services/measurement/measurement_types.hpp"

--- a/include/services/export/video_exporter.hpp
+++ b/include/services/export/video_exporter.hpp
@@ -27,6 +27,23 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file video_exporter.hpp
+ * @brief Video exporter for cine playback and 3D rotation animations
+ * @details Captures render window frames at cardiac phases and encodes as
+ *          OGG Theora video. Supports 2D cine phase animation and 3D
+ *          rotation capture with progress callbacks for long encoding
+ *          operations.
+ *
+ * ## Thread Safety
+ * - Render window frame capture must be synchronized with rendering
+ * - Video encoding is a long-running operation; use background threads
+ * - Progress callbacks are invoked from the encoding thread
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "services/export/data_exporter.hpp"

--- a/include/services/flow/flow_dicom_parser.hpp
+++ b/include/services/flow/flow_dicom_parser.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file flow_dicom_parser.hpp
+ * @brief 4D Flow MRI DICOM series parser with vendor-specific strategy
+ * @details Identifies 4D Flow series from DICOM metadata, selects appropriate
+ *          vendor-specific parser (Siemens, Philips, GE), and organizes
+ *          frames into a cardiac_phase x velocity_component matrix.
+ *          Uses Strategy pattern via IVendorFlowParser for vendor abstraction.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <expected>

--- a/include/services/flow/flow_dicom_types.hpp
+++ b/include/services/flow/flow_dicom_types.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file flow_dicom_types.hpp
+ * @brief Error information and type definitions for flow analysis operations
+ * @details Defines FlowError struct with detailed error codes and messages
+ *          for flow analysis operations. Contains FlowVendorType enum
+ *          for scanner vendor identification.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <array>

--- a/include/services/flow/flow_quantifier.hpp
+++ b/include/services/flow/flow_quantifier.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file flow_quantifier.hpp
+ * @brief Flow measurement quantification at discrete cardiac phases
+ * @details Provides flow measurement results and time-velocity curves for
+ *          flow quantification analysis. Defines MeasurementPlane for
+ *          specifying sampling geometry with center, normal, radius,
+ *          and spacing parameters.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <array>

--- a/include/services/flow/flow_visualizer.hpp
+++ b/include/services/flow/flow_visualizer.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file flow_visualizer.hpp
+ * @brief Velocity field rendering with streamlines, pathlines, and vector glyphs
+ * @details Provides visualization types (Streamlines, Pathlines, VectorGlyphs)
+ *          and color modes (VelocityMagnitude, VelocityComponent,
+ *          FlowDirection, TriggerTime). Contains StreamlineParams for
+ *          configuring integration, step length, and tube rendering.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <array>

--- a/include/services/flow/phase_corrector.hpp
+++ b/include/services/flow/phase_corrector.hpp
@@ -27,6 +27,23 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file phase_corrector.hpp
+ * @brief Systematic error corrections for raw 4D Flow velocity data
+ * @details Corrects three types of systematic errors in phase-contrast MRI:
+ *          velocity aliasing (phase wrapping beyond VENC), eddy current
+ *          background phase offsets, and Maxwell term (concomitant gradient)
+ *          errors. Each correction independently configurable.
+ *
+ * ## Thread Safety
+ * - Processes large 3D image data; corrections may be computationally intensive
+ * - ITK image operations should not be performed concurrently on the same data
+ * - Input images must not be modified during correction
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <expected>

--- a/include/services/flow/temporal_navigator.hpp
+++ b/include/services/flow/temporal_navigator.hpp
@@ -27,6 +27,23 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file temporal_navigator.hpp
+ * @brief LRU sliding window cache for velocity phase data management
+ * @details Manages memory by keeping configurable number of phases loaded,
+ *          evicting least-recently-used phases when window size exceeded.
+ *          Supports cine playback modes with FPS, speed multipliers,
+ *          and CacheStatus monitoring.
+ *
+ * ## Thread Safety
+ * - Uses std::mutex internally for thread-safe cache access
+ * - LRU eviction requires synchronization during phase lookup and updates
+ * - Playback state changes are protected against race conditions
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <expected>

--- a/include/services/flow/velocity_field_assembler.hpp
+++ b/include/services/flow/velocity_field_assembler.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file velocity_field_assembler.hpp
+ * @brief Assembles 3D velocity vector fields from parsed 4D Flow DICOM frames
+ * @details Constructs temporal sequence of 3D velocity vector fields from frame
+ *          matrix using ITK image types. Pipeline: read scalar volumes,
+ *          apply VENC scaling, compose 3 components into VectorImage3D,
+ *          output VelocityPhase per cardiac phase.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <expected>

--- a/include/services/flow/vendor_parsers/ge_flow_parser.hpp
+++ b/include/services/flow/vendor_parsers/ge_flow_parser.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file ge_flow_parser.hpp
+ * @brief GE-specific 4D Flow DICOM parser implementing IVendorFlowParser
+ * @details Parses GE Classic MR IOD format with velocity/VENC in DICOM tag
+ *          (0019,10cc) and instance number-based phase ordering. Extracts
+ *          VENC, classifies velocity components, and determines phase
+ *          indices and trigger times.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "services/flow/vendor_parsers/i_vendor_flow_parser.hpp"

--- a/include/services/flow/vendor_parsers/i_vendor_flow_parser.hpp
+++ b/include/services/flow/vendor_parsers/i_vendor_flow_parser.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file i_vendor_flow_parser.hpp
+ * @brief Interface for vendor-specific 4D Flow DICOM parsing
+ * @details Strategy pattern interface for vendor-specific parsing logic. Each
+ *          vendor (Siemens, Philips, GE) implements methods for velocity
+ *          tags extraction, VENC retrieval, velocity component classification,
+ *          phase indexing, and trigger time extraction.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <string>

--- a/include/services/flow/vendor_parsers/philips_flow_parser.hpp
+++ b/include/services/flow/vendor_parsers/philips_flow_parser.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file philips_flow_parser.hpp
+ * @brief Philips-specific 4D Flow DICOM parser implementing IVendorFlowParser
+ * @details Parses Philips Classic MR IOD format with scale slope in DICOM tag
+ *          (2005,1071) and phase index in (2001,100a). Implements vendor-
+ *          specific VENC, component classification, phase indexing, and
+ *          trigger time extraction.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "services/flow/vendor_parsers/i_vendor_flow_parser.hpp"

--- a/include/services/flow/vendor_parsers/siemens_flow_parser.hpp
+++ b/include/services/flow/vendor_parsers/siemens_flow_parser.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file siemens_flow_parser.hpp
+ * @brief Siemens-specific 4D Flow DICOM parser implementing IVendorFlowParser
+ * @details Parses Siemens Enhanced MR IOD format with velocity info in DICOM
+ *          tag (0051,1014) and VENC in (0018,9197). Implements vendor-
+ *          specific extraction methods for VENC, component classification,
+ *          phase indices, and trigger times.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "services/flow/vendor_parsers/i_vendor_flow_parser.hpp"

--- a/include/services/flow/vessel_analyzer.hpp
+++ b/include/services/flow/vessel_analyzer.hpp
@@ -27,6 +27,23 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file vessel_analyzer.hpp
+ * @brief Wall Shear Stress and vortex analysis for flow dynamics
+ * @details Computes Wall Shear Stress (WSS), vorticity magnitude and field,
+ *          helicity density with right/left components, and kinetic energy
+ *          per voxel. Provides WSSResult, VortexResult, and
+ *          KineticEnergyResult structures.
+ *
+ * ## Thread Safety
+ * - Computationally intensive derivative calculations on 3D velocity fields
+ * - Different analysis metrics may be computed in parallel on separate data
+ * - Input velocity data must not be modified during analysis
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <expected>

--- a/include/services/segmentation/brush_stroke_command.hpp
+++ b/include/services/segmentation/brush_stroke_command.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file brush_stroke_command.hpp
+ * @brief Diff-based undoable command for brush stroke operations
+ * @details Stores only changed voxels for memory-efficient undo/redo of
+ *          localized brush, eraser, and fill operations. Records individual
+ *          voxel changes with old and new label values for efficient playback.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "services/segmentation/segmentation_command.hpp"

--- a/include/services/segmentation/centerline_tracer.hpp
+++ b/include/services/segmentation/centerline_tracer.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file centerline_tracer.hpp
+ * @brief Vessel centerline tracing using Dijkstra path finding
+ * @details Computes optimal path between two points through 3D volume using
+ *          Dijkstra shortest path on 26-connectivity voxel grid, followed by
+ *          Catmull-Rom spline smoothing and local radius estimation via
+ *          radial gradient sampling.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "threshold_segmenter.hpp"

--- a/include/services/segmentation/hollow_tool.hpp
+++ b/include/services/segmentation/hollow_tool.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file hollow_tool.hpp
+ * @brief Creates hollow shell masks from solid segmentation masks
+ * @details Extracts boundary regions at configurable thickness from binary
+ *          masks. Supports inward, outward, or bidirectional shell extraction
+ *          useful for visualizing thin structures like vessel walls.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "threshold_segmenter.hpp"

--- a/include/services/segmentation/label_manager.hpp
+++ b/include/services/segmentation/label_manager.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file label_manager.hpp
+ * @brief Manager for multi-label segmentation with undo/redo support
+ * @details Comprehensive management of multiple segmentation labels including
+ *          creation, modification, deletion, visibility control, statistics
+ *          computation, and import/export of segmentation data. Supports up
+ *          to 255 labels with 0 reserved for background.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "segmentation_label.hpp"

--- a/include/services/segmentation/label_map_overlay.hpp
+++ b/include/services/segmentation/label_map_overlay.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file label_map_overlay.hpp
+ * @brief Renders segmentation label map as overlay on MPR views
+ * @details Visualizes ITK label maps on VTK renderers with support for
+ *          multiple labels and customizable colors. Non-copyable and movable
+ *          for proper resource management.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "services/mpr_renderer.hpp"

--- a/include/services/segmentation/level_set_segmenter.hpp
+++ b/include/services/segmentation/level_set_segmenter.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file level_set_segmenter.hpp
+ * @brief Parameters and seed points for Level Set segmentation algorithms
+ * @details Defines configuration structures for level set-based segmentation
+ *          with propagation scaling, curvature constraint, and advection
+ *          parameters for edge attraction and boundary smoothness control.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <expected>

--- a/include/services/segmentation/level_tracing_tool.hpp
+++ b/include/services/segmentation/level_tracing_tool.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file level_tracing_tool.hpp
+ * @brief Edge-following contour tool using flood-fill and Moore boundary tracing
+ * @details Automatically traces intensity boundaries on 2D slices using
+ *          flood-fill within tolerance band and Moore neighborhood contour
+ *          extraction. Optionally fills enclosed regions to produce binary masks.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "threshold_segmenter.hpp"

--- a/include/services/segmentation/manual_segmentation_controller.hpp
+++ b/include/services/segmentation/manual_segmentation_controller.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file manual_segmentation_controller.hpp
+ * @brief Tool enumeration and input types for manual segmentation drawing
+ * @details Enumerates supported drawing tools (brush, eraser, fill, freehand,
+ *          polygon, smart scissors, level tracing, centerline) and brush
+ *          shapes with 2D point structures for mouse interaction.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <cstdint>

--- a/include/services/segmentation/mask_boolean_operations.hpp
+++ b/include/services/segmentation/mask_boolean_operations.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file mask_boolean_operations.hpp
+ * @brief Boolean operations between segmentation label maps
+ * @details Provides voxel-wise set operations: union, difference, and
+ *          intersection. All operations produce new maps preserving originals;
+ *          input maps must have identical dimensions, spacing, and origin.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <expected>

--- a/include/services/segmentation/mask_smoother.hpp
+++ b/include/services/segmentation/mask_smoother.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file mask_smoother.hpp
+ * @brief Volume-preserving Gaussian boundary smoother for binary masks
+ * @details Smooths mask boundaries using Gaussian blur followed by adaptive
+ *          re-thresholding via binary search to preserve original volume
+ *          within tolerance (default 1%).
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "threshold_segmenter.hpp"

--- a/include/services/segmentation/morphological_processor.hpp
+++ b/include/services/segmentation/morphological_processor.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file morphological_processor.hpp
+ * @brief Morphological post-processing for segmentation refinement
+ * @details Provides morphological operations (opening, closing, dilation,
+ *          erosion, fill holes, island removal) to refine binary
+ *          segmentation masks using ITK filters for noise removal
+ *          and boundary smoothing.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "threshold_segmenter.hpp"

--- a/include/services/segmentation/mpr_segmentation_renderer.hpp
+++ b/include/services/segmentation/mpr_segmentation_renderer.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file mpr_segmentation_renderer.hpp
+ * @brief Renders segmentation overlays on MPR views
+ * @details Creates and manages VTK actors for displaying segmentation labels
+ *          as semi-transparent colored overlays on MPR planes. Extracts 2D
+ *          slices from 3D label map for each plane with customizable colors
+ *          and opacity.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <array>

--- a/include/services/segmentation/phase_tracker.hpp
+++ b/include/services/segmentation/phase_tracker.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file phase_tracker.hpp
+ * @brief Temporal mask propagation across cardiac phases
+ * @details Propagates segmentation masks from reference phase to all others
+ *          using deformable registration via ITK Demons. Bidirectional
+ *          propagation from reference with optional morphological closing
+ *          and volume deviation flagging.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "services/segmentation/threshold_segmenter.hpp"

--- a/include/services/segmentation/region_growing_segmenter.hpp
+++ b/include/services/segmentation/region_growing_segmenter.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file region_growing_segmenter.hpp
+ * @brief Seed point-based region growing segmentation using ITK filters
+ * @details Provides connected threshold and confidence connected region growing
+ *          algorithms for semi-automatic segmentation. Connected threshold
+ *          uses user-defined intensity range; confidence connected
+ *          automatically determines range from seed statistics.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <expected>

--- a/include/services/segmentation/segmentation_command.hpp
+++ b/include/services/segmentation/segmentation_command.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file segmentation_command.hpp
+ * @brief Abstract interface for undoable segmentation operations
+ * @details Base interface and command stack for undo/redo of segmentation
+ *          operations. Manages history with configurable depth (default 20)
+ *          and clears redo stack on new commands after undo.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <cstddef>

--- a/include/services/segmentation/segmentation_label.hpp
+++ b/include/services/segmentation/segmentation_label.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file segmentation_label.hpp
+ * @brief RGBA color representation for segmentation labels
+ * @details Stores normalized floating-point color components [0.0, 1.0]
+ *          compatible with rendering pipelines. Provides constructors for
+ *          float and 8-bit RGBA values with automatic component clamping.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <array>

--- a/include/services/segmentation/slice_interpolator.hpp
+++ b/include/services/segmentation/slice_interpolator.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file slice_interpolator.hpp
+ * @brief Interpolation method selection and parameters for slice interpolation
+ * @details Supports morphological (recommended), shape-based, and linear
+ *          interpolation methods with heuristic contour alignment and
+ *          multiple pass options. Includes label filtering and slice bounds.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <expected>

--- a/include/services/segmentation/snapshot_command.hpp
+++ b/include/services/segmentation/snapshot_command.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file snapshot_command.hpp
+ * @brief Snapshot-based undoable command for bulk segmentation operations
+ * @details Stores RLE-compressed before/after snapshots for operations
+ *          modifying large regions (threshold, region growing, morphological).
+ *          Captures 'before' on construction and 'after' after operation
+ *          completion.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "services/segmentation/segmentation_command.hpp"

--- a/include/services/segmentation/threshold_segmenter.hpp
+++ b/include/services/segmentation/threshold_segmenter.hpp
@@ -27,6 +27,17 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file threshold_segmenter.hpp
+ * @brief Error types and result structures for segmentation operations
+ * @details Defines error codes (Success, InvalidInput, InvalidParameters,
+ *          ProcessingFailed, InternalError) with human-readable messages.
+ *          Includes OtsuThresholdResult for automatic threshold calculation.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <expected>

--- a/include/services/segmentation/watershed_segmenter.hpp
+++ b/include/services/segmentation/watershed_segmenter.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file watershed_segmenter.hpp
+ * @brief Watershed segmentation with region analysis and merging
+ * @details Provides flood level and threshold control for output region count.
+ *          Includes Gaussian preprocessing, gradient computation,
+ *          marker-based option, and small region merging for
+ *          oversegmentation reduction.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <array>


### PR DESCRIPTION
Closes #446

## Summary
- Add Doxygen `@file`, `@brief`, `@details`, `@author`, `@since` tags to **52 header files**
- Coverage: segmentation (20), flow + vendor_parsers (12), cardiac (6), enhanced_dicom (6), export (8)
- Thread safety notes included for 6 files with concurrency concerns
- 636 lines added (documentation only, no code changes)

## Files Modified

### Segmentation (`include/services/segmentation/`) — 20 files
- `brush_stroke_command.hpp`, `centerline_tracer.hpp`, `hollow_tool.hpp`
- `label_manager.hpp`, `label_map_overlay.hpp`, `level_set_segmenter.hpp`
- `level_tracing_tool.hpp`, `manual_segmentation_controller.hpp`
- `mask_boolean_operations.hpp`, `mask_smoother.hpp`, `morphological_processor.hpp`
- `mpr_segmentation_renderer.hpp`, `phase_tracker.hpp`, `region_growing_segmenter.hpp`
- `segmentation_command.hpp`, `segmentation_label.hpp`, `slice_interpolator.hpp`
- `snapshot_command.hpp`, `threshold_segmenter.hpp`, `watershed_segmenter.hpp`

### Flow (`include/services/flow/`) — 12 files
- `flow_dicom_parser.hpp`, `flow_dicom_types.hpp`, `flow_quantifier.hpp`
- `flow_visualizer.hpp`, `phase_corrector.hpp`, `temporal_navigator.hpp`
- `velocity_field_assembler.hpp`, `vessel_analyzer.hpp`
- `vendor_parsers/`: `i_vendor_flow_parser.hpp`, `ge_flow_parser.hpp`, `philips_flow_parser.hpp`, `siemens_flow_parser.hpp`

### Cardiac (`include/services/cardiac/`) — 6 files
- `calcium_scorer.hpp`, `cardiac_phase_detector.hpp`, `cardiac_types.hpp`
- `cine_organizer.hpp`, `coronary_centerline_extractor.hpp`, `curved_planar_reformatter.hpp`

### Enhanced DICOM (`include/services/enhanced_dicom/`) — 6 files
- `dimension_index_sorter.hpp`, `enhanced_dicom_parser.hpp`, `enhanced_dicom_types.hpp`
- `frame_extractor.hpp`, `functional_group_parser.hpp`, `series_classifier.hpp`

### Export (`include/services/export/`) — 8 files
- `data_exporter.hpp`, `dicom_sr_writer.hpp`, `ensight_exporter.hpp`
- `matlab_exporter.hpp`, `measurement_serializer.hpp`, `mesh_exporter.hpp`
- `report_generator.hpp`, `video_exporter.hpp`

## Test Plan
- [x] Build passes (cmake --build Release, exit code 0)
- [x] Documentation blocks are well-formed Doxygen syntax
- [x] No runtime behavior changes (comment-only modifications)
- [x] Thread safety sections added selectively where relevant

Part of #442