### PR TITLE
docs(doxygen): add file-level documentation to UI headers

### DIFF
--- a/include/ui/dialogs/mask_wizard.hpp
+++ b/include/ui/dialogs/mask_wizard.hpp
@@ -27,6 +27,21 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file mask_wizard.hpp
+ * @brief 4-step wizard dialog for segmentation mask creation
+ * @details Sequentially guides through Crop (3D bounding box), Threshold
+ *          (intensity range), Separate (connected component selection),
+ *          and Track (phase propagation). Aggregates results in
+ *          MaskWizardResult struct.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QWizard-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/ui/dialogs/pacs_config_dialog.hpp
+++ b/include/ui/dialogs/pacs_config_dialog.hpp
@@ -27,6 +27,20 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file pacs_config_dialog.hpp
+ * @brief Dialog for managing PACS server configurations
+ * @details Provides UI for adding, editing, and removing PACS servers with
+ *          connection test via C-ECHO. Returns selected server ID
+ *          on acceptance.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QDialog-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/ui/dialogs/settings_dialog.hpp
+++ b/include/ui/dialogs/settings_dialog.hpp
@@ -27,6 +27,20 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file settings_dialog.hpp
+ * @brief Application settings dialog with log level configuration
+ * @details Configures application settings including log level selection
+ *          (four levels with descriptions). Changes are persisted
+ *          via QSettings.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QDialog-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/ui/dialogs/video_export_dialog.hpp
+++ b/include/ui/dialogs/video_export_dialog.hpp
@@ -27,6 +27,20 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file video_export_dialog.hpp
+ * @brief Configuration dialog for video export parameters
+ * @details Allows selection of export mode (2D Cine, 3D Rotation, Combined)
+ *          with resolution, FPS, and mode-specific parameters.
+ *          Generates VideoExporter configuration structs.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QDialog-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "services/export/video_exporter.hpp"

--- a/include/ui/display_3d_controller.hpp
+++ b/include/ui/display_3d_controller.hpp
@@ -27,6 +27,18 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file display_3d_controller.hpp
+ * @brief Routes Display 3D checkbox toggles to rendering backends
+ * @details Maps Display3DItem toggles (Volume, Surface, Streamline, etc.)
+ *          to renderer visibility calls. Does not derive from QObject;
+ *          caller wires FlowToolPanel::display3DToggled to handleToggle()
+ *          via lambda.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/ui/dr_viewer.hpp
+++ b/include/ui/dr_viewer.hpp
@@ -27,6 +27,21 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file dr_viewer.hpp
+ * @brief DR/CR window for radiograph comparison and annotation
+ * @details Provides comparison layout modes (SideBySide, TopBottom, Overlay)
+ *          for prior studies. Supports DR presets (window/level),
+ *          annotation types (Text, Arrow, Marker), and comparison
+ *          navigation.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QWidget-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/ui/drop_handler.hpp
+++ b/include/ui/drop_handler.hpp
@@ -27,6 +27,20 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file drop_handler.hpp
+ * @brief Drag-and-drop handler for DICOM viewers
+ * @details Classifies dropped content (DicomFolder, ProjectFile, MaskFile,
+ *          StlFile). Detects DICOM folders by checking DICM magic
+ *          bytes. Installed as event filter on QWidget targets.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QObject-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <QObject>

--- a/include/ui/intro_page.hpp
+++ b/include/ui/intro_page.hpp
@@ -27,6 +27,20 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file intro_page.hpp
+ * @brief Landing page shown on application startup
+ * @details Provides quick access to DICOM import, project opening, recent
+ *          project list, and PACS connection before any data is loaded.
+ *          Emits signals for user actions.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QWidget-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/ui/main_window.hpp
+++ b/include/ui/main_window.hpp
@@ -27,6 +27,21 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file main_window.hpp
+ * @brief Main application window with dockable panels and VTK viewports
+ * @details Qt6-based main window coordinating DICOM loading, PACS access,
+ *          settings management, and viewport layout. Integrates
+ *          dockable tool panels, toolbar, and status bar with VTK
+ *          rendering widgets.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QMainWindow-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/ui/mask_wizard_controller.hpp
+++ b/include/ui/mask_wizard_controller.hpp
@@ -27,6 +27,23 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file mask_wizard_controller.hpp
+ * @brief Coordinates MaskWizard UI with segmentation service layer
+ * @details Wires 4-step wizard (Crop, Threshold, Separate, Track) to
+ *          ThresholdSegmenter, ConnectedComponentImageFilter,
+ *          PhaseTracker, and LabelManager. Long-running operations
+ *          run asynchronously via QtConcurrent.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QObject-derived)
+ * - Long-running segmentation tasks dispatched via QtConcurrent
+ * - Results delivered back to UI thread via signals
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "ui/dialogs/mask_wizard.hpp"

