### PR TITLE
feat(render): add off-screen rendering support for headless environments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,6 +534,8 @@ add_library(render_service STATIC
     src/services/render/streamline_overlay_renderer.cpp
     src/services/render/hemodynamic_surface_manager.cpp
     src/services/render/asc_view_controller.cpp
+    src/services/render/offscreen_render_context.cpp
+    src/services/render/render_session.cpp
 )
 
 target_link_libraries(render_service PUBLIC

--- a/include/services/mpr_renderer.hpp
+++ b/include/services/mpr_renderer.hpp
@@ -47,8 +47,10 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <functional>
 #include <memory>
+#include <vector>
 
 #include <vtkSmartPointer.h>
 #include <vtkImageData.h>
@@ -250,6 +252,38 @@ public:
      * @brief Update all views
      */
     void update();
+
+    // ==================== Off-Screen Rendering ====================
+
+    /**
+     * @brief Enable headless off-screen rendering mode
+     * @param width Frame width in pixels
+     * @param height Frame height in pixels
+     *
+     * Creates three internal off-screen render contexts (one per plane)
+     * for server-side rendering without a display.
+     */
+    void enableOffscreenMode(uint32_t width, uint32_t height);
+
+    /**
+     * @brief Check if off-screen mode is active
+     * @return True if off-screen rendering is enabled
+     */
+    [[nodiscard]] bool isOffscreenMode() const;
+
+    /**
+     * @brief Capture the current frame for a specific plane as RGBA pixels
+     * @param plane MPR plane to capture
+     * @return RGBA pixel data (width * height * 4 bytes), empty if not in off-screen mode
+     */
+    [[nodiscard]] std::vector<uint8_t> captureFrame(MPRPlane plane);
+
+    /**
+     * @brief Resize all off-screen render targets
+     * @param width New width in pixels
+     * @param height New height in pixels
+     */
+    void resizeOffscreen(uint32_t width, uint32_t height);
 
     /**
      * @brief Reset views to default positions (center of volume)

--- a/include/services/render/offscreen_render_context.hpp
+++ b/include/services/render/offscreen_render_context.hpp
@@ -1,0 +1,136 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file offscreen_render_context.hpp
+ * @brief Headless off-screen VTK rendering context
+ * @details Encapsulates a VTK render window configured for off-screen
+ *          rendering and RGBA frame capture. Provides the foundation for
+ *          server-side rendering without a display.
+ *
+ * VTK 9.x SetOffScreenRendering(true) auto-selects the best backend:
+ * Metal on macOS, EGL/OSMesa on Linux.
+ *
+ * ## Thread Safety
+ * - Not thread-safe. External synchronization required for concurrent access.
+ * - Each context should be used from a single thread at a time.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <vtkSmartPointer.h>
+
+class vtkRenderer;
+class vtkRenderWindow;
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Off-screen VTK rendering context for headless frame capture
+ *
+ * Creates a VTK render window with off-screen rendering enabled,
+ * paired with a vtkWindowToImageFilter for RGBA pixel extraction.
+ *
+ * @trace SRS-FR-REMOTE-001
+ */
+class OffscreenRenderContext {
+public:
+    OffscreenRenderContext();
+    ~OffscreenRenderContext();
+
+    // Non-copyable, movable
+    OffscreenRenderContext(const OffscreenRenderContext&) = delete;
+    OffscreenRenderContext& operator=(const OffscreenRenderContext&) = delete;
+    OffscreenRenderContext(OffscreenRenderContext&&) noexcept;
+    OffscreenRenderContext& operator=(OffscreenRenderContext&&) noexcept;
+
+    /**
+     * @brief Initialize the off-screen render window
+     * @param width Frame width in pixels
+     * @param height Frame height in pixels
+     */
+    void initialize(uint32_t width, uint32_t height);
+
+    /**
+     * @brief Check if the context has been initialized
+     * @return True if initialized
+     */
+    [[nodiscard]] bool isInitialized() const;
+
+    /**
+     * @brief Get the underlying VTK render window
+     * @return Render window pointer, or nullptr if not initialized
+     */
+    [[nodiscard]] vtkRenderWindow* getRenderWindow() const;
+
+    /**
+     * @brief Get the default renderer attached to this context
+     * @return Renderer pointer, or nullptr if not initialized
+     */
+    [[nodiscard]] vtkRenderer* getRenderer() const;
+
+    /**
+     * @brief Resize the render window
+     * @param width New width in pixels
+     * @param height New height in pixels
+     */
+    void resize(uint32_t width, uint32_t height);
+
+    /**
+     * @brief Get the current frame size
+     * @return {width, height} pair
+     */
+    [[nodiscard]] std::pair<uint32_t, uint32_t> getSize() const;
+
+    /**
+     * @brief Check if the render window supports OpenGL rendering
+     * @return True if OpenGL is available, false on headless systems without GPU
+     */
+    [[nodiscard]] bool supportsOpenGL() const;
+
+    /**
+     * @brief Render the scene and capture the frame as RGBA pixels
+     * @return RGBA pixel data (width * height * 4 bytes), empty if OpenGL unavailable
+     */
+    [[nodiscard]] std::vector<uint8_t> captureFrame();
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::services

--- a/include/services/render/render_session.hpp
+++ b/include/services/render/render_session.hpp
@@ -1,0 +1,127 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file render_session.hpp
+ * @brief Aggregate headless rendering session for remote rendering
+ * @details Bundles VolumeRenderer and MPRRenderer in off-screen mode,
+ *          providing thread-safe frame capture for server-side rendering.
+ *
+ * ## Thread Safety
+ * - Frame capture methods are mutex-protected for concurrent access.
+ * - Input data and renderer configuration should be set before
+ *   capturing frames from multiple threads.
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <vtkSmartPointer.h>
+#include <vtkImageData.h>
+
+namespace dicom_viewer::services {
+
+class VolumeRenderer;
+class MPRRenderer;
+enum class MPRPlane;
+
+/**
+ * @brief Aggregate headless rendering session
+ *
+ * Owns a VolumeRenderer and MPRRenderer, both initialized in off-screen mode.
+ * Provides thread-safe frame capture for remote rendering.
+ *
+ * @trace SRS-FR-REMOTE-002
+ */
+class RenderSession {
+public:
+    /**
+     * @brief Create a render session with the specified frame size
+     * @param width Frame width in pixels
+     * @param height Frame height in pixels
+     */
+    explicit RenderSession(uint32_t width, uint32_t height);
+    ~RenderSession();
+
+    // Non-copyable, movable
+    RenderSession(const RenderSession&) = delete;
+    RenderSession& operator=(const RenderSession&) = delete;
+    RenderSession(RenderSession&&) noexcept;
+    RenderSession& operator=(RenderSession&&) noexcept;
+
+    /**
+     * @brief Get the volume renderer
+     * @return Reference to the volume renderer
+     */
+    VolumeRenderer& volumeRenderer();
+
+    /**
+     * @brief Get the MPR renderer
+     * @return Reference to the MPR renderer
+     */
+    MPRRenderer& mprRenderer();
+
+    /**
+     * @brief Set input volume data for all renderers
+     * @param imageData VTK image data (3D volume)
+     */
+    void setInputData(vtkSmartPointer<vtkImageData> imageData);
+
+    /**
+     * @brief Capture a volume rendering frame (thread-safe)
+     * @return RGBA pixel data (width * height * 4 bytes)
+     */
+    [[nodiscard]] std::vector<uint8_t> captureVolumeFrame();
+
+    /**
+     * @brief Capture an MPR frame for a specific plane (thread-safe)
+     * @param plane MPR plane to capture
+     * @return RGBA pixel data (width * height * 4 bytes)
+     */
+    [[nodiscard]] std::vector<uint8_t> captureMPRFrame(MPRPlane plane);
+
+    /**
+     * @brief Resize all off-screen render targets
+     * @param width New width in pixels
+     * @param height New height in pixels
+     */
+    void resize(uint32_t width, uint32_t height);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::services

--- a/include/services/surface_renderer.hpp
+++ b/include/services/surface_renderer.hpp
@@ -47,6 +47,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -249,6 +250,37 @@ public:
      * @brief Update rendering
      */
     void update();
+
+    // ==================== Off-Screen Rendering ====================
+
+    /**
+     * @brief Enable headless off-screen rendering mode
+     * @param width Frame width in pixels
+     * @param height Frame height in pixels
+     *
+     * Creates an internal off-screen render window and adds all
+     * current surface actors to it via addToRenderer().
+     */
+    void enableOffscreenMode(uint32_t width, uint32_t height);
+
+    /**
+     * @brief Check if off-screen mode is active
+     * @return True if off-screen rendering is enabled
+     */
+    [[nodiscard]] bool isOffscreenMode() const;
+
+    /**
+     * @brief Capture the current frame as RGBA pixels
+     * @return RGBA pixel data (width * height * 4 bytes), empty if not in off-screen mode
+     */
+    [[nodiscard]] std::vector<uint8_t> captureFrame();
+
+    /**
+     * @brief Resize the off-screen render target
+     * @param width New width in pixels
+     * @param height New height in pixels
+     */
+    void resizeOffscreen(uint32_t width, uint32_t height);
 
     // Preset surface configurations
     static SurfaceConfig getPresetBone();

--- a/include/services/volume_renderer.hpp
+++ b/include/services/volume_renderer.hpp
@@ -46,6 +46,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -179,6 +180,37 @@ public:
      * @brief Update rendering (call after changes)
      */
     void update();
+
+    // ==================== Off-Screen Rendering ====================
+
+    /**
+     * @brief Enable headless off-screen rendering mode
+     * @param width Frame width in pixels
+     * @param height Frame height in pixels
+     *
+     * Creates an internal off-screen render window and attaches
+     * the volume actor to it. GPU support is validated automatically.
+     */
+    void enableOffscreenMode(uint32_t width, uint32_t height);
+
+    /**
+     * @brief Check if off-screen mode is active
+     * @return True if off-screen rendering is enabled
+     */
+    [[nodiscard]] bool isOffscreenMode() const;
+
+    /**
+     * @brief Capture the current frame as RGBA pixels
+     * @return RGBA pixel data (width * height * 4 bytes), empty if not in off-screen mode
+     */
+    [[nodiscard]] std::vector<uint8_t> captureFrame();
+
+    /**
+     * @brief Resize the off-screen render target
+     * @param width New width in pixels
+     * @param height New height in pixels
+     */
+    void resizeOffscreen(uint32_t width, uint32_t height);
 
     // Built-in presets
     static TransferFunctionPreset getPresetCTBone();

--- a/src/services/render/mpr_renderer.cpp
+++ b/src/services/render/mpr_renderer.cpp
@@ -28,6 +28,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "services/mpr_renderer.hpp"
+#include "services/render/offscreen_render_context.hpp"
 #include <kcenon/common/logging/log_macros.h>
 #include "services/coordinate/mpr_coordinate_transformer.hpp"
 #include "services/segmentation/mpr_segmentation_renderer.hpp"
@@ -38,6 +39,7 @@
 #include <vtkImageMapToColors.h>
 #include <vtkLookupTable.h>
 #include <vtkRenderer.h>
+#include <vtkRenderWindow.h>
 #include <vtkCamera.h>
 #include <vtkMatrix4x4.h>
 #include <vtkTransform.h>
@@ -113,6 +115,9 @@ public:
     // Segmentation support (using unified coordinate service)
     std::unique_ptr<coordinate::MPRCoordinateTransformer> coordinateTransformer;
     std::unique_ptr<MPRSegmentationRenderer> segmentationRenderer;
+
+    // Off-screen rendering (one context per plane)
+    std::array<std::unique_ptr<OffscreenRenderContext>, 3> offscreenContexts;
 
     Impl() {
         coordinateTransformer = std::make_unique<coordinate::MPRCoordinateTransformer>();
@@ -694,6 +699,43 @@ int MPRRenderer::worldPositionToSliceIndex(MPRPlane plane, double worldPosition)
 
 double MPRRenderer::sliceIndexToWorldPosition(MPRPlane plane, int sliceIndex) const {
     return impl_->coordinateTransformer->getWorldPosition(plane, sliceIndex);
+}
+
+// =============================================================================
+// Off-Screen Rendering
+// =============================================================================
+
+void MPRRenderer::enableOffscreenMode(uint32_t width, uint32_t height) {
+    for (int i = 0; i < 3; ++i) {
+        impl_->offscreenContexts[i] = std::make_unique<OffscreenRenderContext>();
+        impl_->offscreenContexts[i]->initialize(width, height);
+
+        auto* renderWindow = impl_->offscreenContexts[i]->getRenderWindow();
+        renderWindow->AddRenderer(impl_->renderers[i]);
+    }
+
+    LOG_INFO(std::format("MPR renderer off-screen mode enabled: {}x{}", width, height));
+}
+
+bool MPRRenderer::isOffscreenMode() const {
+    return impl_->offscreenContexts[0] != nullptr
+        && impl_->offscreenContexts[0]->isInitialized();
+}
+
+std::vector<uint8_t> MPRRenderer::captureFrame(MPRPlane plane) {
+    int idx = static_cast<int>(plane);
+    if (idx < 0 || idx >= 3 || !impl_->offscreenContexts[idx]) {
+        return {};
+    }
+    return impl_->offscreenContexts[idx]->captureFrame();
+}
+
+void MPRRenderer::resizeOffscreen(uint32_t width, uint32_t height) {
+    for (int i = 0; i < 3; ++i) {
+        if (impl_->offscreenContexts[i]) {
+            impl_->offscreenContexts[i]->resize(width, height);
+        }
+    }
 }
 
 } // namespace dicom_viewer::services

--- a/src/services/render/offscreen_render_context.cpp
+++ b/src/services/render/offscreen_render_context.cpp
@@ -1,0 +1,161 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "services/render/offscreen_render_context.hpp"
+#include <kcenon/common/logging/log_macros.h>
+
+#include <vtkRenderWindow.h>
+#include <vtkRenderer.h>
+#include <vtkWindowToImageFilter.h>
+#include <vtkImageData.h>
+#include <vtkUnsignedCharArray.h>
+#include <vtkPointData.h>
+
+#include <format>
+
+namespace dicom_viewer::services {
+
+class OffscreenRenderContext::Impl {
+public:
+    vtkSmartPointer<vtkRenderWindow> renderWindow;
+    vtkSmartPointer<vtkRenderer> renderer;
+    vtkSmartPointer<vtkWindowToImageFilter> windowToImage;
+    uint32_t width = 0;
+    uint32_t height = 0;
+    bool initialized = false;
+};
+
+OffscreenRenderContext::OffscreenRenderContext() : impl_(std::make_unique<Impl>()) {}
+OffscreenRenderContext::~OffscreenRenderContext() = default;
+OffscreenRenderContext::OffscreenRenderContext(OffscreenRenderContext&&) noexcept = default;
+OffscreenRenderContext& OffscreenRenderContext::operator=(OffscreenRenderContext&&) noexcept = default;
+
+void OffscreenRenderContext::initialize(uint32_t width, uint32_t height)
+{
+    impl_->renderWindow = vtkSmartPointer<vtkRenderWindow>::New();
+    impl_->renderWindow->SetOffScreenRendering(1);
+    impl_->renderWindow->SetSize(static_cast<int>(width), static_cast<int>(height));
+
+    impl_->renderer = vtkSmartPointer<vtkRenderer>::New();
+    impl_->renderer->SetBackground(0.0, 0.0, 0.0);
+    impl_->renderWindow->AddRenderer(impl_->renderer);
+
+    impl_->windowToImage = vtkSmartPointer<vtkWindowToImageFilter>::New();
+    impl_->windowToImage->SetInput(impl_->renderWindow);
+    impl_->windowToImage->SetInputBufferTypeToRGBA();
+    impl_->windowToImage->ReadFrontBufferOff();
+
+    impl_->width = width;
+    impl_->height = height;
+    impl_->initialized = true;
+
+    LOG_INFO(std::format("Off-screen render context initialized: {}x{}", width, height));
+}
+
+bool OffscreenRenderContext::isInitialized() const
+{
+    return impl_->initialized;
+}
+
+vtkRenderWindow* OffscreenRenderContext::getRenderWindow() const
+{
+    return impl_->renderWindow;
+}
+
+vtkRenderer* OffscreenRenderContext::getRenderer() const
+{
+    return impl_->renderer;
+}
+
+void OffscreenRenderContext::resize(uint32_t width, uint32_t height)
+{
+    if (!impl_->initialized) {
+        return;
+    }
+
+    impl_->renderWindow->SetSize(static_cast<int>(width), static_cast<int>(height));
+    impl_->width = width;
+    impl_->height = height;
+
+    // Reset the filter so it picks up the new window size
+    impl_->windowToImage->Modified();
+
+    LOG_INFO(std::format("Off-screen render context resized: {}x{}", width, height));
+}
+
+std::pair<uint32_t, uint32_t> OffscreenRenderContext::getSize() const
+{
+    return {impl_->width, impl_->height};
+}
+
+bool OffscreenRenderContext::supportsOpenGL() const
+{
+    if (!impl_->initialized || !impl_->renderWindow) {
+        return false;
+    }
+    return impl_->renderWindow->SupportsOpenGL();
+}
+
+std::vector<uint8_t> OffscreenRenderContext::captureFrame()
+{
+    if (!impl_->initialized) {
+        return {};
+    }
+
+    // Check OpenGL support before attempting to render.
+    // On headless macOS (no display), OpenGL context creation fails and
+    // calling Render() would crash. Return empty in that case.
+    if (!impl_->renderWindow->SupportsOpenGL()) {
+        LOG_WARNING("Off-screen render window does not support OpenGL");
+        return {};
+    }
+
+    impl_->renderWindow->Render();
+    impl_->windowToImage->Modified();
+    impl_->windowToImage->Update();
+
+    vtkImageData* image = impl_->windowToImage->GetOutput();
+    if (!image) {
+        LOG_WARNING("Off-screen capture produced null image");
+        return {};
+    }
+
+    int* dims = image->GetDimensions();
+    size_t totalBytes = static_cast<size_t>(dims[0]) * dims[1] * 4;
+
+    auto* scalars = image->GetPointData()->GetScalars();
+    if (!scalars) {
+        return {};
+    }
+
+    auto* rawPtr = static_cast<uint8_t*>(scalars->GetVoidPointer(0));
+    return {rawPtr, rawPtr + totalBytes};
+}
+
+} // namespace dicom_viewer::services

--- a/src/services/render/render_session.cpp
+++ b/src/services/render/render_session.cpp
@@ -1,0 +1,100 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "services/render/render_session.hpp"
+#include "services/volume_renderer.hpp"
+#include "services/mpr_renderer.hpp"
+#include <kcenon/common/logging/log_macros.h>
+
+#include <format>
+#include <mutex>
+
+namespace dicom_viewer::services {
+
+class RenderSession::Impl {
+public:
+    std::unique_ptr<VolumeRenderer> volume;
+    std::unique_ptr<MPRRenderer> mpr;
+    std::mutex renderMutex;
+
+    Impl(uint32_t width, uint32_t height)
+        : volume(std::make_unique<VolumeRenderer>())
+        , mpr(std::make_unique<MPRRenderer>())
+    {
+        volume->enableOffscreenMode(width, height);
+        mpr->enableOffscreenMode(width, height);
+        LOG_INFO(std::format("Render session created: {}x{}", width, height));
+    }
+};
+
+RenderSession::RenderSession(uint32_t width, uint32_t height)
+    : impl_(std::make_unique<Impl>(width, height))
+{
+}
+
+RenderSession::~RenderSession() = default;
+RenderSession::RenderSession(RenderSession&&) noexcept = default;
+RenderSession& RenderSession::operator=(RenderSession&&) noexcept = default;
+
+VolumeRenderer& RenderSession::volumeRenderer()
+{
+    return *impl_->volume;
+}
+
+MPRRenderer& RenderSession::mprRenderer()
+{
+    return *impl_->mpr;
+}
+
+void RenderSession::setInputData(vtkSmartPointer<vtkImageData> imageData)
+{
+    impl_->volume->setInputData(imageData);
+    impl_->mpr->setInputData(imageData);
+}
+
+std::vector<uint8_t> RenderSession::captureVolumeFrame()
+{
+    std::lock_guard<std::mutex> lock(impl_->renderMutex);
+    return impl_->volume->captureFrame();
+}
+
+std::vector<uint8_t> RenderSession::captureMPRFrame(MPRPlane plane)
+{
+    std::lock_guard<std::mutex> lock(impl_->renderMutex);
+    return impl_->mpr->captureFrame(plane);
+}
+
+void RenderSession::resize(uint32_t width, uint32_t height)
+{
+    std::lock_guard<std::mutex> lock(impl_->renderMutex);
+    impl_->volume->resizeOffscreen(width, height);
+    impl_->mpr->resizeOffscreen(width, height);
+}
+
+} // namespace dicom_viewer::services

--- a/src/services/render/surface_renderer.cpp
+++ b/src/services/render/surface_renderer.cpp
@@ -28,8 +28,10 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "services/surface_renderer.hpp"
+#include "services/render/offscreen_render_context.hpp"
 #include <kcenon/common/logging/log_macros.h>
 
+#include <vtkRenderWindow.h>
 #include <vtkMarchingCubes.h>
 #include <vtkWindowedSincPolyDataFilter.h>
 #include <vtkDecimatePro.h>
@@ -68,6 +70,10 @@ public:
     vtkSmartPointer<vtkImageData> inputData;
     std::vector<SurfaceEntry> surfaces;
     SurfaceQuality quality = SurfaceQuality::Medium;
+
+    // Off-screen rendering
+    std::unique_ptr<OffscreenRenderContext> offscreenCtx;
+    vtkSmartPointer<vtkRenderer> offscreenRenderer;
 
     SurfaceEntry createSurfaceEntry(const SurfaceConfig& config) {
         SurfaceEntry entry;
@@ -672,6 +678,47 @@ vtkSmartPointer<vtkLookupTable> SurfaceRenderer::createAFILookupTable(double max
     }
 
     return lut;
+}
+
+// =============================================================================
+// Off-Screen Rendering
+// =============================================================================
+
+void SurfaceRenderer::enableOffscreenMode(uint32_t width, uint32_t height)
+{
+    impl_->offscreenCtx = std::make_unique<OffscreenRenderContext>();
+    impl_->offscreenCtx->initialize(width, height);
+
+    impl_->offscreenRenderer = vtkSmartPointer<vtkRenderer>::New();
+    impl_->offscreenRenderer->SetBackground(0.0, 0.0, 0.0);
+
+    auto* renderWindow = impl_->offscreenCtx->getRenderWindow();
+    renderWindow->AddRenderer(impl_->offscreenRenderer);
+
+    addToRenderer(impl_->offscreenRenderer);
+
+    LOG_INFO(std::format("Surface renderer off-screen mode enabled: {}x{}", width, height));
+}
+
+bool SurfaceRenderer::isOffscreenMode() const
+{
+    return impl_->offscreenCtx && impl_->offscreenCtx->isInitialized();
+}
+
+std::vector<uint8_t> SurfaceRenderer::captureFrame()
+{
+    if (!isOffscreenMode()) {
+        return {};
+    }
+    return impl_->offscreenCtx->captureFrame();
+}
+
+void SurfaceRenderer::resizeOffscreen(uint32_t width, uint32_t height)
+{
+    if (!isOffscreenMode()) {
+        return;
+    }
+    impl_->offscreenCtx->resize(width, height);
 }
 
 } // namespace dicom_viewer::services

--- a/src/services/render/volume_renderer.cpp
+++ b/src/services/render/volume_renderer.cpp
@@ -28,6 +28,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "services/volume_renderer.hpp"
+#include "services/render/offscreen_render_context.hpp"
 #include <kcenon/common/logging/log_macros.h>
 
 #include <vtkGPUVolumeRayCastMapper.h>
@@ -78,6 +79,10 @@ public:
 
     // Scalar overlays (name → entry)
     std::map<std::string, ScalarOverlayEntry> overlays;
+
+    // Off-screen rendering
+    std::unique_ptr<OffscreenRenderContext> offscreenCtx;
+    vtkSmartPointer<vtkRenderer> offscreenRenderer;
 
     Impl() {
         volume = vtkSmartPointer<vtkVolume>::New();
@@ -296,6 +301,48 @@ void VolumeRenderer::clearClippingPlanes()
 void VolumeRenderer::update()
 {
     impl_->volume->Modified();
+}
+
+// =============================================================================
+// Off-Screen Rendering
+// =============================================================================
+
+void VolumeRenderer::enableOffscreenMode(uint32_t width, uint32_t height)
+{
+    impl_->offscreenCtx = std::make_unique<OffscreenRenderContext>();
+    impl_->offscreenCtx->initialize(width, height);
+
+    impl_->offscreenRenderer = vtkSmartPointer<vtkRenderer>::New();
+    impl_->offscreenRenderer->SetBackground(0.0, 0.0, 0.0);
+
+    auto* renderWindow = impl_->offscreenCtx->getRenderWindow();
+    renderWindow->AddRenderer(impl_->offscreenRenderer);
+    impl_->offscreenRenderer->AddVolume(impl_->volume);
+
+    validateGPUSupport(vtkSmartPointer<vtkRenderWindow>(renderWindow));
+
+    LOG_INFO(std::format("Volume renderer off-screen mode enabled: {}x{}", width, height));
+}
+
+bool VolumeRenderer::isOffscreenMode() const
+{
+    return impl_->offscreenCtx && impl_->offscreenCtx->isInitialized();
+}
+
+std::vector<uint8_t> VolumeRenderer::captureFrame()
+{
+    if (!isOffscreenMode()) {
+        return {};
+    }
+    return impl_->offscreenCtx->captureFrame();
+}
+
+void VolumeRenderer::resizeOffscreen(uint32_t width, uint32_t height)
+{
+    if (!isOffscreenMode()) {
+        return;
+    }
+    impl_->offscreenCtx->resize(width, height);
 }
 
 // Preset definitions

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2034,3 +2034,38 @@ target_include_directories(settings_dialog_test PRIVATE
 )
 
 gtest_discover_tests(settings_dialog_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for OffscreenRenderContext
+add_executable(offscreen_render_context_test
+    unit/offscreen_render_context_test.cpp
+)
+
+target_link_libraries(offscreen_render_context_test PRIVATE
+    render_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(offscreen_render_context_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(offscreen_render_context_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for RenderSession
+add_executable(render_session_test
+    unit/render_session_test.cpp
+)
+
+target_link_libraries(render_session_test PRIVATE
+    render_service
+    segmentation_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(render_session_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(render_session_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/mpr_renderer_test.cpp
+++ b/tests/unit/mpr_renderer_test.cpp
@@ -643,3 +643,52 @@ TEST_F(MPRRendererTest, ExtremeSlicePositionsClamped) {
     EXPECT_NO_THROW(renderer->scrollSlice(MPRPlane::Sagittal, -999999));
     EXPECT_NO_THROW(renderer->update());
 }
+
+// =============================================================================
+// Off-Screen Rendering (Issue #469)
+// =============================================================================
+
+TEST_F(MPRRendererTest, OffscreenModeDefaultOff) {
+    EXPECT_FALSE(renderer->isOffscreenMode());
+}
+
+TEST_F(MPRRendererTest, EnableOffscreenMode) {
+    EXPECT_NO_THROW(renderer->enableOffscreenMode(256, 256));
+    EXPECT_TRUE(renderer->isOffscreenMode());
+}
+
+TEST_F(MPRRendererTest, CaptureFramePerPlane) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+    renderer->enableOffscreenMode(64, 48);
+
+    for (auto plane : {MPRPlane::Axial, MPRPlane::Coronal, MPRPlane::Sagittal}) {
+        auto frame = renderer->captureFrame(plane);
+        // On headless (no OpenGL), frame may be empty
+        if (!frame.empty()) {
+            EXPECT_EQ(frame.size(), 64u * 48u * 4u);
+        }
+    }
+}
+
+TEST_F(MPRRendererTest, CaptureFrameNotInOffscreenMode) {
+    auto frame = renderer->captureFrame(MPRPlane::Axial);
+    EXPECT_TRUE(frame.empty());
+}
+
+TEST_F(MPRRendererTest, ResizeOffscreen) {
+    renderer->enableOffscreenMode(64, 48);
+    renderer->resizeOffscreen(128, 96);
+
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+
+    auto frame = renderer->captureFrame(MPRPlane::Axial);
+    if (!frame.empty()) {
+        EXPECT_EQ(frame.size(), 128u * 96u * 4u);
+    }
+}
+
+TEST_F(MPRRendererTest, ResizeOffscreenNotInMode) {
+    EXPECT_NO_THROW(renderer->resizeOffscreen(128, 96));
+}

--- a/tests/unit/offscreen_render_context_test.cpp
+++ b/tests/unit/offscreen_render_context_test.cpp
@@ -1,0 +1,175 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include "services/render/offscreen_render_context.hpp"
+
+#include <vtkRenderWindow.h>
+#include <vtkRenderer.h>
+
+using namespace dicom_viewer::services;
+
+class OffscreenRenderContextTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        context = std::make_unique<OffscreenRenderContext>();
+    }
+
+    void TearDown() override {
+        context.reset();
+    }
+
+    std::unique_ptr<OffscreenRenderContext> context;
+};
+
+// Test construction
+TEST_F(OffscreenRenderContextTest, DefaultConstruction) {
+    EXPECT_NE(context, nullptr);
+    EXPECT_FALSE(context->isInitialized());
+}
+
+// Test initialization
+TEST_F(OffscreenRenderContextTest, Initialize) {
+    context->initialize(800, 600);
+    EXPECT_TRUE(context->isInitialized());
+}
+
+TEST_F(OffscreenRenderContextTest, GetRenderWindowAfterInit) {
+    context->initialize(800, 600);
+    EXPECT_NE(context->getRenderWindow(), nullptr);
+}
+
+TEST_F(OffscreenRenderContextTest, GetRendererAfterInit) {
+    context->initialize(800, 600);
+    EXPECT_NE(context->getRenderer(), nullptr);
+}
+
+TEST_F(OffscreenRenderContextTest, GetRenderWindowBeforeInit) {
+    EXPECT_EQ(context->getRenderWindow(), nullptr);
+}
+
+TEST_F(OffscreenRenderContextTest, GetRendererBeforeInit) {
+    EXPECT_EQ(context->getRenderer(), nullptr);
+}
+
+TEST_F(OffscreenRenderContextTest, OffScreenRenderingEnabled) {
+    context->initialize(800, 600);
+    auto* renderWindow = context->getRenderWindow();
+    ASSERT_NE(renderWindow, nullptr);
+    EXPECT_TRUE(renderWindow->GetOffScreenRendering());
+}
+
+// Test size
+TEST_F(OffscreenRenderContextTest, GetSizeAfterInit) {
+    context->initialize(1024, 768);
+    auto [width, height] = context->getSize();
+    EXPECT_EQ(width, 1024u);
+    EXPECT_EQ(height, 768u);
+}
+
+TEST_F(OffscreenRenderContextTest, GetSizeBeforeInit) {
+    auto [width, height] = context->getSize();
+    EXPECT_EQ(width, 0u);
+    EXPECT_EQ(height, 0u);
+}
+
+// Test resize
+TEST_F(OffscreenRenderContextTest, Resize) {
+    context->initialize(800, 600);
+    context->resize(1920, 1080);
+    auto [width, height] = context->getSize();
+    EXPECT_EQ(width, 1920u);
+    EXPECT_EQ(height, 1080u);
+}
+
+TEST_F(OffscreenRenderContextTest, ResizeBeforeInit) {
+    EXPECT_NO_THROW(context->resize(1920, 1080));
+    // Size should remain 0 since not initialized
+    auto [width, height] = context->getSize();
+    EXPECT_EQ(width, 0u);
+    EXPECT_EQ(height, 0u);
+}
+
+// Test OpenGL support check
+TEST_F(OffscreenRenderContextTest, SupportsOpenGLBeforeInit) {
+    EXPECT_FALSE(context->supportsOpenGL());
+}
+
+TEST_F(OffscreenRenderContextTest, SupportsOpenGLAfterInit) {
+    context->initialize(64, 48);
+    // Result depends on environment; just verify no crash
+    (void)context->supportsOpenGL();
+}
+
+// Test capture
+TEST_F(OffscreenRenderContextTest, CaptureFrameReturnsCorrectSize) {
+    context->initialize(64, 48);
+    if (!context->supportsOpenGL()) {
+        GTEST_SKIP() << "OpenGL not available in this environment";
+    }
+    auto frame = context->captureFrame();
+    // 64 * 48 * 4 (RGBA) = 12288 bytes
+    EXPECT_EQ(frame.size(), 64u * 48u * 4u);
+}
+
+TEST_F(OffscreenRenderContextTest, CaptureFrameBeforeInit) {
+    auto frame = context->captureFrame();
+    EXPECT_TRUE(frame.empty());
+}
+
+TEST_F(OffscreenRenderContextTest, CaptureFrameAfterResize) {
+    context->initialize(32, 32);
+    if (!context->supportsOpenGL()) {
+        GTEST_SKIP() << "OpenGL not available in this environment";
+    }
+    context->resize(64, 64);
+    auto frame = context->captureFrame();
+    EXPECT_EQ(frame.size(), 64u * 64u * 4u);
+}
+
+// Test move semantics
+TEST_F(OffscreenRenderContextTest, MoveConstructor) {
+    context->initialize(800, 600);
+    OffscreenRenderContext moved(std::move(*context));
+    EXPECT_TRUE(moved.isInitialized());
+    auto [width, height] = moved.getSize();
+    EXPECT_EQ(width, 800u);
+    EXPECT_EQ(height, 600u);
+}
+
+TEST_F(OffscreenRenderContextTest, MoveAssignment) {
+    context->initialize(800, 600);
+    OffscreenRenderContext other;
+    other = std::move(*context);
+    EXPECT_TRUE(other.isInitialized());
+    auto [width, height] = other.getSize();
+    EXPECT_EQ(width, 800u);
+    EXPECT_EQ(height, 600u);
+}

--- a/tests/unit/render_session_test.cpp
+++ b/tests/unit/render_session_test.cpp
@@ -1,0 +1,177 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include "services/render/render_session.hpp"
+#include "services/volume_renderer.hpp"
+#include "services/mpr_renderer.hpp"
+
+#include <vtkImageData.h>
+#include <vtkSmartPointer.h>
+
+#include <future>
+#include <vector>
+
+using namespace dicom_viewer::services;
+
+class RenderSessionTest : public ::testing::Test {
+protected:
+    vtkSmartPointer<vtkImageData> createTestVolume(int dims = 32) {
+        auto imageData = vtkSmartPointer<vtkImageData>::New();
+        imageData->SetDimensions(dims, dims, dims);
+        imageData->SetSpacing(1.0, 1.0, 1.0);
+        imageData->SetOrigin(0.0, 0.0, 0.0);
+        imageData->AllocateScalars(VTK_SHORT, 1);
+
+        short* ptr = static_cast<short*>(imageData->GetScalarPointer());
+        for (int i = 0; i < dims * dims * dims; ++i) {
+            ptr[i] = static_cast<short>(i % 1000 - 500);
+        }
+
+        return imageData;
+    }
+};
+
+// Test construction
+TEST_F(RenderSessionTest, Construction) {
+    EXPECT_NO_THROW(RenderSession session(256, 256));
+}
+
+TEST_F(RenderSessionTest, RenderersInitialized) {
+    RenderSession session(256, 256);
+    EXPECT_TRUE(session.volumeRenderer().isOffscreenMode());
+    EXPECT_TRUE(session.mprRenderer().isOffscreenMode());
+}
+
+// Test move semantics
+TEST_F(RenderSessionTest, MoveConstructor) {
+    RenderSession session(256, 256);
+    RenderSession moved(std::move(session));
+    EXPECT_TRUE(moved.volumeRenderer().isOffscreenMode());
+}
+
+TEST_F(RenderSessionTest, MoveAssignment) {
+    RenderSession session(256, 256);
+    RenderSession other(128, 128);
+    other = std::move(session);
+    EXPECT_TRUE(other.volumeRenderer().isOffscreenMode());
+}
+
+// Test input data propagation
+TEST_F(RenderSessionTest, SetInputDataPropagates) {
+    RenderSession session(64, 48);
+    auto volume = createTestVolume();
+
+    EXPECT_NO_THROW(session.setInputData(volume));
+}
+
+// Test frame capture (may be empty on headless systems without OpenGL)
+TEST_F(RenderSessionTest, CaptureVolumeFrame) {
+    RenderSession session(64, 48);
+    auto volume = createTestVolume();
+    session.setInputData(volume);
+
+    auto frame = session.captureVolumeFrame();
+    if (!frame.empty()) {
+        EXPECT_EQ(frame.size(), 64u * 48u * 4u);
+    }
+}
+
+TEST_F(RenderSessionTest, CaptureMPRFrameAxial) {
+    RenderSession session(64, 48);
+    auto volume = createTestVolume();
+    session.setInputData(volume);
+
+    auto frame = session.captureMPRFrame(MPRPlane::Axial);
+    if (!frame.empty()) {
+        EXPECT_EQ(frame.size(), 64u * 48u * 4u);
+    }
+}
+
+TEST_F(RenderSessionTest, CaptureMPRFrameAllPlanes) {
+    RenderSession session(64, 48);
+    auto volume = createTestVolume();
+    session.setInputData(volume);
+
+    for (auto plane : {MPRPlane::Axial, MPRPlane::Coronal, MPRPlane::Sagittal}) {
+        auto frame = session.captureMPRFrame(plane);
+        if (!frame.empty()) {
+            EXPECT_EQ(frame.size(), 64u * 48u * 4u);
+        }
+    }
+}
+
+// Test resize
+TEST_F(RenderSessionTest, Resize) {
+    RenderSession session(64, 48);
+    session.resize(128, 96);
+
+    auto frame = session.captureVolumeFrame();
+    if (!frame.empty()) {
+        EXPECT_EQ(frame.size(), 128u * 96u * 4u);
+    }
+}
+
+// Test concurrent access safety
+// VTK's Cocoa backend is not thread-safe for OpenGL context creation,
+// so this test verifies the mutex protects against concurrent access
+// without crashing. On headless systems, captures may throw or return empty.
+TEST_F(RenderSessionTest, ConcurrentFrameCapture) {
+    RenderSession session(32, 32);
+    auto volume = createTestVolume();
+    session.setInputData(volume);
+
+    // Launch multiple captures concurrently
+    auto future1 = std::async(std::launch::async, [&]() -> std::vector<uint8_t> {
+        try {
+            return session.captureVolumeFrame();
+        } catch (...) {
+            return {};
+        }
+    });
+    auto future2 = std::async(std::launch::async, [&]() -> std::vector<uint8_t> {
+        try {
+            return session.captureMPRFrame(MPRPlane::Axial);
+        } catch (...) {
+            return {};
+        }
+    });
+
+    auto frame1 = future1.get();
+    auto frame2 = future2.get();
+
+    // Frames may be empty on headless systems without OpenGL
+    if (!frame1.empty()) {
+        EXPECT_EQ(frame1.size(), 32u * 32u * 4u);
+    }
+    if (!frame2.empty()) {
+        EXPECT_EQ(frame2.size(), 32u * 32u * 4u);
+    }
+}

--- a/tests/unit/surface_renderer_test.cpp
+++ b/tests/unit/surface_renderer_test.cpp
@@ -30,6 +30,7 @@
 #include <gtest/gtest.h>
 
 #include "services/surface_renderer.hpp"
+#include "services/render/offscreen_render_context.hpp"
 
 #include <vtkFloatArray.h>
 #include <vtkImageData.h>
@@ -815,4 +816,50 @@ TEST_F(SurfaceRendererTest, MultipleScalarArraysOnSameSurface) {
     auto actor = renderer->getActor(idx);
     ASSERT_NE(actor, nullptr);
     EXPECT_NE(actor->GetMapper(), nullptr);
+}
+
+// =============================================================================
+// Off-Screen Rendering (Issue #469)
+// =============================================================================
+
+TEST_F(SurfaceRendererTest, OffscreenModeDefaultOff) {
+    EXPECT_FALSE(renderer->isOffscreenMode());
+}
+
+TEST_F(SurfaceRendererTest, EnableOffscreenMode) {
+    EXPECT_NO_THROW(renderer->enableOffscreenMode(256, 256));
+    EXPECT_TRUE(renderer->isOffscreenMode());
+}
+
+TEST_F(SurfaceRendererTest, CaptureFrameWithSurface) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+    renderer->addPresetSurface(TissueType::Bone);
+    renderer->extractSurfaces();
+    renderer->enableOffscreenMode(64, 48);
+
+    auto frame = renderer->captureFrame();
+    // On headless (no OpenGL), frame may be empty
+    if (!frame.empty()) {
+        EXPECT_EQ(frame.size(), 64u * 48u * 4u);
+    }
+}
+
+TEST_F(SurfaceRendererTest, CaptureFrameNotInOffscreenMode) {
+    auto frame = renderer->captureFrame();
+    EXPECT_TRUE(frame.empty());
+}
+
+TEST_F(SurfaceRendererTest, ResizeOffscreen) {
+    renderer->enableOffscreenMode(64, 48);
+    renderer->resizeOffscreen(128, 96);
+
+    auto frame = renderer->captureFrame();
+    if (!frame.empty()) {
+        EXPECT_EQ(frame.size(), 128u * 96u * 4u);
+    }
+}
+
+TEST_F(SurfaceRendererTest, ResizeOffscreenNotInMode) {
+    EXPECT_NO_THROW(renderer->resizeOffscreen(128, 96));
 }

--- a/tests/unit/volume_renderer_test.cpp
+++ b/tests/unit/volume_renderer_test.cpp
@@ -30,6 +30,7 @@
 #include <gtest/gtest.h>
 
 #include "services/volume_renderer.hpp"
+#include "services/render/offscreen_render_context.hpp"
 
 #include <vtkImageData.h>
 #include <vtkSmartPointer.h>
@@ -298,4 +299,57 @@ TEST_F(VolumeRendererTest, NullTransferFunctionHandled) {
     };
     EXPECT_NO_THROW(renderer->applyPreset(singlePoint));
     EXPECT_NO_THROW(renderer->update());
+}
+
+// =============================================================================
+// Off-Screen Rendering (Issue #469)
+// =============================================================================
+
+TEST_F(VolumeRendererTest, OffscreenModeDefaultOff) {
+    EXPECT_FALSE(renderer->isOffscreenMode());
+}
+
+TEST_F(VolumeRendererTest, EnableOffscreenMode) {
+    EXPECT_NO_THROW(renderer->enableOffscreenMode(256, 256));
+    EXPECT_TRUE(renderer->isOffscreenMode());
+}
+
+TEST_F(VolumeRendererTest, CaptureFrameWithoutData) {
+    renderer->enableOffscreenMode(64, 48);
+    auto frame = renderer->captureFrame();
+    // On headless (no OpenGL), frame may be empty
+    if (!frame.empty()) {
+        EXPECT_EQ(frame.size(), 64u * 48u * 4u);
+    }
+}
+
+TEST_F(VolumeRendererTest, CaptureFrameWithData) {
+    auto volume = createTestVolume();
+    renderer->setInputData(volume);
+    renderer->applyPreset(VolumeRenderer::getPresetCTBone());
+    renderer->enableOffscreenMode(64, 48);
+
+    auto frame = renderer->captureFrame();
+    if (!frame.empty()) {
+        EXPECT_EQ(frame.size(), 64u * 48u * 4u);
+    }
+}
+
+TEST_F(VolumeRendererTest, CaptureFrameNotInOffscreenMode) {
+    auto frame = renderer->captureFrame();
+    EXPECT_TRUE(frame.empty());
+}
+
+TEST_F(VolumeRendererTest, ResizeOffscreen) {
+    renderer->enableOffscreenMode(64, 48);
+    renderer->resizeOffscreen(128, 96);
+
+    auto frame = renderer->captureFrame();
+    if (!frame.empty()) {
+        EXPECT_EQ(frame.size(), 128u * 96u * 4u);
+    }
+}
+
+TEST_F(VolumeRendererTest, ResizeOffscreenNotInMode) {
+    EXPECT_NO_THROW(renderer->resizeOffscreen(128, 96));
 }


### PR DESCRIPTION
## Summary

- Add `OffscreenRenderContext` utility class encapsulating headless VTK render window creation and RGBA frame capture, shared across all three renderers
- Integrate off-screen mode into `VolumeRenderer`, `MPRRenderer`, and `SurfaceRenderer` with `enableOffscreenMode()`, `captureFrame()`, and `resizeOffscreen()` APIs
- Create `RenderSession` aggregate class with thread-safe (mutex-guarded) frame capture coordinating volume and MPR renderers in a single off-screen session

## Motivation

Foundation for the Remote Rendering Architecture (Epic #468). Enables the rendering pipeline to execute on servers without a display, producing RGBA frame buffers that can be streamed to clients.

Closes #469

## Architecture

```
RenderSession (thread-safe aggregate)
├── VolumeRenderer  ──► OffscreenRenderContext (owns vtkRenderWindow)
└── MPRRenderer     ──► OffscreenRenderContext x3 (one per plane: Axial/Coronal/Sagittal)
```

`OffscreenRenderContext` wraps:
- `vtkRenderWindow` with `SetOffScreenRendering(1)` — VTK 9.x auto-selects Metal (macOS) / EGL / OSMesa (Linux)
- `vtkWindowToImageFilter` with RGBA buffer type for frame capture
- `SupportsOpenGL()` safety check preventing segfaults on headless systems without GPU

## Files Changed

| Area | Files | Changes |
|------|-------|---------|
| New utility | `offscreen_render_context.{hpp,cpp}` | Shared headless render context |
| New aggregate | `render_session.{hpp,cpp}` | Thread-safe session coordinator |
| Renderer integration | `volume_renderer.{hpp,cpp}` | +4 off-screen methods |
| Renderer integration | `mpr_renderer.{hpp,cpp}` | +4 off-screen methods (per-plane capture) |
| Renderer integration | `surface_renderer.{hpp,cpp}` | +4 off-screen methods |
| Build | `CMakeLists.txt`, `tests/CMakeLists.txt` | Register new sources and test targets |
| Tests | 5 test files (3 modified, 2 new) | 37 new test cases |

## Test plan

- [x] `offscreen_render_context_test` — 18 tests (init, resize, capture, move semantics, OpenGL check)
- [x] `render_session_test` — 10 tests (construction, data propagation, concurrent capture, resize)
- [x] `volume_renderer_test` — 7 new off-screen tests added
- [x] `mpr_renderer_test` — 6 new off-screen tests added
- [x] `surface_renderer_test` — 6 new off-screen tests added
- [x] All 201 tests pass (2 skipped on headless environments without OpenGL)
- [x] Existing tests unaffected — no behavioral changes to on-screen rendering paths