### PR TITLE
feat(network): add HTJ2K transfer syntax support via pacs_system codec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,49 @@ if(EXISTS "${PACS_SYSTEM_ROOT}" AND EXISTS "${PACS_SYSTEM_BUILD_DIR}/lib")
                 set_property(TARGET pacs::encoding APPEND PROPERTY
                     INTERFACE_LINK_LIBRARIES iconv)
             endif()
+
+            # pacs_encoding codec dependencies (transitive from pacs_system)
+            find_package(JPEG QUIET)
+            if(JPEG_FOUND)
+                set_property(TARGET pacs::encoding APPEND PROPERTY
+                    INTERFACE_LINK_LIBRARIES JPEG::JPEG)
+            endif()
+
+            find_package(OpenJPEG QUIET)
+            if(OpenJPEG_FOUND AND TARGET openjp2)
+                set_property(TARGET pacs::encoding APPEND PROPERTY
+                    INTERFACE_LINK_LIBRARIES openjp2)
+            else()
+                find_library(OPENJP2_LIB openjp2)
+                if(OPENJP2_LIB)
+                    set_property(TARGET pacs::encoding APPEND PROPERTY
+                        INTERFACE_LINK_LIBRARIES "${OPENJP2_LIB}")
+                endif()
+            endif()
+
+            find_package(openjph CONFIG QUIET)
+            if(openjph_FOUND AND TARGET openjph::openjph)
+                set_property(TARGET pacs::encoding APPEND PROPERTY
+                    INTERFACE_LINK_LIBRARIES openjph::openjph)
+            else()
+                find_library(OPENJPH_LIB openjph)
+                if(OPENJPH_LIB)
+                    set_property(TARGET pacs::encoding APPEND PROPERTY
+                        INTERFACE_LINK_LIBRARIES "${OPENJPH_LIB}")
+                endif()
+            endif()
+
+            find_package(charls CONFIG QUIET)
+            if(charls_FOUND AND TARGET charls::charls)
+                set_property(TARGET pacs::encoding APPEND PROPERTY
+                    INTERFACE_LINK_LIBRARIES charls::charls)
+            else()
+                find_library(CHARLS_LIB charls)
+                if(CHARLS_LIB)
+                    set_property(TARGET pacs::encoding APPEND PROPERTY
+                        INTERFACE_LINK_LIBRARIES "${CHARLS_LIB}")
+                endif()
+            endif()
         endif()
 
         if(PACS_INTEGRATION_LIB)

--- a/include/services/dicom_store_scp.hpp
+++ b/include/services/dicom_store_scp.hpp
@@ -193,6 +193,19 @@ public:
     static constexpr const char* ENHANCED_CT_STORAGE = "1.2.840.10008.5.1.4.1.1.2.1";
     static constexpr const char* ENHANCED_MR_STORAGE = "1.2.840.10008.5.1.4.1.1.4.1";
 
+    // HTJ2K Transfer Syntax UIDs (DICOM Supplement 235)
+    static constexpr const char* HTJ2K_LOSSLESS = "1.2.840.10008.1.2.4.201";
+    static constexpr const char* HTJ2K_RPCL = "1.2.840.10008.1.2.4.202";
+    static constexpr const char* HTJ2K_LOSSY = "1.2.840.10008.1.2.4.203";
+
+    /**
+     * @brief Get list of supported transfer syntax UIDs
+     *
+     * Returns all transfer syntaxes the Store SCP can accept,
+     * including standard uncompressed and HTJ2K compressed syntaxes.
+     */
+    [[nodiscard]] static std::vector<std::string> getSupportedTransferSyntaxes();
+
     DicomStoreSCP();
     ~DicomStoreSCP();
 

--- a/src/services/pacs/dicom_move_scu.cpp
+++ b/src/services/pacs/dicom_move_scu.cpp
@@ -246,9 +246,12 @@ private:
         moveCtx.id = 1;
         moveCtx.abstract_syntax = moveSopClassUid;
         moveCtx.transfer_syntaxes = {
-            "1.2.840.10008.1.2.1",  // Explicit VR Little Endian
-            "1.2.840.10008.1.2.2",  // Explicit VR Big Endian
-            "1.2.840.10008.1.2"     // Implicit VR Little Endian
+            "1.2.840.10008.1.2.1",    // Explicit VR Little Endian
+            "1.2.840.10008.1.2.2",    // Explicit VR Big Endian
+            "1.2.840.10008.1.2",      // Implicit VR Little Endian
+            "1.2.840.10008.1.2.4.201", // HTJ2K Lossless
+            "1.2.840.10008.1.2.4.202", // HTJ2K Lossless RPCL
+            "1.2.840.10008.1.2.4.203"  // HTJ2K Lossy
         };
         assocConfig.proposed_contexts.push_back(moveCtx);
 