--- a/include/ui/mpr_view_widget.hpp
+++ b/include/ui/mpr_view_widget.hpp
@@ -27,6 +27,20 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file mpr_view_widget.hpp
+ * @brief Composite widget displaying synchronized MPR views with segmentation
+ * @details Provides 2x2 layout of MPR views (Axial, Coronal, Sagittal, 3D)
+ *          with synchronized crosshair navigation, segmentation tools,
+ *          label map overlay, and coordinate transformation.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QWidget-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "services/mpr_renderer.hpp"

--- a/include/ui/panels/flow_tool_panel.hpp
+++ b/include/ui/panels/flow_tool_panel.hpp
@@ -27,6 +27,21 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file flow_tool_panel.hpp
+ * @brief Panel for controlling 4D Flow display and analysis
+ * @details Provides Display 2D (Mask, Velocity, Streamline, EnergyLoss,
+ *          Vorticity, VelocityTexture) and Display 3D (MaskVolume,
+ *          Surface, Cine, Magnitude, Velocity, ASC, Streamline,
+ *          EnergyLoss, WSS, OSI, AFI, RRT) toggles.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QWidget-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <cstdint>

--- a/include/ui/panels/overlay_control_panel.hpp
+++ b/include/ui/panels/overlay_control_panel.hpp
@@ -27,6 +27,20 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file overlay_control_panel.hpp
+ * @brief UI panel for controlling 2D hemodynamic overlay display
+ * @details Provides checkboxes for each overlay type with per-overlay
+ *          colormap range controls and opacity sliders. Emits
+ *          signals on setting changes.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QWidget-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/ui/panels/patient_browser.hpp
+++ b/include/ui/panels/patient_browser.hpp
@@ -27,6 +27,21 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file patient_browser.hpp
+ * @brief Patient browser panel for navigating DICOM studies
+ * @details Displays hierarchical tree view of Patients, Studies, and Series.
+ *          Supports loading from directory, PACS query results,
+ *          or manual entry. Classifies series as 4D Flow or other
+ *          modality.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QWidget-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/ui/panels/report_panel.hpp
+++ b/include/ui/panels/report_panel.hpp
@@ -27,6 +27,20 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file report_panel.hpp
+ * @brief Report and export panel for the workflow Report stage
+ * @details Quick-access buttons for all export operations: Screenshot, Movie,
+ *          MATLAB, Ensight, DICOM, and Report generation. Embedded
+ *          in WorkflowPanel as Report tab content.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QWidget-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/ui/panels/segmentation_panel.hpp
+++ b/include/ui/panels/segmentation_panel.hpp
@@ -27,6 +27,20 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file segmentation_panel.hpp
+ * @brief UI panel for manual segmentation tools
+ * @details Provides access to segmentation tools (Brush, Eraser, Fill,
+ *          Freehand, Polygon, Smart Scissors) with configurable
+ *          parameters including brush size, shape, and active label.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QWidget-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/ui/panels/statistics_panel.hpp
+++ b/include/ui/panels/statistics_panel.hpp
@@ -27,6 +27,20 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file statistics_panel.hpp
+ * @brief Panel for displaying ROI statistics and histogram
+ * @details Displays comprehensive statistics for selected ROIs (mean, stdDev,
+ *          min, max, median) with histogram visualization, multi-ROI
+ *          comparison, and CSV export.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QWidget-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "services/measurement/roi_statistics.hpp"

--- a/include/ui/panels/tools_panel.hpp
+++ b/include/ui/panels/tools_panel.hpp
@@ -27,6 +27,20 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file tools_panel.hpp
+ * @brief Tools panel providing context-sensitive tool options
+ * @details Displays tool settings based on selected tool category (Navigation,
+ *          Measurement, Annotation, Visualization). Provides quick
+ *          access to window/level presets and visualization modes.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QWidget-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/ui/panels/workflow_panel.hpp
+++ b/include/ui/panels/workflow_panel.hpp
@@ -27,6 +27,20 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file workflow_panel.hpp
+ * @brief Container panel that organizes tools by workflow stage
+ * @details Combines WorkflowTabBar with QStackedWidget to present
+ *          stage-appropriate tools: Preprocessing, Segmentation,
+ *          Analysis, and Report.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QWidget-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include "ui/widgets/workflow_tab_bar.hpp"

