### PR TITLE
feat(network): integrate character set decoding for multilingual patient data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,10 @@ if(EXISTS "${PACS_SYSTEM_ROOT}" AND EXISTS "${PACS_SYSTEM_BUILD_DIR}/lib")
                 IMPORTED_LOCATION "${PACS_ENCODING_LIB}"
                 INTERFACE_INCLUDE_DIRECTORIES "${PACS_INCLUDE_DIRS}"
             )
+            if(APPLE)
+                set_property(TARGET pacs::encoding APPEND PROPERTY
+                    INTERFACE_LINK_LIBRARIES iconv)
+            endif()
         endif()
 
         if(PACS_INTEGRATION_LIB)

--- a/src/services/export/dicom_sr_writer.cpp
+++ b/src/services/export/dicom_sr_writer.cpp
@@ -49,6 +49,7 @@
 #include <pacs/core/dicom_tag.hpp>
 #include <pacs/core/dicom_tag_constants.hpp>
 #include <pacs/core/result.hpp>
+#include <pacs/encoding/dataset_charset.hpp>
 #include <pacs/encoding/transfer_syntax.hpp>
 #include <pacs/encoding/vr_type.hpp>
 #include <pacs/network/association.hpp>
@@ -444,6 +445,7 @@ private:
         ds.set_string(tags::sop_class_uid, vr_type::UI,
                       std::string(pacs::services::sop_classes::comprehensive_sr_storage_uid));
         ds.set_string(tags::sop_instance_uid, vr_type::UI, sopUid);
