### PR TITLE
feat(network): add C-FIND query result caching for improved performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,10 +562,12 @@ add_library(pacs_service STATIC
     src/services/pacs/pacs_config_manager.cpp
     src/services/pacs/storage_commitment_service.cpp
     src/services/pacs/audit_service.cpp
+    src/services/pacs/query_cache_manager.cpp
     include/services/pacs_config_manager.hpp
     include/services/dicom_store_scp.hpp
     include/services/storage_commitment_service.hpp
     include/services/audit_service.hpp
+    include/services/query_cache_manager.hpp
 )
 
 target_include_directories(pacs_service PUBLIC

--- a/include/services/query_cache_manager.hpp
+++ b/include/services/query_cache_manager.hpp
@@ -1,0 +1,305 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file query_cache_manager.hpp
+ * @brief C-FIND query result caching service for improved performance
+ * @details Wraps pacs_system's query_cache to provide a viewer-level
+ *          caching service for DICOM C-FIND query results. Supports
+ *          configurable cache size, TTL, and per-query-level invalidation.
+ *
+ * ## Thread Safety
+ * - All public methods are thread-safe
+ * - Configuration changes take effect immediately
+ * - Statistics can be read concurrently with cache operations
+ *
+ * @see pacs::services::cache::query_cache
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include "dicom_echo_scu.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <expected>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Configuration for the query cache
+ */
+struct QueryCacheConfig {
+    /// Enable/disable caching
+    bool enabled = false;
+
+    /// Maximum number of cached query results
+    size_t maxEntries = 1000;
+
+    /// Time-to-live for cached results in seconds
+    std::chrono::seconds ttl{300};
+
+    /// Cache identifier for logging
+    std::string cacheName = "cfind_query_cache";
+
+    /**
+     * @brief Validate the configuration
+     * @return true if configuration is valid for use
+     */
+    [[nodiscard]] bool isValid() const noexcept {
+        if (!enabled) return true;
+        return maxEntries > 0 && ttl.count() > 0;
+    }
+};
+
+/**
+ * @brief Cached query result metadata
+ */
+struct CachedResult {
+    /// Serialized query result data
+    std::vector<uint8_t> data;
+
+    /// Number of matching records
+    uint32_t matchCount = 0;
+
+    /// Query level (PATIENT, STUDY, SERIES, IMAGE)
+    std::string queryLevel;
+};
+
+/**
+ * @brief Cache performance statistics
+ */
+struct QueryCacheStatistics {
+    /// Number of cache hits
+    uint64_t hits = 0;
+
+    /// Number of cache misses
+    uint64_t misses = 0;
+
+    /// Number of insertions
+    uint64_t insertions = 0;
+
+    /// Number of LRU evictions
+    uint64_t evictions = 0;
+
+    /// Number of TTL expirations
+    uint64_t expirations = 0;
+
+    /// Current number of cached entries
+    size_t currentSize = 0;
+
+    /// Cache hit rate as percentage (0.0 to 100.0)
+    double hitRate = 0.0;
+};
+
+/**
+ * @brief C-FIND query result caching service
+ *
+ * Provides a viewer-level API for caching DICOM C-FIND query results
+ * using an LRU eviction policy with configurable TTL. Wraps
+ * pacs_system's query_cache with viewer-specific configuration.
+ *
+ * @example
+ * @code
+ * QueryCacheManager cache;
+ * QueryCacheConfig config;
+ * config.enabled = true;
+ * config.maxEntries = 500;
+ * config.ttl = std::chrono::seconds{120};
+ *
+ * auto result = cache.configure(config);
+ * if (result) {
+ *     auto key = QueryCacheManager::buildKey("STUDY", {
+ *         {"PatientID", "12345"},
+ *         {"StudyDate", "20240101"}
+ *     });
+ *
+ *     CachedResult entry;
+ *     entry.data = serialized_data;
+ *     entry.matchCount = 5;
+ *     entry.queryLevel = "STUDY";
+ *     cache.store(key, entry);
+ *
+ *     auto cached = cache.lookup(key);
+ *     if (cached) {
+ *         // Use cached result
+ *     }
+ * }
+ * @endcode
+ *
+ * @trace SRS-FR-040
+ */
+class QueryCacheManager {
+public:
+    QueryCacheManager();
+    ~QueryCacheManager();
+
+    // Non-copyable, movable
+    QueryCacheManager(const QueryCacheManager&) = delete;
+    QueryCacheManager& operator=(const QueryCacheManager&) = delete;
+    QueryCacheManager(QueryCacheManager&&) noexcept;
+    QueryCacheManager& operator=(QueryCacheManager&&) noexcept;
+
+    /**
+     * @brief Configure and initialize the cache
+     *
+     * Creates the underlying query cache based on the provided
+     * configuration. If config.enabled is false, the cache will
+     * accept calls but return misses for all lookups.
+     *
+     * @param config Cache configuration
+     * @return void on success, PacsErrorInfo on failure
+     */
+    [[nodiscard]] std::expected<void, PacsErrorInfo> configure(
+        const QueryCacheConfig& config);
+
+    /**
+     * @brief Check if the cache is configured and enabled
+     */
+    [[nodiscard]] bool isEnabled() const;
+
+    /**
+     * @brief Enable or disable caching
+     */
+    void setEnabled(bool enabled);
+
+    /**
+     * @brief Get current configuration
+     */
+    [[nodiscard]] QueryCacheConfig getConfig() const;
+
+    // -- Cache Operations --
+
+    /**
+     * @brief Look up a cached query result
+     *
+     * @param key The cache key (use buildKey to generate)
+     * @return The cached result if found, std::nullopt otherwise
+     */
+    [[nodiscard]] std::optional<CachedResult> lookup(const std::string& key);
+
+    /**
+     * @brief Store a query result in the cache
+     *
+     * @param key The cache key
+     * @param result The query result to cache
+     */
+    void store(const std::string& key, const CachedResult& result);
+
+    /**
+     * @brief Remove a specific entry from the cache
+     *
+     * @param key The cache key
+     * @return true if the entry was found and removed
+     */
+    bool invalidate(const std::string& key);
+
+    /**
+     * @brief Remove all entries for a specific query level
+     *
+     * @param queryLevel The query level (PATIENT, STUDY, SERIES, IMAGE)
+     * @return Number of entries removed
+     */
+    size_t invalidateByQueryLevel(const std::string& queryLevel);
+
+    /**
+     * @brief Remove all entries with keys starting with the given prefix
+     *
+     * @param prefix The key prefix to match
+     * @return Number of entries removed
+     */
+    size_t invalidateByPrefix(const std::string& prefix);
+
+    /**
+     * @brief Remove all entries from the cache
+     */
+    void clear();
+
+    /**
+     * @brief Remove all expired entries
+     * @return Number of entries removed
+     */
+    size_t purgeExpired();
+
+    // -- Statistics --
+
+    /**
+     * @brief Get cache performance statistics
+     */
+    [[nodiscard]] QueryCacheStatistics getStatistics() const;
+
+    /**
+     * @brief Reset statistics counters
+     */
+    void resetStatistics();
+
+    // -- Key Generation --
+
+    /**
+     * @brief Build a cache key from query parameters
+     *
+     * Creates a deterministic key from the query level and parameters.
+     * Parameters are sorted by name for consistent key generation.
+     *
+     * @param queryLevel The query retrieve level (PATIENT, STUDY, SERIES, IMAGE)
+     * @param params List of parameter name-value pairs
+     * @return Cache key string
+     */
+    [[nodiscard]] static std::string buildKey(
+        const std::string& queryLevel,
+        const std::vector<std::pair<std::string, std::string>>& params);
+
+    /**
+     * @brief Build a cache key with AE title prefix
+     *
+     * Includes the calling AE title in the key for per-client caching.
+     *
+     * @param callingAe The calling AE title
+     * @param queryLevel The query retrieve level
+     * @param params List of parameter name-value pairs
+     * @return Cache key string
+     */
+    [[nodiscard]] static std::string buildKeyWithAe(
+        const std::string& callingAe,
+        const std::string& queryLevel,
+        const std::vector<std::pair<std::string, std::string>>& params);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::services

--- a/src/services/pacs/query_cache_manager.cpp
+++ b/src/services/pacs/query_cache_manager.cpp
@@ -1,0 +1,275 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "services/query_cache_manager.hpp"
+
+#include <mutex>
+
+#include <spdlog/spdlog.h>
+
+#include <pacs/services/cache/query_cache.hpp>
+
+namespace dicom_viewer::services {
+
+class QueryCacheManager::Impl {
+public:
+    Impl() = default;
+
+    std::expected<void, PacsErrorInfo> configure(const QueryCacheConfig& config) {
+        std::lock_guard lock(mutex_);
+
+        if (!config.isValid()) {
+            return std::unexpected(PacsErrorInfo{
+                PacsError::ConfigurationInvalid,
+                "Invalid query cache configuration"
+            });
+        }
+
+        config_ = config;
+
+        if (!config.enabled) {
+            cache_.reset();
+            spdlog::info("Query cache configured but disabled");
+            return {};
+        }
+
+        pacs::services::cache::query_cache_config qc;
+        qc.max_entries = config.maxEntries;
+        qc.ttl = config.ttl;
+        qc.cache_name = config.cacheName;
+        qc.enable_logging = false;
+        qc.enable_metrics = true;
+
+        try {
+            cache_ = std::make_unique<pacs::services::cache::query_cache>(qc);
+        } catch (const std::exception& e) {
+            cache_.reset();
+            return std::unexpected(PacsErrorInfo{
+                PacsError::InternalError,
+                std::string("Failed to initialize query cache: ") + e.what()
+            });
+        }
+
+        spdlog::info("Query cache configured: max_entries={}, ttl={}s",
+                     config.maxEntries, config.ttl.count());
+        return {};
+    }
+
+    bool isEnabled() const {
+        std::lock_guard lock(mutex_);
+        return config_.enabled && cache_ != nullptr;
+    }
+
+    void setEnabled(bool enabled) {
+        std::lock_guard lock(mutex_);
+        config_.enabled = enabled;
+    }
+
+    QueryCacheConfig getConfig() const {
+        std::lock_guard lock(mutex_);
+        return config_;
+    }
+
+    std::optional<CachedResult> lookup(const std::string& key) {
+        std::lock_guard lock(mutex_);
+        if (!isEnabledLocked()) return std::nullopt;
+
+        auto result = cache_->get(key);
+        if (!result) return std::nullopt;
+
+        CachedResult cr;
+        cr.data = std::move(result->data);
+        cr.matchCount = result->match_count;
+        cr.queryLevel = std::move(result->query_level);
+        return cr;
+    }
+
+    void store(const std::string& key, const CachedResult& result) {
+        std::lock_guard lock(mutex_);
+        if (!isEnabledLocked()) return;
+
+        pacs::services::cache::cached_query_result cqr;
+        cqr.data = result.data;
+        cqr.match_count = result.matchCount;
+        cqr.cached_at = std::chrono::steady_clock::now();
+        cqr.query_level = result.queryLevel;
+
+        cache_->put(key, std::move(cqr));
+    }
+
+    bool invalidate(const std::string& key) {
+        std::lock_guard lock(mutex_);
+        if (!isEnabledLocked()) return false;
+
+        return cache_->invalidate(key);
+    }
+
+    size_t invalidateByQueryLevel(const std::string& queryLevel) {
+        std::lock_guard lock(mutex_);
+        if (!isEnabledLocked()) return 0;
+
+        return cache_->invalidate_by_query_level(queryLevel);
+    }
+
+    size_t invalidateByPrefix(const std::string& prefix) {
+        std::lock_guard lock(mutex_);
+        if (!isEnabledLocked()) return 0;
+
+        return cache_->invalidate_by_prefix(prefix);
+    }
+
+    void clear() {
+        std::lock_guard lock(mutex_);
+        if (cache_) {
+            cache_->clear();
+        }
+    }
+
+    size_t purgeExpired() {
+        std::lock_guard lock(mutex_);
+        if (!isEnabledLocked()) return 0;
+
+        return cache_->purge_expired();
+    }
+
+    QueryCacheStatistics getStatistics() const {
+        std::lock_guard lock(mutex_);
+        if (!cache_) {
+            return {};
+        }
+
+        const auto& stats = cache_->stats();
+        QueryCacheStatistics qs;
+        qs.hits = stats.hits.load(std::memory_order_relaxed);
+        qs.misses = stats.misses.load(std::memory_order_relaxed);
+        qs.insertions = stats.insertions.load(std::memory_order_relaxed);
+        qs.evictions = stats.evictions.load(std::memory_order_relaxed);
+        qs.expirations = stats.expirations.load(std::memory_order_relaxed);
+        qs.currentSize = stats.current_size.load(std::memory_order_relaxed);
+        qs.hitRate = cache_->hit_rate();
+        return qs;
+    }
+
+    void resetStatistics() {
+        std::lock_guard lock(mutex_);
+        if (cache_) {
+            cache_->reset_stats();
+        }
+    }
+
+private:
+    bool isEnabledLocked() const {
+        return config_.enabled && cache_ != nullptr;
+    }
+
+    QueryCacheConfig config_;
+    std::unique_ptr<pacs::services::cache::query_cache> cache_;
+    mutable std::mutex mutex_;
+};
+
+// Public interface implementation
+
+QueryCacheManager::QueryCacheManager()
+    : impl_(std::make_unique<Impl>()) {
+}
+
+QueryCacheManager::~QueryCacheManager() = default;
+
+QueryCacheManager::QueryCacheManager(QueryCacheManager&&) noexcept = default;
+QueryCacheManager& QueryCacheManager::operator=(QueryCacheManager&&) noexcept = default;
+
+std::expected<void, PacsErrorInfo> QueryCacheManager::configure(
+    const QueryCacheConfig& config) {
+    return impl_->configure(config);
+}
+
+bool QueryCacheManager::isEnabled() const {
+    return impl_->isEnabled();
+}
+
+void QueryCacheManager::setEnabled(bool enabled) {
+    impl_->setEnabled(enabled);
+}
+
+QueryCacheConfig QueryCacheManager::getConfig() const {
+    return impl_->getConfig();
+}
+
+std::optional<CachedResult> QueryCacheManager::lookup(const std::string& key) {
+    return impl_->lookup(key);
+}
+
+void QueryCacheManager::store(const std::string& key,
+                               const CachedResult& result) {
+    impl_->store(key, result);
+}
+
+bool QueryCacheManager::invalidate(const std::string& key) {
+    return impl_->invalidate(key);
+}
+
+size_t QueryCacheManager::invalidateByQueryLevel(const std::string& queryLevel) {
+    return impl_->invalidateByQueryLevel(queryLevel);
+}
+
+size_t QueryCacheManager::invalidateByPrefix(const std::string& prefix) {
+    return impl_->invalidateByPrefix(prefix);
+}
+
+void QueryCacheManager::clear() {
+    impl_->clear();
+}
+
+size_t QueryCacheManager::purgeExpired() {
+    return impl_->purgeExpired();
+}
+
+QueryCacheStatistics QueryCacheManager::getStatistics() const {
+    return impl_->getStatistics();
+}
+
+void QueryCacheManager::resetStatistics() {
+    impl_->resetStatistics();
+}
+
+std::string QueryCacheManager::buildKey(
+    const std::string& queryLevel,
+    const std::vector<std::pair<std::string, std::string>>& params) {
+    return pacs::services::cache::query_cache::build_key(queryLevel, params);
+}
+
+std::string QueryCacheManager::buildKeyWithAe(
+    const std::string& callingAe,
+    const std::string& queryLevel,
+    const std::vector<std::pair<std::string, std::string>>& params) {
+    return pacs::services::cache::query_cache::build_key_with_ae(
+        callingAe, queryLevel, params);
+}
+
+} // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -257,6 +257,22 @@ target_include_directories(audit_service_test PRIVATE
 
 gtest_discover_tests(audit_service_test DISCOVERY_TIMEOUT 60)
 
+add_executable(query_cache_manager_test
+    unit/query_cache_manager_test.cpp
+)
+
+target_link_libraries(query_cache_manager_test PRIVATE
+    pacs_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(query_cache_manager_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(query_cache_manager_test DISCOVERY_TIMEOUT 60)
+
 # Unit tests for DICOM Move SCU
 add_executable(dicom_move_scu_test
     unit/dicom_move_scu_test.cpp

--- a/tests/unit/query_cache_manager_test.cpp
+++ b/tests/unit/query_cache_manager_test.cpp
@@ -1,0 +1,443 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <services/query_cache_manager.hpp>
+
+#include <pacs/services/cache/query_cache.hpp>
+
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace dicom_viewer::services;
+
+class QueryCacheManagerTest : public ::testing::Test {
+protected:
+    QueryCacheManager manager;
+
+    QueryCacheConfig makeEnabledConfig(size_t maxEntries = 100,
+                                       std::chrono::seconds ttl = std::chrono::seconds{300}) {
+        QueryCacheConfig config;
+        config.enabled = true;
+        config.maxEntries = maxEntries;
+        config.ttl = ttl;
+        return config;
+    }
+
+    CachedResult makeSampleResult(const std::string& level = "STUDY",
+                                  uint32_t matchCount = 5) {
+        CachedResult result;
+        result.data = {0x01, 0x02, 0x03, 0x04};
+        result.matchCount = matchCount;
+        result.queryLevel = level;
+        return result;
+    }
+};
+
+// --- Default State ---
+
+TEST_F(QueryCacheManagerTest, DefaultNotEnabled) {
+    EXPECT_FALSE(manager.isEnabled());
+}
+
+TEST_F(QueryCacheManagerTest, DefaultConfigDisabled) {
+    auto config = manager.getConfig();
+    EXPECT_FALSE(config.enabled);
+}
+
+TEST_F(QueryCacheManagerTest, DefaultStatisticsZero) {
+    auto stats = manager.getStatistics();
+    EXPECT_EQ(stats.hits, 0u);
+    EXPECT_EQ(stats.misses, 0u);
+    EXPECT_EQ(stats.insertions, 0u);
+    EXPECT_EQ(stats.evictions, 0u);
+    EXPECT_EQ(stats.currentSize, 0u);
+}
+
+TEST_F(QueryCacheManagerTest, LookupReturnsNulloptWhenDisabled) {
+    auto result = manager.lookup("any_key");
+    EXPECT_FALSE(result.has_value());
+}
+
+// --- Configuration Validation ---
+
+TEST_F(QueryCacheManagerTest, ConfigureDisabledSucceeds) {
+    QueryCacheConfig config;
+    config.enabled = false;
+    auto result = manager.configure(config);
+    EXPECT_TRUE(result.has_value())
+        << "Disabled configuration should always succeed";
+}
+
+TEST_F(QueryCacheManagerTest, ConfigureZeroEntriesFails) {
+    QueryCacheConfig config;
+    config.enabled = true;
+    config.maxEntries = 0;
+    auto result = manager.configure(config);
+    EXPECT_FALSE(result.has_value())
+        << "Zero max entries should fail validation";
+}
+
+TEST_F(QueryCacheManagerTest, ConfigureZeroTtlFails) {
+    QueryCacheConfig config;
+    config.enabled = true;
+    config.ttl = std::chrono::seconds{0};
+    auto result = manager.configure(config);
+    EXPECT_FALSE(result.has_value())
+        << "Zero TTL should fail validation";
+}
+
+TEST_F(QueryCacheManagerTest, ConfigureValidSucceeds) {
+    auto result = manager.configure(makeEnabledConfig());
+    EXPECT_TRUE(result.has_value())
+        << "Valid configuration should succeed";
+}
+
+TEST_F(QueryCacheManagerTest, ConfigurePreservesSettings) {
+    QueryCacheConfig config;
+    config.enabled = true;
+    config.maxEntries = 500;
+    config.ttl = std::chrono::seconds{120};
+    config.cacheName = "test_cache";
+
+    (void)manager.configure(config);
+    auto retrieved = manager.getConfig();
+
+    EXPECT_EQ(retrieved.maxEntries, 500u);
+    EXPECT_EQ(retrieved.ttl.count(), 120);
+    EXPECT_EQ(retrieved.cacheName, "test_cache");
+}
+
+// --- Enable/Disable ---
+
+TEST_F(QueryCacheManagerTest, EnableAfterConfigure) {
+    (void)manager.configure(makeEnabledConfig());
+    EXPECT_TRUE(manager.isEnabled());
+}
+
+TEST_F(QueryCacheManagerTest, DisableAfterEnable) {
+    (void)manager.configure(makeEnabledConfig());
+    manager.setEnabled(false);
+    EXPECT_FALSE(manager.isEnabled());
+}
+
+TEST_F(QueryCacheManagerTest, ReEnable) {
+    (void)manager.configure(makeEnabledConfig());
+    manager.setEnabled(false);
+    manager.setEnabled(true);
+    EXPECT_TRUE(manager.isEnabled());
+}
+
+// --- Store and Lookup ---
+
+TEST_F(QueryCacheManagerTest, StoreAndLookup) {
+    (void)manager.configure(makeEnabledConfig());
+
+    auto key = QueryCacheManager::buildKey("STUDY", {
+        {"PatientID", "PAT001"},
+        {"StudyDate", "20240101"}
+    });
+
+    manager.store(key, makeSampleResult());
+
+    auto cached = manager.lookup(key);
+    ASSERT_TRUE(cached.has_value());
+    EXPECT_EQ(cached->matchCount, 5u);
+    EXPECT_EQ(cached->queryLevel, "STUDY");
+    EXPECT_EQ(cached->data.size(), 4u);
+}
+
+TEST_F(QueryCacheManagerTest, LookupMissReturnsNullopt) {
+    (void)manager.configure(makeEnabledConfig());
+
+    auto result = manager.lookup("nonexistent_key");
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(QueryCacheManagerTest, StoreOverwritesExisting) {
+    (void)manager.configure(makeEnabledConfig());
+    auto key = QueryCacheManager::buildKey("STUDY", {{"PatientID", "PAT001"}});
+
+    manager.store(key, makeSampleResult("STUDY", 5));
+    manager.store(key, makeSampleResult("STUDY", 10));
+
+    auto cached = manager.lookup(key);
+    ASSERT_TRUE(cached.has_value());
+    EXPECT_EQ(cached->matchCount, 10u);
+}
+
+TEST_F(QueryCacheManagerTest, StoreDoesNothingWhenDisabled) {
+    (void)manager.configure(makeEnabledConfig());
+    manager.setEnabled(false);
+
+    auto key = QueryCacheManager::buildKey("STUDY", {{"PatientID", "PAT001"}});
+    manager.store(key, makeSampleResult());
+
+    manager.setEnabled(true);
+    auto cached = manager.lookup(key);
+    EXPECT_FALSE(cached.has_value())
+        << "Store should be no-op when disabled";
+}
+
+// --- Invalidation ---
+
+TEST_F(QueryCacheManagerTest, InvalidateRemovesEntry) {
+    (void)manager.configure(makeEnabledConfig());
+    auto key = QueryCacheManager::buildKey("STUDY", {{"PatientID", "PAT001"}});
+
+    manager.store(key, makeSampleResult());
+    EXPECT_TRUE(manager.invalidate(key));
+
+    auto cached = manager.lookup(key);
+    EXPECT_FALSE(cached.has_value());
+}
+
+TEST_F(QueryCacheManagerTest, InvalidateNonexistentReturnsFalse) {
+    (void)manager.configure(makeEnabledConfig());
+    EXPECT_FALSE(manager.invalidate("nonexistent_key"));
+}
+
+TEST_F(QueryCacheManagerTest, InvalidateByQueryLevel) {
+    (void)manager.configure(makeEnabledConfig());
+
+    auto studyKey1 = QueryCacheManager::buildKey("STUDY", {{"PatientID", "PAT001"}});
+    auto studyKey2 = QueryCacheManager::buildKey("STUDY", {{"PatientID", "PAT002"}});
+    auto patientKey = QueryCacheManager::buildKey("PATIENT", {{"PatientName", "Test"}});
+
+    manager.store(studyKey1, makeSampleResult("STUDY"));
+    manager.store(studyKey2, makeSampleResult("STUDY"));
+    manager.store(patientKey, makeSampleResult("PATIENT"));
+
+    auto removed = manager.invalidateByQueryLevel("STUDY");
+    EXPECT_EQ(removed, 2u);
+
+    EXPECT_FALSE(manager.lookup(studyKey1).has_value());
+    EXPECT_FALSE(manager.lookup(studyKey2).has_value());
+    EXPECT_TRUE(manager.lookup(patientKey).has_value());
+}
+
+TEST_F(QueryCacheManagerTest, Clear) {
+    (void)manager.configure(makeEnabledConfig());
+
+    auto key1 = QueryCacheManager::buildKey("STUDY", {{"PatientID", "PAT001"}});
+    auto key2 = QueryCacheManager::buildKey("PATIENT", {{"PatientName", "Test"}});
+
+    manager.store(key1, makeSampleResult());
+    manager.store(key2, makeSampleResult("PATIENT"));
+
+    manager.clear();
+
+    EXPECT_FALSE(manager.lookup(key1).has_value());
+    EXPECT_FALSE(manager.lookup(key2).has_value());
+}
+
+// --- Statistics ---
+
+TEST_F(QueryCacheManagerTest, StatisticsTrackHitsAndMisses) {
+    (void)manager.configure(makeEnabledConfig());
+
+    auto key = QueryCacheManager::buildKey("STUDY", {{"PatientID", "PAT001"}});
+    manager.store(key, makeSampleResult());
+
+    (void)manager.lookup(key);         // hit
+    (void)manager.lookup("missing");   // miss
+
+    auto stats = manager.getStatistics();
+    EXPECT_EQ(stats.hits, 1u);
+    EXPECT_EQ(stats.misses, 1u);
+    EXPECT_EQ(stats.insertions, 1u);
+}
+
+TEST_F(QueryCacheManagerTest, ResetStatistics) {
+    (void)manager.configure(makeEnabledConfig());
+
+    auto key = QueryCacheManager::buildKey("STUDY", {{"PatientID", "PAT001"}});
+    manager.store(key, makeSampleResult());
+    (void)manager.lookup(key);
+
+    manager.resetStatistics();
+    auto stats = manager.getStatistics();
+    EXPECT_EQ(stats.hits, 0u);
+    EXPECT_EQ(stats.misses, 0u);
+}
+
+TEST_F(QueryCacheManagerTest, ResetStatisticsWhenNotConfigured) {
+    EXPECT_NO_THROW(manager.resetStatistics());
+    auto stats = manager.getStatistics();
+    EXPECT_EQ(stats.hits, 0u);
+}
+
+// --- LRU Eviction ---
+
+TEST_F(QueryCacheManagerTest, LruEviction) {
+    (void)manager.configure(makeEnabledConfig(3));
+
+    auto key1 = QueryCacheManager::buildKey("STUDY", {{"ID", "1"}});
+    auto key2 = QueryCacheManager::buildKey("STUDY", {{"ID", "2"}});
+    auto key3 = QueryCacheManager::buildKey("STUDY", {{"ID", "3"}});
+    auto key4 = QueryCacheManager::buildKey("STUDY", {{"ID", "4"}});
+
+    manager.store(key1, makeSampleResult());
+    manager.store(key2, makeSampleResult());
+    manager.store(key3, makeSampleResult());
+    manager.store(key4, makeSampleResult());  // evicts key1
+
+    EXPECT_FALSE(manager.lookup(key1).has_value())
+        << "Oldest entry should be evicted";
+    EXPECT_TRUE(manager.lookup(key4).has_value())
+        << "Newest entry should exist";
+}
+
+// --- Key Generation ---
+
+TEST_F(QueryCacheManagerTest, BuildKeyDeterministic) {
+    auto key1 = QueryCacheManager::buildKey("STUDY", {
+        {"PatientID", "PAT001"},
+        {"StudyDate", "20240101"}
+    });
+
+    auto key2 = QueryCacheManager::buildKey("STUDY", {
+        {"StudyDate", "20240101"},
+        {"PatientID", "PAT001"}
+    });
+
+    EXPECT_EQ(key1, key2)
+        << "Key generation should be deterministic regardless of param order";
+}
+
+TEST_F(QueryCacheManagerTest, BuildKeyDifferentLevels) {
+    auto studyKey = QueryCacheManager::buildKey("STUDY", {{"PatientID", "PAT001"}});
+    auto patientKey = QueryCacheManager::buildKey("PATIENT", {{"PatientID", "PAT001"}});
+
+    EXPECT_NE(studyKey, patientKey)
+        << "Different query levels should produce different keys";
+}
+
+TEST_F(QueryCacheManagerTest, BuildKeyWithAeIncludesAeTitle) {
+    auto key1 = QueryCacheManager::buildKeyWithAe("AE1", "STUDY",
+        {{"PatientID", "PAT001"}});
+    auto key2 = QueryCacheManager::buildKeyWithAe("AE2", "STUDY",
+        {{"PatientID", "PAT001"}});
+
+    EXPECT_NE(key1, key2)
+        << "Different AE titles should produce different keys";
+}
+
+TEST_F(QueryCacheManagerTest, BuildKeyNotEmpty) {
+    auto key = QueryCacheManager::buildKey("STUDY", {});
+    EXPECT_FALSE(key.empty());
+}
+
+// --- pacs_system Cache Integration ---
+
+TEST_F(QueryCacheManagerTest, PacsQueryCacheDirectConstruction) {
+    pacs::services::cache::query_cache_config config;
+    config.max_entries = 10;
+    config.ttl = std::chrono::seconds{60};
+
+    pacs::services::cache::query_cache cache(config);
+    EXPECT_EQ(cache.max_size(), 10u);
+    EXPECT_TRUE(cache.empty());
+}
+
+TEST_F(QueryCacheManagerTest, PacsQueryCacheBuildKey) {
+    auto key = pacs::services::cache::query_cache::build_key("STUDY", {
+        {"PatientID", "12345"}
+    });
+    EXPECT_FALSE(key.empty());
+}
+
+// --- Safe Operations When Disabled ---
+
+TEST_F(QueryCacheManagerTest, OperationsDoNotCrashWhenDisabled) {
+    EXPECT_NO_THROW(manager.store("key", makeSampleResult()));
+    EXPECT_NO_THROW(manager.invalidate("key"));
+    EXPECT_NO_THROW(manager.invalidateByQueryLevel("STUDY"));
+    EXPECT_NO_THROW(manager.invalidateByPrefix("prefix"));
+    EXPECT_NO_THROW(manager.clear());
+    EXPECT_NO_THROW(manager.purgeExpired());
+}
+
+TEST_F(QueryCacheManagerTest, OperationsDoNotCrashWhenConfiguredButDisabled) {
+    QueryCacheConfig config;
+    config.enabled = false;
+    (void)manager.configure(config);
+
+    EXPECT_NO_THROW(manager.store("key", makeSampleResult()));
+    EXPECT_NO_THROW(manager.lookup("key"));
+}
+
+// --- Move Semantics ---
+
+TEST_F(QueryCacheManagerTest, MoveConstruction) {
+    QueryCacheConfig config;
+    config.enabled = false;
+    config.maxEntries = 500;
+    (void)manager.configure(config);
+
+    QueryCacheManager moved(std::move(manager));
+    auto retrievedConfig = moved.getConfig();
+    EXPECT_EQ(retrievedConfig.maxEntries, 500u);
+}
+
+TEST_F(QueryCacheManagerTest, MoveAssignment) {
+    QueryCacheConfig config;
+    config.enabled = false;
+    config.maxEntries = 250;
+    (void)manager.configure(config);
+
+    QueryCacheManager other;
+    other = std::move(manager);
+    auto retrievedConfig = other.getConfig();
+    EXPECT_EQ(retrievedConfig.maxEntries, 250u);
+}
+
+// --- QueryCacheConfig::isValid ---
+
+TEST_F(QueryCacheManagerTest, DisabledConfigAlwaysValid) {
+    QueryCacheConfig config;
+    config.enabled = false;
+    config.maxEntries = 0;
+    config.ttl = std::chrono::seconds{0};
+    EXPECT_TRUE(config.isValid())
+        << "Disabled config should always be valid regardless of fields";
+}
+
+TEST_F(QueryCacheManagerTest, ValidEnabledConfig) {
+    QueryCacheConfig config;
+    config.enabled = true;
+    config.maxEntries = 100;
+    config.ttl = std::chrono::seconds{60};
+    EXPECT_TRUE(config.isValid());
+}
+
+} // anonymous namespace


### PR DESCRIPTION
Closes #458

## Summary
- Add `QueryCacheManager` service wrapping pacs_system's `query_cache` with viewer-level configuration and Pimpl pattern
- Support LRU-based caching with configurable max entries, TTL, and per-query-level/prefix invalidation
- Expose deterministic key generation via `buildKey()` and `buildKeyWithAe()` static methods
- Add 36 unit tests covering configuration, store/lookup, invalidation, LRU eviction, statistics, move semantics, and safety when disabled

## Test Plan
- [x] 36 new unit tests all pass
- [x] Full regression: 17 pre-existing failures only (UI SEGFAULT + ReportGenerator), no new failures
- [x] Build succeeds with no new warnings