### PR TITLE
feat(network): implement DICOMweb REST API service wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,9 @@ if(EXISTS "${PACS_SYSTEM_ROOT}" AND EXISTS "${PACS_SYSTEM_BUILD_DIR}/lib")
     find_library(NETWORK_SYSTEM_LIB NetworkSystem HINTS ${PACS_SYSTEM_LIB_DIR})
     find_library(LOGGER_SYSTEM_LIB LoggerSystem HINTS ${PACS_SYSTEM_LIB_DIR})
     find_library(THREAD_BASE_LIB thread_base HINTS ${PACS_SYSTEM_LIB_DIR})
+    find_library(DATABASE_LIB database HINTS ${PACS_SYSTEM_LIB_DIR})
+    find_library(UTILITIES_LIB utilities HINTS ${PACS_SYSTEM_LIB_DIR})
+    find_library(MONITORING_SYSTEM_LIB monitoring_system HINTS ${PACS_SYSTEM_LIB_DIR})
     find_library(THREAD_CORE_LIB thread_core HINTS ${PACS_SYSTEM_LIB_DIR})
 
     if(PACS_CORE_LIB AND PACS_NETWORK_LIB AND PACS_SERVICES_LIB)
@@ -291,6 +294,31 @@ if(EXISTS "${PACS_SYSTEM_ROOT}" AND EXISTS "${PACS_SYSTEM_BUILD_DIR}/lib")
                 IMPORTED_LOCATION "${PACS_STORAGE_LIB}"
                 INTERFACE_INCLUDE_DIRECTORIES "${PACS_INCLUDE_DIRS}"
             )
+            # pacs_storage depends on database, integrated_database, sqlite3
+            find_library(INTEGRATED_DB_LIB integrated_database HINTS ${PACS_SYSTEM_LIB_DIR})
+            if(DATABASE_LIB)
+                set_property(TARGET pacs::storage APPEND PROPERTY
+                    INTERFACE_LINK_LIBRARIES "${DATABASE_LIB}")
+            endif()
+            if(INTEGRATED_DB_LIB)
+                set_property(TARGET pacs::storage APPEND PROPERTY
+                    INTERFACE_LINK_LIBRARIES "${INTEGRATED_DB_LIB}")
+            endif()
+            find_package(SQLite3 QUIET)
+            if(SQLite3_FOUND)
+                set_property(TARGET pacs::storage APPEND PROPERTY
+                    INTERFACE_LINK_LIBRARIES SQLite::SQLite3)
+            else()
+                find_library(SQLITE3_LIB sqlite3)
+                if(SQLITE3_LIB)
+                    set_property(TARGET pacs::storage APPEND PROPERTY
+                        INTERFACE_LINK_LIBRARIES "${SQLITE3_LIB}")
+                endif()
+            endif()
+            if(UTILITIES_LIB)
+                set_property(TARGET pacs::storage APPEND PROPERTY
+                    INTERFACE_LINK_LIBRARIES "${UTILITIES_LIB}")
+            endif()
             message(STATUS "  - pacs_storage: ${PACS_STORAGE_LIB}")
         endif()
 
@@ -300,6 +328,19 @@ if(EXISTS "${PACS_SYSTEM_ROOT}" AND EXISTS "${PACS_SYSTEM_BUILD_DIR}/lib")
                 IMPORTED_LOCATION "${PACS_WEB_LIB}"
                 INTERFACE_INCLUDE_DIRECTORIES "${PACS_INCLUDE_DIRS}"
             )
+            # pacs_web transitive dependencies (storage, client, monitoring)
+            if(PACS_STORAGE_LIB AND TARGET pacs::storage)
+                set_property(TARGET pacs::web APPEND PROPERTY
+                    INTERFACE_LINK_LIBRARIES pacs::storage)
+            endif()
+            if(PACS_CLIENT_LIB AND TARGET pacs::client)
+                set_property(TARGET pacs::web APPEND PROPERTY
+                    INTERFACE_LINK_LIBRARIES pacs::client)
+            endif()
+            if(PACS_MONITORING_LIB AND TARGET pacs::monitoring)
+                set_property(TARGET pacs::web APPEND PROPERTY
+                    INTERFACE_LINK_LIBRARIES pacs::monitoring)
+            endif()
             message(STATUS "  - pacs_web: ${PACS_WEB_LIB}")
         endif()
 