--- a/include/ui/quantification_window.hpp
+++ b/include/ui/quantification_window.hpp
@@ -27,6 +27,21 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file quantification_window.hpp
+ * @brief Window for displaying hemodynamic measurement parameters
+ * @details Displays quantification rows (FlowRate, PeakVelocity,
+ *          MeanVelocity, KineticEnergy) with mean/stdDev/max/min
+ *          statistics. Also shows volume-level parameters
+ *          (TotalKE, VortexVolume, EnergyLoss).
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QMainWindow-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/ui/viewport_layout_manager.hpp
+++ b/include/ui/viewport_layout_manager.hpp
@@ -27,6 +27,20 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file viewport_layout_manager.hpp
+ * @brief Manages viewport layout with 1/2/4-split modes
+ * @details Uses QStackedWidget to switch between layout containers for
+ *          Single, DualSplit (2D|3D), and QuadSplit (2x2 grid).
+ *          Provides access to primary and secondary viewports.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QWidget-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/ui/viewport_widget.hpp
+++ b/include/ui/viewport_widget.hpp
@@ -27,6 +27,23 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file viewport_widget.hpp
+ * @brief VTK viewport widget for medical image visualization
+ * @details Wraps QVTKOpenGLNativeWidget for volume rendering, MPR views,
+ *          surface rendering, and segmentation. Supports multiple
+ *          rendering modes (VolumeRendering, SurfaceRendering,
+ *          MPR, SingleSlice).
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QWidget-derived)
+ * - VTK rendering calls must be synchronized with Qt paint events
+ * - Background data loading should use signals to update the viewport
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/ui/widgets/flow_graph_widget.hpp
+++ b/include/ui/widgets/flow_graph_widget.hpp
@@ -27,6 +27,20 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file flow_graph_widget.hpp
+ * @brief Custom QPainter-based time-series graph widget
+ * @details Renders flow rate curves over cardiac phases with multi-plane
+ *          display, auto/manual Y-axis scaling, and phase marker.
+ *          Uses QPainter directly to avoid Qt Charts dependency.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QWidget-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/ui/widgets/phase_slider_widget.hpp
+++ b/include/ui/widgets/phase_slider_widget.hpp
@@ -27,6 +27,20 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file phase_slider_widget.hpp
+ * @brief Widget for cardiac phase navigation with cine playback
+ * @details Provides slider, spinbox, and play/stop controls for navigating
+ *          through cardiac phases in 4D Flow MRI data. Layout:
+ *          Phase [Play/Stop] slider [current/total].
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QWidget-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/ui/widgets/sp_mode_toggle.hpp
+++ b/include/ui/widgets/sp_mode_toggle.hpp
@@ -27,6 +27,20 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file sp_mode_toggle.hpp
+ * @brief Toggle widget for S/P (Slice/Phase) scroll mode
+ * @details Provides two mutually exclusive buttons [S] [P] that switch
+ *          scroll wheel behavior between slice navigation and
+ *          phase navigation in 4D Flow MRI viewers.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QWidget-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <memory>

--- a/include/ui/widgets/workflow_tab_bar.hpp
+++ b/include/ui/widgets/workflow_tab_bar.hpp
@@ -27,6 +27,21 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+/**
+ * @file workflow_tab_bar.hpp
+ * @brief Tab bar for switching between workflow stages
+ * @details Provides 4 tabs representing sequential analysis workflow:
+ *          Preprocessing, Segmentation, Analysis, and Report.
+ *          Each tab reconfigures the tool panel to show
+ *          stage-relevant tools.
+ *
+ * ## Thread Safety
+ * - All methods must be called from the Qt UI thread (QTabBar-derived)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
 #pragma once
 
 #include <QTabBar>


### PR DESCRIPTION
Closes #447

## Summary
- Add Doxygen `@file`, `@brief`, `@details`, `@author`, `@since` tags to **26 header files**
- Coverage: root-level UI (10), dialogs (4), panels (8), widgets (4)
- Thread safety notes for all Qt widget/object classes specifying UI thread requirement
- 375 lines added (documentation only, no code changes)
- **Final part** of the 3-part Doxygen documentation effort (#442)

## Files Modified

### Root (`include/ui/`) — 10 files
- `main_window.hpp`, `viewport_widget.hpp`, `mpr_view_widget.hpp`
- `viewport_layout_manager.hpp`, `quantification_window.hpp`
- `dr_viewer.hpp`, `drop_handler.hpp`, `intro_page.hpp`
- `mask_wizard_controller.hpp`, `display_3d_controller.hpp`

### Dialogs (`include/ui/dialogs/`) — 4 files
- `mask_wizard.hpp`, `pacs_config_dialog.hpp`
- `settings_dialog.hpp`, `video_export_dialog.hpp`

### Panels (`include/ui/panels/`) — 8 files
- `flow_tool_panel.hpp`, `overlay_control_panel.hpp`
- `patient_browser.hpp`, `report_panel.hpp`
- `segmentation_panel.hpp`, `statistics_panel.hpp`
- `tools_panel.hpp`, `workflow_panel.hpp`

### Widgets (`include/ui/widgets/`) — 4 files
- `flow_graph_widget.hpp`, `phase_slider_widget.hpp`
- `sp_mode_toggle.hpp`, `workflow_tab_bar.hpp`

## Test Plan
- [x] Build passes (cmake --build Release, exit code 0)
- [x] Documentation blocks are well-formed Doxygen syntax
- [x] No runtime behavior changes (comment-only modifications)
- [x] Thread safety sections added for all Qt-derived classes

## Doxygen Coverage Summary (All 3 Parts)
| PR | Scope | Files |
|----|-------|-------|
| #448 | Core + foundational services | 37 |
| #449 | Domain services | 52 |
| #450 | UI layer | 26 |
| **Total** | **All headers** | **115** |

Part of #442