--- a/src/services/pacs/dicom_store_scp.cpp
+++ b/src/services/pacs/dicom_store_scp.cpp
@@ -430,4 +430,15 @@ std::vector<std::string> DicomStoreSCP::getSupportedSopClasses() {
     };
 }
 
+std::vector<std::string> DicomStoreSCP::getSupportedTransferSyntaxes() {
+    return {
+        "1.2.840.10008.1.2",      // Implicit VR Little Endian
+        "1.2.840.10008.1.2.1",    // Explicit VR Little Endian
+        "1.2.840.10008.1.2.2",    // Explicit VR Big Endian
+        HTJ2K_LOSSLESS,           // HTJ2K Lossless
+        HTJ2K_RPCL,              // HTJ2K Lossless RPCL
+        HTJ2K_LOSSY              // HTJ2K Lossy
+    };
+}
+
 } // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -183,6 +183,20 @@ target_include_directories(storage_commitment_test PRIVATE
     ${CMAKE_SOURCE_DIR}/include
 )
 
+add_executable(htj2k_transfer_syntax_test
+    unit/htj2k_transfer_syntax_test.cpp
+)
+
+target_link_libraries(htj2k_transfer_syntax_test PRIVATE
+    pacs_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(htj2k_transfer_syntax_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
 # VTK module autoinit for tests
 vtk_module_autoinit(
     TARGETS volume_renderer_test transfer_function_manager_test mpr_renderer_test surface_renderer_test
@@ -225,6 +239,7 @@ gtest_discover_tests(dicom_find_scu_test DISCOVERY_TIMEOUT 60)
 gtest_discover_tests(charset_decoding_test DISCOVERY_TIMEOUT 60)
 gtest_discover_tests(iod_validation_test DISCOVERY_TIMEOUT 60)
 gtest_discover_tests(storage_commitment_test DISCOVERY_TIMEOUT 60)
+gtest_discover_tests(htj2k_transfer_syntax_test DISCOVERY_TIMEOUT 60)
 
 # Unit tests for DICOM Move SCU
 add_executable(dicom_move_scu_test

--- a/tests/unit/htj2k_transfer_syntax_test.cpp
+++ b/tests/unit/htj2k_transfer_syntax_test.cpp
@@ -1,0 +1,204 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <services/dicom_store_scp.hpp>
+
+#include <pacs/encoding/transfer_syntax.hpp>
+#include <pacs/encoding/compression/htj2k_codec.hpp>
+#include <pacs/encoding/compression/codec_factory.hpp>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace dicom_viewer::services;
+
+class Htj2kTransferSyntaxTest : public ::testing::Test {};
+
+// --- HTJ2K Transfer Syntax UID Constants ---
+
+TEST_F(Htj2kTransferSyntaxTest, LosslessUidCorrect) {
+    EXPECT_STREQ(DicomStoreSCP::HTJ2K_LOSSLESS, "1.2.840.10008.1.2.4.201");
+}
+
+TEST_F(Htj2kTransferSyntaxTest, RpclUidCorrect) {
+    EXPECT_STREQ(DicomStoreSCP::HTJ2K_RPCL, "1.2.840.10008.1.2.4.202");
+}
+
+TEST_F(Htj2kTransferSyntaxTest, LossyUidCorrect) {
+    EXPECT_STREQ(DicomStoreSCP::HTJ2K_LOSSY, "1.2.840.10008.1.2.4.203");
+}
+
+// --- Supported Transfer Syntaxes List ---
+
+TEST_F(Htj2kTransferSyntaxTest, SupportedTransferSyntaxesIncludesHtj2k) {
+    auto ts = DicomStoreSCP::getSupportedTransferSyntaxes();
+
+    auto contains = [&](const std::string& uid) {
+        return std::find(ts.begin(), ts.end(), uid) != ts.end();
+    };
+
+    EXPECT_TRUE(contains(DicomStoreSCP::HTJ2K_LOSSLESS))
+        << "Supported transfer syntaxes should include HTJ2K Lossless";
+    EXPECT_TRUE(contains(DicomStoreSCP::HTJ2K_RPCL))
+        << "Supported transfer syntaxes should include HTJ2K RPCL";
+    EXPECT_TRUE(contains(DicomStoreSCP::HTJ2K_LOSSY))
+        << "Supported transfer syntaxes should include HTJ2K Lossy";
+}
+
+TEST_F(Htj2kTransferSyntaxTest, SupportedTransferSyntaxesIncludesStandard) {
+    auto ts = DicomStoreSCP::getSupportedTransferSyntaxes();
+
+    auto contains = [&](const std::string& uid) {
+        return std::find(ts.begin(), ts.end(), uid) != ts.end();
+    };
+
+    EXPECT_TRUE(contains("1.2.840.10008.1.2"))
+        << "Should include Implicit VR Little Endian";
+    EXPECT_TRUE(contains("1.2.840.10008.1.2.1"))
+        << "Should include Explicit VR Little Endian";
+}
+
+TEST_F(Htj2kTransferSyntaxTest, SupportedTransferSyntaxesNotEmpty) {
+    auto ts = DicomStoreSCP::getSupportedTransferSyntaxes();
+    EXPECT_GE(ts.size(), 6u)
+        << "Should have at least 6 transfer syntaxes (3 standard + 3 HTJ2K)";
+}
+
+// --- pacs_system Transfer Syntax Registry ---
+
+TEST_F(Htj2kTransferSyntaxTest, Htj2kLosslessRegisteredInPacs) {
+    auto ts = pacs::encoding::find_transfer_syntax("1.2.840.10008.1.2.4.201");
+    ASSERT_TRUE(ts.has_value())
+        << "HTJ2K Lossless should be registered in pacs_system";
+    EXPECT_TRUE(ts->is_encapsulated())
+        << "HTJ2K Lossless should be encapsulated";
+    EXPECT_TRUE(ts->is_valid());
+}
+
+TEST_F(Htj2kTransferSyntaxTest, Htj2kRpclRegisteredInPacs) {
+    auto ts = pacs::encoding::find_transfer_syntax("1.2.840.10008.1.2.4.202");
+    ASSERT_TRUE(ts.has_value())
+        << "HTJ2K RPCL should be registered in pacs_system";
+    EXPECT_TRUE(ts->is_encapsulated());
+}
+
+TEST_F(Htj2kTransferSyntaxTest, Htj2kLossyRegisteredInPacs) {
+    auto ts = pacs::encoding::find_transfer_syntax("1.2.840.10008.1.2.4.203");
+    ASSERT_TRUE(ts.has_value())
+        << "HTJ2K Lossy should be registered in pacs_system";
+    EXPECT_TRUE(ts->is_encapsulated());
+}
+
+// --- HTJ2K Codec Properties ---
+
+TEST_F(Htj2kTransferSyntaxTest, CodecLosslessMode) {
+    pacs::encoding::compression::htj2k_codec codec(true, false);
+    EXPECT_TRUE(codec.is_lossless_mode());
+    EXPECT_FALSE(codec.is_lossy());
+    EXPECT_FALSE(codec.is_rpcl_mode());
+    EXPECT_EQ(codec.transfer_syntax_uid(), "1.2.840.10008.1.2.4.201");
+}
+
+TEST_F(Htj2kTransferSyntaxTest, CodecRpclMode) {
+    pacs::encoding::compression::htj2k_codec codec(true, true);
+    EXPECT_TRUE(codec.is_lossless_mode());
+    EXPECT_FALSE(codec.is_lossy());
+    EXPECT_TRUE(codec.is_rpcl_mode());
+    EXPECT_EQ(codec.transfer_syntax_uid(), "1.2.840.10008.1.2.4.202");
+}
+
+TEST_F(Htj2kTransferSyntaxTest, CodecLossyMode) {
+    pacs::encoding::compression::htj2k_codec codec(false, false);
+    EXPECT_FALSE(codec.is_lossless_mode());
+    EXPECT_TRUE(codec.is_lossy());
+    EXPECT_EQ(codec.transfer_syntax_uid(), "1.2.840.10008.1.2.4.203");
+}
+
+TEST_F(Htj2kTransferSyntaxTest, CodecDefaultCompressionRatio) {
+    pacs::encoding::compression::htj2k_codec codec;
+    EXPECT_FLOAT_EQ(codec.compression_ratio(),
+                    pacs::encoding::compression::htj2k_codec::kDefaultCompressionRatio);
+}
+
+TEST_F(Htj2kTransferSyntaxTest, CodecDefaultResolutionLevels) {
+    pacs::encoding::compression::htj2k_codec codec;
+    EXPECT_EQ(codec.resolution_levels(),
+              pacs::encoding::compression::htj2k_codec::kDefaultResolutionLevels);
+}
+
+TEST_F(Htj2kTransferSyntaxTest, CodecCustomCompressionRatio) {
+    pacs::encoding::compression::htj2k_codec codec(false, false, 10.0f);
+    EXPECT_FLOAT_EQ(codec.compression_ratio(), 10.0f);
+}
+
+TEST_F(Htj2kTransferSyntaxTest, CodecNameNotEmpty) {
+    pacs::encoding::compression::htj2k_codec codec;
+    EXPECT_FALSE(codec.name().empty());
+}
+
+// --- Codec Factory ---
+
+TEST_F(Htj2kTransferSyntaxTest, CodecFactoryCreatesHtj2kLossless) {
+    auto codec = pacs::encoding::compression::codec_factory::create("1.2.840.10008.1.2.4.201");
+    EXPECT_NE(codec, nullptr)
+        << "Codec factory should create HTJ2K Lossless codec";
+}
+
+TEST_F(Htj2kTransferSyntaxTest, CodecFactoryCreatesHtj2kRpcl) {
+    auto codec = pacs::encoding::compression::codec_factory::create("1.2.840.10008.1.2.4.202");
+    EXPECT_NE(codec, nullptr)
+        << "Codec factory should create HTJ2K RPCL codec";
+}
+
+TEST_F(Htj2kTransferSyntaxTest, CodecFactoryCreatesHtj2kLossy) {
+    auto codec = pacs::encoding::compression::codec_factory::create("1.2.840.10008.1.2.4.203");
+    EXPECT_NE(codec, nullptr)
+        << "Codec factory should create HTJ2K Lossy codec";
+}
+
+TEST_F(Htj2kTransferSyntaxTest, CodecFactoryReportsHtj2kSupported) {
+    EXPECT_TRUE(pacs::encoding::compression::codec_factory::is_supported("1.2.840.10008.1.2.4.201"));
+    EXPECT_TRUE(pacs::encoding::compression::codec_factory::is_supported("1.2.840.10008.1.2.4.202"));
+    EXPECT_TRUE(pacs::encoding::compression::codec_factory::is_supported("1.2.840.10008.1.2.4.203"));
+}
+
+// --- SOP Classes Still Correct ---
+
+TEST_F(Htj2kTransferSyntaxTest, SopClassesUnchanged) {
+    auto sop = DicomStoreSCP::getSupportedSopClasses();
+    EXPECT_EQ(sop.size(), 5u)
+        << "SOP classes list should remain unchanged (5 classes)";
+}
+
+} // anonymous namespace


### PR DESCRIPTION
Closes #456

## Summary
- Register HTJ2K (High-Throughput JPEG 2000) transfer syntaxes from DICOM Supplement 235 in Store SCP and Move SCU
- Add `HTJ2K_LOSSLESS`, `HTJ2K_RPCL`, `HTJ2K_LOSSY` constants and `getSupportedTransferSyntaxes()` to `DicomStoreSCP`
- Include HTJ2K transfer syntaxes in Move SCU presentation context proposals
- Fix `pacs::encoding` imported target to properly link codec dependencies (JPEG, OpenJPEG, OpenJPH, CharLS) as transitive libraries
- Add 21 unit tests covering UID constants, transfer syntax registry, codec properties, and codec factory

## Test Plan
- [x] 21 HTJ2K transfer syntax tests pass locally
- [x] Full regression suite: 3116/3133 pass (17 pre-existing failures unrelated to this change)
- [ ] CI passes on macOS-14 runner