+        ds.set_string(tags::specific_character_set, vr_type::CS, "ISO_IR 192");
 
         // Patient Module
         if (options.includePatientInfo) {

--- a/src/services/pacs/dicom_find_scu.cpp
+++ b/src/services/pacs/dicom_find_scu.cpp
@@ -44,6 +44,7 @@
 #include <pacs/network/dimse/dimse_message.hpp>
 #include <pacs/network/dimse/status_codes.hpp>
 #include <pacs/services/query_scu.hpp>
+#include <pacs/encoding/dataset_charset.hpp>
 #include <pacs/encoding/vr_type.hpp>
 
 namespace dicom_viewer::services {
@@ -96,11 +97,11 @@ inline constexpr pacs::core::dicom_tag body_part_examined{0x0018, 0x0015};
 }
 
 /**
- * @brief Helper to safely get string from pacs_system dataset
+ * @brief Helper to safely get string from pacs_system dataset with charset decoding
  */
 std::string getStringFromDataset(const pacs::core::dicom_dataset& dataset,
                                   pacs::core::dicom_tag tag) {
-    return dataset.get_string(tag, "");
+    return pacs::encoding::get_decoded_string(dataset, tag);
 }
 
 /**

--- a/src/services/pacs/dicom_store_scp.cpp
+++ b/src/services/pacs/dicom_store_scp.cpp
@@ -45,6 +45,7 @@
 #include <pacs/network/server_config.hpp>
 #include <pacs/services/storage_scp.hpp>
 #include <pacs/services/verification_scp.hpp>
+#include <pacs/encoding/dataset_charset.hpp>
 #include <pacs/encoding/vr_type.hpp>
 #include <pacs/encoding/transfer_syntax.hpp>
 
@@ -314,7 +315,7 @@ private:
         info.filePath = filePath;
         info.sopClassUid = dataset.get_string(tags::sop_class_uid, "");
         info.sopInstanceUid = sopInstanceUid;
-        info.patientId = patientId;
+        info.patientId = pacs::encoding::get_decoded_string(dataset, tags::patient_id);
         info.studyInstanceUid = studyUid;
         info.seriesInstanceUid = seriesUid;
         info.callingAeTitle = callingAe;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -139,6 +139,21 @@ target_include_directories(dicom_find_scu_test PRIVATE
     ${CMAKE_SOURCE_DIR}/include
 )
 
+# Unit tests for character set decoding
+add_executable(charset_decoding_test
+    unit/charset_decoding_test.cpp
+)
+
+target_link_libraries(charset_decoding_test PRIVATE
+    pacs_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(charset_decoding_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
 # VTK module autoinit for tests
 vtk_module_autoinit(
     TARGETS volume_renderer_test transfer_function_manager_test mpr_renderer_test surface_renderer_test
@@ -178,6 +193,7 @@ gtest_discover_tests(mpr_renderer_test DISCOVERY_TIMEOUT 60)
 gtest_discover_tests(surface_renderer_test DISCOVERY_TIMEOUT 60)
 gtest_discover_tests(dicom_echo_scu_test DISCOVERY_TIMEOUT 60)
 gtest_discover_tests(dicom_find_scu_test DISCOVERY_TIMEOUT 60)
+gtest_discover_tests(charset_decoding_test DISCOVERY_TIMEOUT 60)
 
 # Unit tests for DICOM Move SCU
 add_executable(dicom_move_scu_test

--- a/tests/unit/charset_decoding_test.cpp
+++ b/tests/unit/charset_decoding_test.cpp
@@ -1,0 +1,128 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <pacs/core/dicom_dataset.hpp>
+#include <pacs/core/dicom_tag_constants.hpp>
+#include <pacs/encoding/character_set.hpp>
+#include <pacs/encoding/dataset_charset.hpp>
+#include <pacs/encoding/vr_type.hpp>
+
+#include <string>
+
+namespace {
+
+using namespace pacs::core;
+using namespace pacs::encoding;
+
+class CharsetDecodingTest : public ::testing::Test {};
+
+TEST_F(CharsetDecodingTest, Utf8PatientNamePassthrough) {
+    dicom_dataset ds;
+    ds.set_string(tags::specific_character_set, vr_type::CS, "ISO_IR 192");
+    ds.set_string(tags::patient_name, vr_type::PN, "Hong^GilDong");
+
+    auto result = get_decoded_string(ds, tags::patient_name);
+    EXPECT_EQ(result, "Hong^GilDong");
+}
+
+TEST_F(CharsetDecodingTest, Utf8KoreanPatientName) {
+    dicom_dataset ds;
+    ds.set_string(tags::specific_character_set, vr_type::CS, "ISO_IR 192");
+    // UTF-8 encoded Korean name
+    ds.set_string(tags::patient_name, vr_type::PN,
+                  "\xED\x99\x8D\x5E\xEA\xB8\xB8\xEB\x8F\x99");
+
+    auto result = get_decoded_string(ds, tags::patient_name);
+    // Should pass through unchanged since dataset is already UTF-8
+    EXPECT_EQ(result, "\xED\x99\x8D\x5E\xEA\xB8\xB8\xEB\x8F\x99");
+}
+
+TEST_F(CharsetDecodingTest, Latin1Decoding) {
+    dicom_dataset ds;
+    ds.set_string(tags::specific_character_set, vr_type::CS, "ISO_IR 100");
+    // Latin-1: "café" = 0x63 0x61 0x66 0xE9
+    ds.set_string(tags::patient_name, vr_type::PN, "caf\xE9");
+
+    auto result = get_decoded_string(ds, tags::patient_name);
+    // Should decode to UTF-8: "café" = 0x63 0x61 0x66 0xC3 0xA9
+    EXPECT_EQ(result, "caf\xC3\xA9");
+}
+
+TEST_F(CharsetDecodingTest, AsciiDefaultWhenNoCharset) {
+    dicom_dataset ds;
+    // No Specific Character Set set — defaults to ASCII
+    ds.set_string(tags::patient_name, vr_type::PN, "Smith^John");
+
+    auto result = get_decoded_string(ds, tags::patient_name);
+    EXPECT_EQ(result, "Smith^John");
+}
+
+TEST_F(CharsetDecodingTest, MissingTagReturnsEmpty) {
+    dicom_dataset ds;
+    ds.set_string(tags::specific_character_set, vr_type::CS, "ISO_IR 192");
+
+    auto result = get_decoded_string(ds, tags::patient_name);
+    EXPECT_TRUE(result.empty());
+}
+
+TEST_F(CharsetDecodingTest, StudyDescriptionDecoding) {
+    dicom_dataset ds;
+    ds.set_string(tags::specific_character_set, vr_type::CS, "ISO_IR 100");
+    // Latin-1: "Röntgen" = R 0xF6 ntgen
+    ds.set_string(tags::study_description, vr_type::LO, "R\xF6ntgen");
+
+    auto result = get_decoded_string(ds, tags::study_description);
+    // UTF-8: "Röntgen" = R 0xC3 0xB6 ntgen
+    EXPECT_EQ(result, "R\xC3\xB6ntgen");
+}
+
+TEST_F(CharsetDecodingTest, SetEncodedStringRoundTrip) {
+    dicom_dataset ds;
+    ds.set_string(tags::specific_character_set, vr_type::CS, "ISO_IR 100");
+
+    // Encode UTF-8 "café" to Latin-1 in dataset
+    set_encoded_string(ds, tags::patient_name, vr_type::PN, "caf\xC3\xA9");
+
+    // Decode back from dataset to UTF-8
+    auto result = get_decoded_string(ds, tags::patient_name);
+    EXPECT_EQ(result, "caf\xC3\xA9");
+}
+
+TEST_F(CharsetDecodingTest, UidNotAffectedByCharset) {
+    dicom_dataset ds;
+    ds.set_string(tags::specific_character_set, vr_type::CS, "ISO_IR 192");
+    ds.set_string(tags::study_instance_uid, vr_type::UI, "1.2.840.113619.2.55.3");
+
+    auto result = get_decoded_string(ds, tags::study_instance_uid);
+    EXPECT_EQ(result, "1.2.840.113619.2.55.3");
+}
+
+} // anonymous namespace


### PR DESCRIPTION
Closes #453

## Summary
- Integrate `pacs::encoding::get_decoded_string()` API into dicom_viewer for proper decoding of non-ASCII patient data (Korean EUC-KR, Latin-1, etc.)
- Apply charset-aware decoding to C-FIND responses (`dicom_find_scu`), Store SCP received images (`dicom_store_scp`), and SR Writer output (`dicom_sr_writer`)
- Add iconv linkage for `pacs::encoding` on macOS to resolve linker dependency

## Changes

| File | Change |
|------|--------|
| `src/services/pacs/dicom_find_scu.cpp` | Use `get_decoded_string()` for all C-FIND response string extraction |
| `src/services/pacs/dicom_store_scp.cpp` | Decode patient ID from dataset charset in post-store handler |
| `src/services/export/dicom_sr_writer.cpp` | Set Specific Character Set tag (ISO_IR 192) for UTF-8 SR documents |
| `CMakeLists.txt` | Link iconv for `pacs::encoding` imported target on APPLE |
| `tests/unit/charset_decoding_test.cpp` | 8 unit tests covering UTF-8 passthrough, Latin-1 to UTF-8 conversion, Korean names, round-trip encoding, and edge cases |
| `tests/CMakeLists.txt` | Register `charset_decoding_test` target |

## Test Plan
- [x] All 8 new charset decoding tests pass locally
- [x] Full test suite (3079 tests) passes with no new regressions
- [ ] CI build and test workflow passes