@@ -327,6 +368,10 @@ if(EXISTS "${PACS_SYSTEM_ROOT}" AND EXISTS "${PACS_SYSTEM_BUILD_DIR}/lib")
                 IMPORTED_LOCATION "${PACS_MONITORING_LIB}"
                 INTERFACE_INCLUDE_DIRECTORIES "${PACS_INCLUDE_DIRS}"
             )
+            if(MONITORING_SYSTEM_LIB)
+                set_property(TARGET pacs::monitoring APPEND PROPERTY
+                    INTERFACE_LINK_LIBRARIES "${MONITORING_SYSTEM_LIB}")
+            endif()
             message(STATUS "  - pacs_monitoring: ${PACS_MONITORING_LIB}")
         endif()
 
@@ -563,11 +608,13 @@ add_library(pacs_service STATIC
     src/services/pacs/storage_commitment_service.cpp
     src/services/pacs/audit_service.cpp
     src/services/pacs/query_cache_manager.cpp
+    src/services/pacs/dicomweb_service.cpp
     include/services/pacs_config_manager.hpp
     include/services/dicom_store_scp.hpp
     include/services/storage_commitment_service.hpp
     include/services/audit_service.hpp
     include/services/query_cache_manager.hpp
+    include/services/dicomweb_service.hpp
 )
 
 target_include_directories(pacs_service PUBLIC
@@ -616,6 +663,24 @@ endif()
 # pacs_services depends on pacs_security (ATNA audit in storage_scp)
 if(TARGET pacs::security)
     target_link_libraries(pacs_service PUBLIC pacs::security)
+endif()
+
+# pacs_web provides DICOMweb REST API (WADO-RS, STOW-RS, QIDO-RS)
+if(TARGET pacs::web)
+    target_link_libraries(pacs_service PUBLIC pacs::web)
+endif()
+
+# pacs_web transitive dependencies
+if(TARGET pacs::storage)
+    target_link_libraries(pacs_service PUBLIC pacs::storage)
+endif()
+
+if(TARGET pacs::client)
+    target_link_libraries(pacs_service PUBLIC pacs::client)
+endif()
+
+if(TARGET pacs::monitoring)
+    target_link_libraries(pacs_service PUBLIC pacs::monitoring)
 endif()
 
 add_library(export_service STATIC

--- a/include/services/dicomweb_service.hpp
+++ b/include/services/dicomweb_service.hpp
@@ -1,0 +1,203 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file dicomweb_service.hpp
+ * @brief DICOMweb REST API service for WADO-RS, STOW-RS, and QIDO-RS
+ * @details Wraps pacs_system's rest_server to provide a viewer-level
+ *          DICOMweb service supporting DICOM PS3.18 Web Services.
+ *          Manages server lifecycle (start/stop) and configuration.
+ *
+ * ## Thread Safety
+ * - Server lifecycle methods (start/stop) should be called from one thread
+ * - isRunning() and getConfig() are safe to call from any thread
+ * - The underlying REST server handles concurrent HTTP requests internally
+ *
+ * ## Supported Endpoints (provided by pacs::web::rest_server)
+ * - WADO-RS: GET /studies/{studyUID} — Retrieve DICOM objects via REST
+ * - STOW-RS: POST /studies — Store DICOM objects via multipart POST
+ * - QIDO-RS: GET /studies?... — Query DICOM objects via REST
+ * - WADO-URI: GET /wado — Legacy WADO-URI endpoint
+ * - System: GET /api/v1/system/status — Health and metrics
+ *
+ * @see DICOM PS3.18 — Web Services
+ * @see IHE RAD TF — Web-based Image Access (WIA)
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include "dicom_echo_scu.hpp"
+
+#include <cstdint>
+#include <expected>
+#include <memory>
+#include <string>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Configuration for the DICOMweb REST API service
+ */
+struct DicomWebConfig {
+    /// Master enable/disable for DICOMweb service
+    bool enabled = false;
+
+    /// Address to bind the server to
+    std::string bindAddress = "0.0.0.0";
+
+    /// Port to listen on (default: 8080)
+    uint16_t port = 8080;
+
+    /// Number of worker threads for handling requests
+    size_t concurrency = 4;
+
+    /// Enable CORS (Cross-Origin Resource Sharing)
+    bool enableCors = true;
+
+    /// CORS allowed origins (empty = allow all)
+    std::string corsAllowedOrigins = "*";
+
+    /// Enable TLS/SSL encryption
+    bool enableTls = false;
+
+    /// Path to TLS certificate file
+    std::string tlsCertPath;
+
+    /// Path to TLS private key file
+    std::string tlsKeyPath;
+
+    /// Request timeout in seconds
+    uint32_t requestTimeoutSeconds = 30;
+
+    /// Maximum request body size in bytes (default 10MB)
+    size_t maxBodySize = 10 * 1024 * 1024;
+
+    /**
+     * @brief Validate the configuration
+     * @return true if configuration is valid for use
+     */
+    [[nodiscard]] bool isValid() const noexcept {
+        if (!enabled) return true;
+        return port > 0 && concurrency > 0;
+    }
+};
+
+/**
+ * @brief DICOMweb REST API service
+ *
+ * Provides a viewer-level API for managing an embedded HTTP server
+ * that serves DICOMweb endpoints (WADO-RS, STOW-RS, QIDO-RS).
+ * Wraps pacs_system's rest_server with viewer-specific configuration.
+ *
+ * @example
+ * @code
+ * DicomWebService web;
+ * DicomWebConfig config;
+ * config.enabled = true;
+ * config.port = 8080;
+ * config.enableCors = true;
+ *
+ * auto result = web.configure(config);
+ * if (result) {
+ *     auto startResult = web.start();
+ *     if (startResult) {
+ *         // Server is running on port 8080
+ *         // WADO-RS: http://localhost:8080/studies/{uid}
+ *         // QIDO-RS: http://localhost:8080/studies?PatientName=...
+ *     }
+ * }
+ * @endcode
+ *
+ * @trace SRS-FR-041
+ */
+class DicomWebService {
+public:
+    DicomWebService();
+    ~DicomWebService();
+
+    // Non-copyable, movable
+    DicomWebService(const DicomWebService&) = delete;
+    DicomWebService& operator=(const DicomWebService&) = delete;
+    DicomWebService(DicomWebService&&) noexcept;
+    DicomWebService& operator=(DicomWebService&&) noexcept;
+
+    /**
+     * @brief Configure the DICOMweb service
+     *
+     * Sets up the underlying REST server configuration. The server
+     * is not started automatically — call start() after configuring.
+     *
+     * @param config DICOMweb configuration
+     * @return void on success, PacsErrorInfo on failure
+     */
+    [[nodiscard]] std::expected<void, PacsErrorInfo> configure(
+        const DicomWebConfig& config);
+
+    /**
+     * @brief Start the DICOMweb server (non-blocking)
+     *
+     * Starts the HTTP server in a background thread. The server will
+     * begin accepting connections immediately.
+     *
+     * @return void on success, PacsErrorInfo on failure
+     */
+    [[nodiscard]] std::expected<void, PacsErrorInfo> start();
+
+    /**
+     * @brief Stop the DICOMweb server
+     *
+     * Gracefully shuts down the HTTP server. Safe to call multiple times
+     * or when the server is not running.
+     */
+    void stop();
+
+    /**
+     * @brief Check if the server is currently running
+     */
+    [[nodiscard]] bool isRunning() const;
+
+    /**
+     * @brief Get the actual port the server is listening on
+     * @return Port number, or 0 if not running
+     */
+    [[nodiscard]] uint16_t actualPort() const;
+
+    /**
+     * @brief Get current configuration
+     */
+    [[nodiscard]] DicomWebConfig getConfig() const;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::services

--- a/src/services/pacs/dicomweb_service.cpp
+++ b/src/services/pacs/dicomweb_service.cpp
@@ -1,0 +1,205 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "services/dicomweb_service.hpp"
+
+#include <mutex>
+
+#include <spdlog/spdlog.h>
+
+#include <pacs/web/rest_config.hpp>
+#include <pacs/web/rest_server.hpp>
+
+namespace dicom_viewer::services {
+
+namespace {
+
+pacs::web::rest_server_config toRestConfig(const DicomWebConfig& config) {
+    pacs::web::rest_server_config rc;
+    rc.bind_address = config.bindAddress;
+    rc.port = config.port;
+    rc.concurrency = config.concurrency;
+    rc.enable_cors = config.enableCors;
+    rc.cors_allowed_origins = config.corsAllowedOrigins;
+    rc.enable_tls = config.enableTls;
+    rc.tls_cert_path = config.tlsCertPath;
+    rc.tls_key_path = config.tlsKeyPath;
+    rc.request_timeout_seconds = config.requestTimeoutSeconds;
+    rc.max_body_size = config.maxBodySize;
+    return rc;
+}
+
+} // anonymous namespace
+
+class DicomWebService::Impl {
+public:
+    Impl() = default;
+
+    std::expected<void, PacsErrorInfo> configure(const DicomWebConfig& config) {
+        std::lock_guard lock(mutex_);
+
+        if (!config.isValid()) {
+            return std::unexpected(PacsErrorInfo{
+                PacsError::ConfigurationInvalid,
+                "Invalid DICOMweb configuration"
+            });
+        }
+
+        if (server_ && server_->is_running()) {
+            return std::unexpected(PacsErrorInfo{
+                PacsError::InternalError,
+                "Cannot reconfigure while server is running. Stop first."
+            });
+        }
+
+        config_ = config;
+
+        if (!config.enabled) {
+            server_.reset();
+            spdlog::info("DICOMweb service configured but disabled");
+            return {};
+        }
+
+        auto rc = toRestConfig(config);
+
+        try {
+            server_ = std::make_unique<pacs::web::rest_server>(rc);
+        } catch (const std::exception& e) {
+            server_.reset();
+            return std::unexpected(PacsErrorInfo{
+                PacsError::InternalError,
+                std::string("Failed to initialize DICOMweb server: ") + e.what()
+            });
+        }
+
+        spdlog::info("DICOMweb service configured: {}:{} (CORS: {}, TLS: {})",
+                     config.bindAddress, config.port,
+                     config.enableCors ? "on" : "off",
+                     config.enableTls ? "on" : "off");
+        return {};
+    }
+
+    std::expected<void, PacsErrorInfo> start() {
+        std::lock_guard lock(mutex_);
+
+        if (!config_.enabled || !server_) {
+            return std::unexpected(PacsErrorInfo{
+                PacsError::ConfigurationInvalid,
+                "DICOMweb service is not configured or not enabled"
+            });
+        }
+
+        if (server_->is_running()) {
+            return std::unexpected(PacsErrorInfo{
+                PacsError::InternalError,
+                "DICOMweb server is already running"
+            });
+        }
+
+        try {
+            server_->start_async();
+            spdlog::info("DICOMweb server started on port {}",
+                         config_.port);
+        } catch (const std::exception& e) {
+            return std::unexpected(PacsErrorInfo{
+                PacsError::InternalError,
+                std::string("Failed to start DICOMweb server: ") + e.what()
+            });
+        }
+
+        return {};
+    }
+
+    void stop() {
+        std::lock_guard lock(mutex_);
+        if (server_ && server_->is_running()) {
+            server_->stop();
+            spdlog::info("DICOMweb server stopped");
+        }
+    }
+
+    bool isRunning() const {
+        std::lock_guard lock(mutex_);
+        return server_ != nullptr && server_->is_running();
+    }
+
+    uint16_t actualPort() const {
+        std::lock_guard lock(mutex_);
+        if (!server_) return 0;
+        return server_->port();
+    }
+
+    DicomWebConfig getConfig() const {
+        std::lock_guard lock(mutex_);
+        return config_;
+    }
+
+private:
+    DicomWebConfig config_;
+    std::unique_ptr<pacs::web::rest_server> server_;
+    mutable std::mutex mutex_;
+};
+
+// Public interface implementation
+
+DicomWebService::DicomWebService()
+    : impl_(std::make_unique<Impl>()) {
+}
+
+DicomWebService::~DicomWebService() = default;
+
+DicomWebService::DicomWebService(DicomWebService&&) noexcept = default;
+DicomWebService& DicomWebService::operator=(DicomWebService&&) noexcept = default;
+
+std::expected<void, PacsErrorInfo> DicomWebService::configure(
+    const DicomWebConfig& config) {
+    return impl_->configure(config);
+}
+
+std::expected<void, PacsErrorInfo> DicomWebService::start() {
+    return impl_->start();
+}
+
+void DicomWebService::stop() {
+    impl_->stop();
+}
+
+bool DicomWebService::isRunning() const {
+    return impl_->isRunning();
+}
+
+uint16_t DicomWebService::actualPort() const {
+    return impl_->actualPort();
+}
+
+DicomWebConfig DicomWebService::getConfig() const {
+    return impl_->getConfig();
+}
+
+} // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -273,6 +273,22 @@ target_include_directories(query_cache_manager_test PRIVATE
 
 gtest_discover_tests(query_cache_manager_test DISCOVERY_TIMEOUT 60)
 
+add_executable(dicomweb_service_test
+    unit/dicomweb_service_test.cpp
+)
+
+target_link_libraries(dicomweb_service_test PRIVATE
+    pacs_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(dicomweb_service_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(dicomweb_service_test DISCOVERY_TIMEOUT 60)
+
 # Unit tests for DICOM Move SCU
 add_executable(dicom_move_scu_test
     unit/dicom_move_scu_test.cpp

--- a/tests/unit/dicomweb_service_test.cpp
+++ b/tests/unit/dicomweb_service_test.cpp
@@ -1,0 +1,288 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <services/dicomweb_service.hpp>
+
+#include <pacs/web/rest_config.hpp>
+#include <pacs/web/rest_types.hpp>
+
+#include <string>
+
+namespace {
+
+using namespace dicom_viewer::services;
+
+class DicomWebServiceTest : public ::testing::Test {
+protected:
+    DicomWebService service;
+};
+
+// --- Default State ---
+
+TEST_F(DicomWebServiceTest, DefaultNotRunning) {
+    EXPECT_FALSE(service.isRunning());
+}
+
+TEST_F(DicomWebServiceTest, DefaultConfigDisabled) {
+    auto config = service.getConfig();
+    EXPECT_FALSE(config.enabled);
+}
+
+TEST_F(DicomWebServiceTest, DefaultPortZero) {
+    EXPECT_EQ(service.actualPort(), 0u);
+}
+
+// --- Configuration Validation ---
+
+TEST_F(DicomWebServiceTest, ConfigureDisabledSucceeds) {
+    DicomWebConfig config;
+    config.enabled = false;
+    auto result = service.configure(config);
+    EXPECT_TRUE(result.has_value())
+        << "Disabled configuration should always succeed";
+}
+
+TEST_F(DicomWebServiceTest, ConfigureZeroPortFails) {
+    DicomWebConfig config;
+    config.enabled = true;
+    config.port = 0;
+    auto result = service.configure(config);
+    EXPECT_FALSE(result.has_value())
+        << "Zero port should fail validation";
+}
+
+TEST_F(DicomWebServiceTest, ConfigureZeroConcurrencyFails) {
+    DicomWebConfig config;
+    config.enabled = true;
+    config.concurrency = 0;
+    auto result = service.configure(config);
+    EXPECT_FALSE(result.has_value())
+        << "Zero concurrency should fail validation";
+}
+
+TEST_F(DicomWebServiceTest, ConfigureValidSucceeds) {
+    DicomWebConfig config;
+    config.enabled = true;
+    config.port = 18080;
+    config.concurrency = 2;
+    auto result = service.configure(config);
+    EXPECT_TRUE(result.has_value())
+        << "Valid configuration should succeed";
+}
+
+TEST_F(DicomWebServiceTest, ConfigurePreservesSettings) {
+    DicomWebConfig config;
+    config.enabled = true;
+    config.bindAddress = "127.0.0.1";
+    config.port = 9090;
+    config.concurrency = 8;
+    config.enableCors = false;
+    config.corsAllowedOrigins = "https://example.com";
+    config.requestTimeoutSeconds = 60;
+    config.maxBodySize = 50 * 1024 * 1024;
+
+    (void)service.configure(config);
+    auto retrieved = service.getConfig();
+
+    EXPECT_EQ(retrieved.bindAddress, "127.0.0.1");
+    EXPECT_EQ(retrieved.port, 9090);
+    EXPECT_EQ(retrieved.concurrency, 8u);
+    EXPECT_FALSE(retrieved.enableCors);
+    EXPECT_EQ(retrieved.corsAllowedOrigins, "https://example.com");
+    EXPECT_EQ(retrieved.requestTimeoutSeconds, 60u);
+    EXPECT_EQ(retrieved.maxBodySize, 50u * 1024 * 1024);
+}
+
+// --- Start Without Configure ---
+
+TEST_F(DicomWebServiceTest, StartWithoutConfigureFails) {
+    auto result = service.start();
+    EXPECT_FALSE(result.has_value())
+        << "Starting without configuration should fail";
+}
+
+TEST_F(DicomWebServiceTest, StartWhenDisabledFails) {
+    DicomWebConfig config;
+    config.enabled = false;
+    (void)service.configure(config);
+
+    auto result = service.start();
+    EXPECT_FALSE(result.has_value())
+        << "Starting when disabled should fail";
+}
+
+// --- Stop Safety ---
+
+TEST_F(DicomWebServiceTest, StopWhenNotRunningIsSafe) {
+    EXPECT_NO_THROW(service.stop());
+}
+
+TEST_F(DicomWebServiceTest, StopWhenDisabledIsSafe) {
+    DicomWebConfig config;
+    config.enabled = false;
+    (void)service.configure(config);
+
+    EXPECT_NO_THROW(service.stop());
+}
+
+TEST_F(DicomWebServiceTest, DoubleStopIsSafe) {
+    EXPECT_NO_THROW(service.stop());
+    EXPECT_NO_THROW(service.stop());
+}
+
+// --- DicomWebConfig::isValid ---
+
+TEST_F(DicomWebServiceTest, DisabledConfigAlwaysValid) {
+    DicomWebConfig config;
+    config.enabled = false;
+    config.port = 0;
+    config.concurrency = 0;
+    EXPECT_TRUE(config.isValid())
+        << "Disabled config should always be valid regardless of fields";
+}
+
+TEST_F(DicomWebServiceTest, ValidEnabledConfig) {
+    DicomWebConfig config;
+    config.enabled = true;
+    config.port = 8080;
+    config.concurrency = 4;
+    EXPECT_TRUE(config.isValid());
+}
+
+TEST_F(DicomWebServiceTest, InvalidEnabledConfigZeroPort) {
+    DicomWebConfig config;
+    config.enabled = true;
+    config.port = 0;
+    config.concurrency = 4;
+    EXPECT_FALSE(config.isValid());
+}
+
+TEST_F(DicomWebServiceTest, InvalidEnabledConfigZeroConcurrency) {
+    DicomWebConfig config;
+    config.enabled = true;
+    config.port = 8080;
+    config.concurrency = 0;
+    EXPECT_FALSE(config.isValid());
+}
+
+// --- Config Defaults ---
+
+TEST_F(DicomWebServiceTest, ConfigDefaults) {
+    DicomWebConfig config;
+    EXPECT_FALSE(config.enabled);
+    EXPECT_EQ(config.bindAddress, "0.0.0.0");
+    EXPECT_EQ(config.port, 8080);
+    EXPECT_EQ(config.concurrency, 4u);
+    EXPECT_TRUE(config.enableCors);
+    EXPECT_EQ(config.corsAllowedOrigins, "*");
+    EXPECT_FALSE(config.enableTls);
+    EXPECT_TRUE(config.tlsCertPath.empty());
+    EXPECT_TRUE(config.tlsKeyPath.empty());
+    EXPECT_EQ(config.requestTimeoutSeconds, 30u);
+    EXPECT_EQ(config.maxBodySize, 10u * 1024 * 1024);
+}
+
+// --- Move Semantics ---
+
+TEST_F(DicomWebServiceTest, MoveConstruction) {
+    DicomWebConfig config;
+    config.enabled = false;
+    config.port = 9999;
+    (void)service.configure(config);
+
+    DicomWebService moved(std::move(service));
+    auto retrievedConfig = moved.getConfig();
+    EXPECT_EQ(retrievedConfig.port, 9999);
+}
+
+TEST_F(DicomWebServiceTest, MoveAssignment) {
+    DicomWebConfig config;
+    config.enabled = false;
+    config.port = 7777;
+    (void)service.configure(config);
+
+    DicomWebService other;
+    other = std::move(service);
+    auto retrievedConfig = other.getConfig();
+    EXPECT_EQ(retrievedConfig.port, 7777);
+}
+
+// --- pacs::web Types ---
+
+TEST_F(DicomWebServiceTest, PacsRestServerConfigDefaults) {
+    pacs::web::rest_server_config config;
+    EXPECT_EQ(config.port, 8080);
+    EXPECT_EQ(config.concurrency, 4u);
+    EXPECT_TRUE(config.enable_cors);
+    EXPECT_FALSE(config.enable_tls);
+}
+
+TEST_F(DicomWebServiceTest, PacsHttpStatusValues) {
+    EXPECT_EQ(static_cast<uint16_t>(pacs::web::http_status::ok), 200);
+    EXPECT_EQ(static_cast<uint16_t>(pacs::web::http_status::not_found), 404);
+    EXPECT_EQ(static_cast<uint16_t>(pacs::web::http_status::internal_server_error), 500);
+}
+
+TEST_F(DicomWebServiceTest, PacsJsonHelpers) {
+    auto errorJson = pacs::web::make_error_json("NOT_FOUND", "Resource not found");
+    EXPECT_FALSE(errorJson.empty());
+    EXPECT_NE(errorJson.find("NOT_FOUND"), std::string::npos);
+
+    auto successJson = pacs::web::make_success_json("Operation completed");
+    EXPECT_FALSE(successJson.empty());
+    EXPECT_NE(successJson.find("success"), std::string::npos);
+}
+
+TEST_F(DicomWebServiceTest, PacsJsonEscape) {
+    auto escaped = pacs::web::json_escape("hello \"world\"");
+    EXPECT_NE(escaped.find("\\\""), std::string::npos);
+    EXPECT_EQ(escaped.find("\"world\""), std::string::npos);
+}
+
+// --- TLS Config ---
+
+TEST_F(DicomWebServiceTest, TlsConfigPreserved) {
+    DicomWebConfig config;
+    config.enabled = true;
+    config.port = 8443;
+    config.enableTls = true;
+    config.tlsCertPath = "/path/to/cert.pem";
+    config.tlsKeyPath = "/path/to/key.pem";
+
+    (void)service.configure(config);
+    auto retrieved = service.getConfig();
+
+    EXPECT_TRUE(retrieved.enableTls);
+    EXPECT_EQ(retrieved.tlsCertPath, "/path/to/cert.pem");
+    EXPECT_EQ(retrieved.tlsKeyPath, "/path/to/key.pem");
+}
+
+} // anonymous namespace


### PR DESCRIPTION
Closes #459

## Summary
- Add `DicomWebService` wrapping pacs_system's `rest_server` for DICOMweb endpoint management (WADO-RS, STOW-RS, QIDO-RS)
- Add `DicomWebConfig` struct with full server configuration (bind address, port, concurrency, CORS, TLS, timeouts)
- Link `pacs::web` and its transitive dependencies (`pacs::storage`, `pacs::client`, `pacs::monitoring`, database, sqlite3)
- Add 25 unit tests covering default state, config validation, lifecycle, move semantics, and pacs::web type integration

## Test Plan
- [x] 25 new DicomWebService unit tests all pass
- [x] Full regression: 3221 tests, only pre-existing failures (17)
- [x] Build succeeds with all transitive dependency chains resolved