### PR TITLE
feat(network): integrate ATNA audit trail logging for IHE compliance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,9 +561,11 @@ add_library(pacs_service STATIC
     src/services/pacs/dicom_store_scp.cpp
     src/services/pacs/pacs_config_manager.cpp
     src/services/pacs/storage_commitment_service.cpp
+    src/services/pacs/audit_service.cpp
     include/services/pacs_config_manager.hpp
     include/services/dicom_store_scp.hpp
     include/services/storage_commitment_service.hpp
+    include/services/audit_service.hpp
 )
 
 target_include_directories(pacs_service PUBLIC

--- a/include/services/audit_service.hpp
+++ b/include/services/audit_service.hpp
@@ -1,0 +1,264 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file audit_service.hpp
+ * @brief ATNA audit trail service for IHE-compliant audit logging
+ * @details Wraps pacs_system's ATNA audit logger and syslog transport
+ *          to provide a viewer-level service for emitting RFC 3881
+ *          audit events for DICOM network operations.
+ *
+ * ## Thread Safety
+ * - Enable/disable is atomic
+ * - Audit methods are safe to call from any thread
+ * - Configuration changes require stop/start cycle
+ *
+ * @see IHE ITI TF-1 Section 9 — Audit Trail and Node Authentication (ATNA)
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include "dicom_echo_scu.hpp"
+
+#include <cstdint>
+#include <expected>
+#include <memory>
+#include <string>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Transport protocol for ATNA syslog messages
+ */
+enum class AuditTransportProtocol : uint8_t {
+    Udp,  ///< UDP (RFC 5426) — fire-and-forget
+    Tls   ///< TLS over TCP (RFC 5425) — secure
+};
+
+/**
+ * @brief Configuration for the ATNA audit service
+ */
+struct AuditConfig {
+    /// Master enable/disable for ATNA audit logging
+    bool enabled = false;
+
+    /// Audit source identifier (e.g., "DICOM_VIEWER")
+    std::string auditSourceId = "DICOM_VIEWER";
+
+    /// Audit Record Repository hostname or IP
+    std::string host = "localhost";
+
+    /// Audit Record Repository port (514 for UDP, 6514 for TLS)
+    uint16_t port = 514;
+
+    /// Transport protocol
+    AuditTransportProtocol protocol = AuditTransportProtocol::Udp;
+
+    /// Path to CA certificate (TLS only)
+    std::string caCertPath;
+
+    // -- Event filtering --
+
+    /// Audit C-STORE events
+    bool auditStorage = true;
+
+    /// Audit C-FIND events
+    bool auditQuery = true;
+
+    /// Audit authentication events
+    bool auditAuthentication = true;
+
+    /// Audit security alerts
+    bool auditSecurityAlerts = true;
+
+    /**
+     * @brief Validate the configuration
+     * @return true if configuration is valid for use
+     */
+    [[nodiscard]] bool isValid() const noexcept {
+        if (!enabled) return true;  // Disabled config is always valid
+        return !auditSourceId.empty() && !host.empty() && port > 0;
+    }
+};
+
+/**
+ * @brief Statistics for the audit service
+ */
+struct AuditStatistics {
+    /// Number of audit events successfully sent
+    size_t eventsSent = 0;
+
+    /// Number of audit event send failures
+    size_t eventsFailed = 0;
+};
+
+/**
+ * @brief ATNA audit trail service for IHE-compliant logging
+ *
+ * Provides a viewer-level API for emitting RFC 3881 audit events
+ * for DICOM network operations. Wraps pacs_system's atna_service_auditor
+ * with viewer-specific configuration and event types.
+ *
+ * @example
+ * @code
+ * AuditService audit;
+ * AuditConfig config;
+ * config.enabled = true;
+ * config.host = "audit-server.hospital.local";
+ * config.port = 6514;
+ * config.protocol = AuditTransportProtocol::Tls;
+ *
+ * auto result = audit.configure(config);
+ * if (result) {
+ *     audit.auditApplicationStart();
+ *     audit.auditInstanceStored("MODALITY_01", "MY_SCP",
+ *                               "1.2.3.4.5", "PAT001", true);
+ * }
+ * @endcode
+ *
+ * @trace SRS-FR-038
+ */
+class AuditService {
+public:
+    AuditService();
+    ~AuditService();
+
+    // Non-copyable, movable
+    AuditService(const AuditService&) = delete;
+    AuditService& operator=(const AuditService&) = delete;
+    AuditService(AuditService&&) noexcept;
+    AuditService& operator=(AuditService&&) noexcept;
+
+    /**
+     * @brief Configure and initialize the audit service
+     *
+     * Creates the underlying syslog transport and auditor based on
+     * the provided configuration. If config.enabled is false, the
+     * service will accept calls but not emit any events.
+     *
+     * @param config Audit configuration
+     * @return void on success, PacsErrorInfo on failure
+     */
+    [[nodiscard]] std::expected<void, PacsErrorInfo> configure(const AuditConfig& config);
+
+    /**
+     * @brief Check if the audit service is configured and enabled
+     */
+    [[nodiscard]] bool isEnabled() const;
+
+    /**
+     * @brief Enable or disable audit event emission
+     */
+    void setEnabled(bool enabled);
+
+    /**
+     * @brief Get current configuration
+     */
+    [[nodiscard]] AuditConfig getConfig() const;
+
+    /**
+     * @brief Get audit statistics
+     */
+    [[nodiscard]] AuditStatistics getStatistics() const;
+
+    /**
+     * @brief Reset statistics counters
+     */
+    void resetStatistics();
+
+    // -- Application Lifecycle Events --
+
+    /**
+     * @brief Audit application start event
+     */
+    void auditApplicationStart();
+
+    /**
+     * @brief Audit application stop event
+     */
+    void auditApplicationStop();
+
+    // -- DICOM Service Events --
+
+    /**
+     * @brief Audit a C-STORE event (DICOM Instances Transferred)
+     *
+     * @param sourceAe Calling AE title (sender)
+     * @param destAe Called AE title (receiver)
+     * @param studyUid Study Instance UID
+     * @param patientId Patient ID (empty if unavailable)
+     * @param success Whether the operation succeeded
+     */
+    void auditInstanceStored(const std::string& sourceAe,
+                             const std::string& destAe,
+                             const std::string& studyUid,
+                             const std::string& patientId,
+                             bool success);
+
+    /**
+     * @brief Audit a C-FIND event (Query)
+     *
+     * @param callingAe Calling AE title (requester)
+     * @param calledAe Called AE title (responder)
+     * @param queryLevel Query retrieve level (PATIENT/STUDY/SERIES/IMAGE)
+     * @param success Whether the operation succeeded
+     */
+    void auditQuery(const std::string& callingAe,
+                    const std::string& calledAe,
+                    const std::string& queryLevel,
+                    bool success);
+
+    /**
+     * @brief Audit a DICOM association event (authentication)
+     *
+     * @param aeTitle AE title that connected/disconnected
+     * @param isLogin true for association established, false for released
+     * @param success Whether the operation succeeded
+     */
+    void auditAssociation(const std::string& aeTitle,
+                          bool isLogin,
+                          bool success);
+
+    /**
+     * @brief Audit a security alert event
+     *
+     * @param userId User or system identifier
+     * @param description Description of the security alert
+     */
+    void auditSecurityAlert(const std::string& userId,
+                            const std::string& description);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::services

--- a/src/services/pacs/audit_service.cpp
+++ b/src/services/pacs/audit_service.cpp
@@ -1,0 +1,284 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "services/audit_service.hpp"
+
+#include <mutex>
+
+#include <spdlog/spdlog.h>
+
+#include <pacs/security/atna_audit_logger.hpp>
+#include <pacs/security/atna_service_auditor.hpp>
+#include <pacs/security/atna_syslog_transport.hpp>
+
+namespace dicom_viewer::services {
+
+namespace {
+
+pacs::security::syslog_transport_config toTransportConfig(const AuditConfig& config) {
+    pacs::security::syslog_transport_config tc;
+    tc.host = config.host;
+    tc.port = config.port;
+    tc.protocol = (config.protocol == AuditTransportProtocol::Tls)
+        ? pacs::security::syslog_transport_protocol::tls
+        : pacs::security::syslog_transport_protocol::udp;
+    tc.app_name = "dicom_viewer";
+    tc.ca_cert_path = config.caCertPath;
+    return tc;
+}
+
+} // anonymous namespace
+
+class AuditService::Impl {
+public:
+    Impl() = default;
+
+    std::expected<void, PacsErrorInfo> configure(const AuditConfig& config) {
+        std::lock_guard lock(mutex_);
+
+        if (!config.isValid()) {
+            return std::unexpected(PacsErrorInfo{
+                PacsError::ConfigurationInvalid,
+                "Invalid ATNA audit configuration"
+            });
+        }
+
+        config_ = config;
+
+        if (!config.enabled) {
+            auditor_.reset();
+            spdlog::info("ATNA audit service configured but disabled");
+            return {};
+        }
+
+        auto tc = toTransportConfig(config);
+
+        try {
+            auditor_ = std::make_unique<pacs::security::atna_service_auditor>(
+                tc, config.auditSourceId);
+            auditor_->set_enabled(true);
+
+            transport_ = std::make_unique<pacs::security::atna_syslog_transport>(tc);
+        } catch (const std::exception& e) {
+            auditor_.reset();
+            return std::unexpected(PacsErrorInfo{
+                PacsError::InternalError,
+                std::string("Failed to initialize ATNA auditor: ") + e.what()
+            });
+        }
+
+        spdlog::info("ATNA audit service configured: {}:{} ({})",
+                     config.host, config.port,
+                     config.protocol == AuditTransportProtocol::Tls ? "TLS" : "UDP");
+        return {};
+    }
+
+    bool isEnabled() const {
+        std::lock_guard lock(mutex_);
+        return config_.enabled && auditor_ != nullptr && auditor_->is_enabled();
+    }
+
+    void setEnabled(bool enabled) {
+        std::lock_guard lock(mutex_);
+        config_.enabled = enabled;
+        if (auditor_) {
+            auditor_->set_enabled(enabled);
+        }
+    }
+
+    AuditConfig getConfig() const {
+        std::lock_guard lock(mutex_);
+        return config_;
+    }
+
+    AuditStatistics getStatistics() const {
+        std::lock_guard lock(mutex_);
+        if (!auditor_) {
+            return {};
+        }
+        return AuditStatistics{
+            auditor_->events_sent(),
+            auditor_->events_failed()
+        };
+    }
+
+    void resetStatistics() {
+        std::lock_guard lock(mutex_);
+        if (auditor_) {
+            auditor_->reset_statistics();
+        }
+    }
+
+    void auditApplicationStart() {
+        std::lock_guard lock(mutex_);
+        if (!isEnabledLocked()) return;
+
+        auto msg = pacs::security::atna_audit_logger::build_application_activity(
+            config_.auditSourceId, "dicom_viewer", true);
+        sendAudit(msg);
+    }
+
+    void auditApplicationStop() {
+        std::lock_guard lock(mutex_);
+        if (!isEnabledLocked()) return;
+
+        auto msg = pacs::security::atna_audit_logger::build_application_activity(
+            config_.auditSourceId, "dicom_viewer", false);
+        sendAudit(msg);
+    }
+
+    void auditInstanceStored(const std::string& sourceAe,
+                             const std::string& destAe,
+                             const std::string& studyUid,
+                             const std::string& patientId,
+                             bool success) {
+        std::lock_guard lock(mutex_);
+        if (!isEnabledLocked() || !config_.auditStorage) return;
+
+        auditor_->audit_instance_stored(sourceAe, destAe, studyUid, patientId, success);
+    }
+
+    void auditQuery(const std::string& callingAe,
+                    const std::string& calledAe,
+                    const std::string& queryLevel,
+                    bool success) {
+        std::lock_guard lock(mutex_);
+        if (!isEnabledLocked() || !config_.auditQuery) return;
+
+        auditor_->audit_query(callingAe, calledAe, queryLevel, success);
+    }
+
+    void auditAssociation(const std::string& aeTitle,
+                          bool isLogin,
+                          bool success) {
+        std::lock_guard lock(mutex_);
+        if (!isEnabledLocked() || !config_.auditAuthentication) return;
+
+        auditor_->audit_authentication(aeTitle, isLogin, success);
+    }
+
+    void auditSecurityAlert(const std::string& userId,
+                            const std::string& description) {
+        std::lock_guard lock(mutex_);
+        if (!isEnabledLocked() || !config_.auditSecurityAlerts) return;
+
+        auditor_->audit_security_alert(userId, description);
+    }
+
+private:
+    bool isEnabledLocked() const {
+        return config_.enabled && auditor_ != nullptr && auditor_->is_enabled();
+    }
+
+    void sendAudit(const pacs::security::atna_audit_message& msg) {
+        if (!transport_) return;
+
+        auto xml = pacs::security::atna_audit_logger::to_xml(msg);
+        auto result = transport_->send(xml);
+        if (!result.is_ok()) {
+            spdlog::warn("Failed to send ATNA audit event: {}", result.error().message);
+        }
+    }
+
+    AuditConfig config_;
+    std::unique_ptr<pacs::security::atna_service_auditor> auditor_;
+    std::unique_ptr<pacs::security::atna_syslog_transport> transport_;
+    mutable std::mutex mutex_;
+};
+
+// Public interface implementation
+
+AuditService::AuditService()
+    : impl_(std::make_unique<Impl>()) {
+}
+
+AuditService::~AuditService() = default;
+
+AuditService::AuditService(AuditService&&) noexcept = default;
+AuditService& AuditService::operator=(AuditService&&) noexcept = default;
+
+std::expected<void, PacsErrorInfo> AuditService::configure(const AuditConfig& config) {
+    return impl_->configure(config);
+}
+
+bool AuditService::isEnabled() const {
+    return impl_->isEnabled();
+}
+
+void AuditService::setEnabled(bool enabled) {
+    impl_->setEnabled(enabled);
+}
+
+AuditConfig AuditService::getConfig() const {
+    return impl_->getConfig();
+}
+
+AuditStatistics AuditService::getStatistics() const {
+    return impl_->getStatistics();
+}
+
+void AuditService::resetStatistics() {
+    impl_->resetStatistics();
+}
+
+void AuditService::auditApplicationStart() {
+    impl_->auditApplicationStart();
+}
+
+void AuditService::auditApplicationStop() {
+    impl_->auditApplicationStop();
+}
+
+void AuditService::auditInstanceStored(const std::string& sourceAe,
+                                        const std::string& destAe,
+                                        const std::string& studyUid,
+                                        const std::string& patientId,
+                                        bool success) {
+    impl_->auditInstanceStored(sourceAe, destAe, studyUid, patientId, success);
+}
+
+void AuditService::auditQuery(const std::string& callingAe,
+                               const std::string& calledAe,
+                               const std::string& queryLevel,
+                               bool success) {
+    impl_->auditQuery(callingAe, calledAe, queryLevel, success);
+}
+
+void AuditService::auditAssociation(const std::string& aeTitle,
+                                     bool isLogin,
+                                     bool success) {
+    impl_->auditAssociation(aeTitle, isLogin, success);
+}
+
+void AuditService::auditSecurityAlert(const std::string& userId,
+                                       const std::string& description) {
+    impl_->auditSecurityAlert(userId, description);
+}
+
+} // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -241,6 +241,22 @@ gtest_discover_tests(iod_validation_test DISCOVERY_TIMEOUT 60)
 gtest_discover_tests(storage_commitment_test DISCOVERY_TIMEOUT 60)
 gtest_discover_tests(htj2k_transfer_syntax_test DISCOVERY_TIMEOUT 60)
 
+add_executable(audit_service_test
+    unit/audit_service_test.cpp
+)
+
+target_link_libraries(audit_service_test PRIVATE
+    pacs_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(audit_service_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(audit_service_test DISCOVERY_TIMEOUT 60)
+
 # Unit tests for DICOM Move SCU
 add_executable(dicom_move_scu_test
     unit/dicom_move_scu_test.cpp

--- a/tests/unit/audit_service_test.cpp
+++ b/tests/unit/audit_service_test.cpp
@@ -1,0 +1,319 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <services/audit_service.hpp>
+
+#include <pacs/security/atna_audit_logger.hpp>
+#include <pacs/security/atna_config.hpp>
+
+#include <string>
+
+namespace {
+
+using namespace dicom_viewer::services;
+
+class AuditServiceTest : public ::testing::Test {
+protected:
+    AuditService service;
+};
+
+// --- Default State ---
+
+TEST_F(AuditServiceTest, DefaultNotEnabled) {
+    EXPECT_FALSE(service.isEnabled());
+}
+
+TEST_F(AuditServiceTest, DefaultConfigDisabled) {
+    auto config = service.getConfig();
+    EXPECT_FALSE(config.enabled);
+}
+
+TEST_F(AuditServiceTest, DefaultStatisticsZero) {
+    auto stats = service.getStatistics();
+    EXPECT_EQ(stats.eventsSent, 0u);
+    EXPECT_EQ(stats.eventsFailed, 0u);
+}
+
+// --- Configuration Validation ---
+
+TEST_F(AuditServiceTest, ConfigureDisabledSucceeds) {
+    AuditConfig config;
+    config.enabled = false;
+    auto result = service.configure(config);
+    EXPECT_TRUE(result.has_value())
+        << "Disabled configuration should always succeed";
+}
+
+TEST_F(AuditServiceTest, ConfigureEmptySourceIdFails) {
+    AuditConfig config;
+    config.enabled = true;
+    config.auditSourceId = "";
+    auto result = service.configure(config);
+    EXPECT_FALSE(result.has_value())
+        << "Empty audit source ID should fail validation";
+}
+
+TEST_F(AuditServiceTest, ConfigureEmptyHostFails) {
+    AuditConfig config;
+    config.enabled = true;
+    config.host = "";
+    auto result = service.configure(config);
+    EXPECT_FALSE(result.has_value())
+        << "Empty host should fail validation";
+}
+
+TEST_F(AuditServiceTest, ConfigureZeroPortFails) {
+    AuditConfig config;
+    config.enabled = true;
+    config.port = 0;
+    auto result = service.configure(config);
+    EXPECT_FALSE(result.has_value())
+        << "Zero port should fail validation";
+}
+
+TEST_F(AuditServiceTest, ConfigureValidUdpSucceeds) {
+    AuditConfig config;
+    config.enabled = true;
+    config.auditSourceId = "TEST_VIEWER";
+    config.host = "localhost";
+    config.port = 514;
+    config.protocol = AuditTransportProtocol::Udp;
+    auto result = service.configure(config);
+    EXPECT_TRUE(result.has_value())
+        << "Valid UDP configuration should succeed";
+}
+
+TEST_F(AuditServiceTest, ConfigurePreservesSettings) {
+    AuditConfig config;
+    config.enabled = true;
+    config.auditSourceId = "MY_SOURCE";
+    config.host = "audit-server.local";
+    config.port = 6514;
+    config.protocol = AuditTransportProtocol::Tls;
+    config.auditStorage = false;
+    config.auditQuery = true;
+
+    (void)service.configure(config);
+    auto retrieved = service.getConfig();
+
+    EXPECT_EQ(retrieved.auditSourceId, "MY_SOURCE");
+    EXPECT_EQ(retrieved.host, "audit-server.local");
+    EXPECT_EQ(retrieved.port, 6514);
+    EXPECT_EQ(retrieved.protocol, AuditTransportProtocol::Tls);
+    EXPECT_FALSE(retrieved.auditStorage);
+    EXPECT_TRUE(retrieved.auditQuery);
+}
+
+// --- Enable/Disable ---
+
+TEST_F(AuditServiceTest, EnableAfterConfigure) {
+    AuditConfig config;
+    config.enabled = true;
+    config.host = "localhost";
+    config.port = 514;
+    (void)service.configure(config);
+
+    EXPECT_TRUE(service.isEnabled());
+}
+
+TEST_F(AuditServiceTest, DisableAfterEnable) {
+    AuditConfig config;
+    config.enabled = true;
+    config.host = "localhost";
+    config.port = 514;
+    (void)service.configure(config);
+
+    service.setEnabled(false);
+    EXPECT_FALSE(service.isEnabled());
+}
+
+TEST_F(AuditServiceTest, ReEnable) {
+    AuditConfig config;
+    config.enabled = true;
+    config.host = "localhost";
+    config.port = 514;
+    (void)service.configure(config);
+
+    service.setEnabled(false);
+    service.setEnabled(true);
+    EXPECT_TRUE(service.isEnabled());
+}
+
+// --- AuditConfig::isValid ---
+
+TEST_F(AuditServiceTest, DisabledConfigAlwaysValid) {
+    AuditConfig config;
+    config.enabled = false;
+    config.auditSourceId = "";
+    config.host = "";
+    config.port = 0;
+    EXPECT_TRUE(config.isValid())
+        << "Disabled config should always be valid regardless of fields";
+}
+
+TEST_F(AuditServiceTest, ValidEnabledConfig) {
+    AuditConfig config;
+    config.enabled = true;
+    config.auditSourceId = "TEST";
+    config.host = "localhost";
+    config.port = 514;
+    EXPECT_TRUE(config.isValid());
+}
+
+// --- Audit Methods (No-op When Disabled) ---
+
+TEST_F(AuditServiceTest, AuditMethodsDoNotCrashWhenDisabled) {
+    // Should not throw or crash when called without configuration
+    EXPECT_NO_THROW(service.auditApplicationStart());
+    EXPECT_NO_THROW(service.auditApplicationStop());
+    EXPECT_NO_THROW(service.auditInstanceStored(
+        "SRC_AE", "DST_AE", "1.2.3.4.5", "PAT001", true));
+    EXPECT_NO_THROW(service.auditQuery(
+        "CALLING_AE", "CALLED_AE", "STUDY", true));
+    EXPECT_NO_THROW(service.auditAssociation("REMOTE_AE", true, true));
+    EXPECT_NO_THROW(service.auditSecurityAlert("USER", "test alert"));
+}
+
+TEST_F(AuditServiceTest, AuditMethodsDoNotCrashWhenConfiguredButDisabled) {
+    AuditConfig config;
+    config.enabled = false;
+    (void)service.configure(config);
+
+    EXPECT_NO_THROW(service.auditApplicationStart());
+    EXPECT_NO_THROW(service.auditInstanceStored(
+        "SRC_AE", "DST_AE", "1.2.3.4.5", "PAT001", true));
+}
+
+// --- Statistics ---
+
+TEST_F(AuditServiceTest, ResetStatisticsWhenNotConfigured) {
+    EXPECT_NO_THROW(service.resetStatistics());
+    auto stats = service.getStatistics();
+    EXPECT_EQ(stats.eventsSent, 0u);
+    EXPECT_EQ(stats.eventsFailed, 0u);
+}
+
+// --- Move Semantics ---
+
+TEST_F(AuditServiceTest, MoveConstruction) {
+    AuditConfig config;
+    config.enabled = false;
+    config.auditSourceId = "MOVE_TEST";
+    (void)service.configure(config);
+
+    AuditService moved(std::move(service));
+    auto retrievedConfig = moved.getConfig();
+    EXPECT_EQ(retrievedConfig.auditSourceId, "MOVE_TEST");
+}
+
+TEST_F(AuditServiceTest, MoveAssignment) {
+    AuditConfig config;
+    config.enabled = false;
+    config.auditSourceId = "ASSIGN_TEST";
+    (void)service.configure(config);
+
+    AuditService other;
+    other = std::move(service);
+    auto retrievedConfig = other.getConfig();
+    EXPECT_EQ(retrievedConfig.auditSourceId, "ASSIGN_TEST");
+}
+
+// --- Transport Protocol Enum ---
+
+TEST_F(AuditServiceTest, TransportProtocolValues) {
+    EXPECT_NE(static_cast<uint8_t>(AuditTransportProtocol::Udp),
+              static_cast<uint8_t>(AuditTransportProtocol::Tls));
+}
+
+// --- pacs_system ATNA Audit Logger ---
+
+TEST_F(AuditServiceTest, PacsAuditLoggerBuildApplicationActivity) {
+    auto msg = pacs::security::atna_audit_logger::build_application_activity(
+        "TEST_SOURCE", "test_app", true);
+    EXPECT_FALSE(msg.active_participants.empty())
+        << "Application activity message should have participants";
+    EXPECT_EQ(msg.event_outcome, pacs::security::atna_event_outcome::success);
+}
+
+TEST_F(AuditServiceTest, PacsAuditLoggerToXmlNotEmpty) {
+    auto msg = pacs::security::atna_audit_logger::build_application_activity(
+        "TEST_SOURCE", "test_app", true);
+    auto xml = pacs::security::atna_audit_logger::to_xml(msg);
+    EXPECT_FALSE(xml.empty())
+        << "XML serialization should produce non-empty output";
+    EXPECT_NE(xml.find("AuditMessage"), std::string::npos)
+        << "XML should contain AuditMessage element";
+}
+
+TEST_F(AuditServiceTest, PacsAuditLoggerBuildQuery) {
+    auto msg = pacs::security::atna_audit_logger::build_query(
+        "TEST_SOURCE", "CALLING_AE", "192.168.1.1", "STUDY", "PAT001");
+    EXPECT_FALSE(msg.active_participants.empty());
+    EXPECT_FALSE(msg.participant_objects.empty())
+        << "Query message should have participant objects";
+}
+
+TEST_F(AuditServiceTest, PacsAuditLoggerBuildInstancesTransferred) {
+    auto msg = pacs::security::atna_audit_logger::build_dicom_instances_transferred(
+        "TEST_SOURCE", "SRC_AE", "10.0.0.1", "DST_AE", "10.0.0.2",
+        "1.2.3.4.5", "PAT001", true);
+    EXPECT_GE(msg.active_participants.size(), 2u)
+        << "Transfer message should have source and destination participants";
+}
+
+TEST_F(AuditServiceTest, PacsAuditLoggerBuildSecurityAlert) {
+    auto msg = pacs::security::atna_audit_logger::build_security_alert(
+        "TEST_SOURCE", "USER01", "192.168.1.1", "Unauthorized access attempt");
+    EXPECT_EQ(msg.event_outcome, pacs::security::atna_event_outcome::serious_failure);
+}
+
+// --- ATNA Config Defaults ---
+
+TEST_F(AuditServiceTest, PacsDefaultAtnaConfig) {
+    auto config = pacs::security::make_default_atna_config();
+    EXPECT_FALSE(config.enabled)
+        << "Default ATNA config should be disabled";
+    EXPECT_FALSE(config.audit_source_id.empty());
+    EXPECT_TRUE(config.audit_storage);
+    EXPECT_TRUE(config.audit_query);
+}
+
+// --- Event Filtering ---
+
+TEST_F(AuditServiceTest, EventFilteringDefaults) {
+    AuditConfig config;
+    EXPECT_TRUE(config.auditStorage);
+    EXPECT_TRUE(config.auditQuery);
+    EXPECT_TRUE(config.auditAuthentication);
+    EXPECT_TRUE(config.auditSecurityAlerts);
+}
+
+} // anonymous namespace


### PR DESCRIPTION
Closes #457

## Summary
- Add `AuditService` wrapper class around pacs_system's `atna_service_auditor` for ATNA audit trail logging
- Support RFC 3881 XML audit messages over RFC 5424 syslog transport (UDP and TLS)
- Implement audit events: application start/stop, C-STORE, C-FIND, association, and security alerts
- Configurable per-event filtering (storage, query, authentication, security alerts)
- 27 unit tests covering configuration, enable/disable, audit method safety, and pacs_system integration

## Test Plan
- [x] 27 audit service tests pass locally
- [x] Full regression suite: 3143/3160 pass (17 pre-existing failures unrelated to this change)
- [x] CI passes on macOS-14 runner