### PR TITLE
feat(rendering): implement input event dispatcher for VTK interactor injection (#472)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -538,6 +538,7 @@ add_library(render_service STATIC
     src/services/render/render_session.cpp
     src/services/render/frame_encoder.cpp
     src/services/render/websocket_frame_streamer.cpp
+    src/services/render/input_event_dispatcher.cpp
 )
 
 # Crow WebSocket framework (header-only)

--- a/include/services/render/input_event_dispatcher.hpp
+++ b/include/services/render/input_event_dispatcher.hpp
@@ -1,0 +1,168 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file input_event_dispatcher.hpp
+ * @brief Dispatches serialized input events into VTK render window interactors
+ * @details Receives InputEvent structs (from WebSocket JSON) and injects them
+ *          as synthetic VTK interaction events into a vtkRenderWindowInteractor.
+ *          Handles coordinate remapping between client canvas and server render
+ *          window, and provides burst protection via a bounded event queue.
+ *
+ * ## Coordinate System
+ * - Client: origin at top-left, coordinates in client canvas pixels
+ * - VTK: origin at bottom-left, coordinates in render window pixels
+ * - Remapping: normalize to [0,1] then scale to server size, flip Y
+ *
+ * ## Event Mapping
+ * | InputEvent.type | VTK Event(s)                              |
+ * |-----------------|-------------------------------------------|
+ * | mouse_move      | MouseMoveEvent                            |
+ * | mouse_down      | Left/Right/MiddleButtonPressEvent          |
+ * | mouse_up        | Left/Right/MiddleButtonReleaseEvent        |
+ * | scroll          | MouseWheelForward/BackwardEvent            |
+ * | key_down        | KeyPressEvent + CharEvent                 |
+ * | key_up          | KeyReleaseEvent                           |
+ *
+ * ## Thread Safety
+ * - enqueue() is thread-safe (internal mutex)
+ * - processAll() and dispatch() must be called from a single thread
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+class vtkRenderWindowInteractor;
+
+namespace dicom_viewer::services {
+
+struct InputEvent;
+
+/**
+ * @brief Dispatches input events into VTK interactors for remote rendering
+ *
+ * Translates client input events into VTK interaction events with coordinate
+ * remapping and burst protection.
+ *
+ * @trace SRS-FR-REMOTE-004
+ */
+class InputEventDispatcher {
+public:
+    /**
+     * @brief Construct a dispatcher with configurable queue depth
+     * @param maxQueueDepth Maximum events in the burst queue (0 = unlimited)
+     */
+    explicit InputEventDispatcher(uint32_t maxQueueDepth = 64);
+    ~InputEventDispatcher();
+
+    // Non-copyable, movable
+    InputEventDispatcher(const InputEventDispatcher&) = delete;
+    InputEventDispatcher& operator=(const InputEventDispatcher&) = delete;
+    InputEventDispatcher(InputEventDispatcher&&) noexcept;
+    InputEventDispatcher& operator=(InputEventDispatcher&&) noexcept;
+
+    /**
+     * @brief Dispatch a single event immediately to the interactor
+     * @param interactor Target VTK interactor (must not be null)
+     * @param event Input event to dispatch
+     * @param clientWidth Client canvas width in pixels
+     * @param clientHeight Client canvas height in pixels
+     * @return true if dispatched, false if event type is unknown or interactor is null
+     */
+    bool dispatch(vtkRenderWindowInteractor* interactor,
+                  const InputEvent& event,
+                  uint32_t clientWidth, uint32_t clientHeight);
+
+    /**
+     * @brief Enqueue an event for batch processing (thread-safe)
+     *
+     * If the queue exceeds maxQueueDepth, the oldest event is dropped.
+     *
+     * @param event Input event to enqueue
+     */
+    void enqueue(const InputEvent& event);
+
+    /**
+     * @brief Process all queued events on the interactor
+     * @param interactor Target VTK interactor
+     * @param clientWidth Client canvas width in pixels
+     * @param clientHeight Client canvas height in pixels
+     * @return Number of events processed
+     */
+    size_t processAll(vtkRenderWindowInteractor* interactor,
+                      uint32_t clientWidth, uint32_t clientHeight);
+
+    /**
+     * @brief Remap coordinates from client canvas to server render window
+     * @param clientX X coordinate in client canvas
+     * @param clientY Y coordinate in client canvas (top-left origin)
+     * @param clientWidth Client canvas width
+     * @param clientHeight Client canvas height
+     * @param serverWidth Server render window width
+     * @param serverHeight Server render window height
+     * @return {x, y} in server render window coordinates (bottom-left origin)
+     */
+    [[nodiscard]] static std::pair<int, int> remapCoordinates(
+        double clientX, double clientY,
+        uint32_t clientWidth, uint32_t clientHeight,
+        uint32_t serverWidth, uint32_t serverHeight);
+
+    /**
+     * @brief Get the number of events currently in the queue
+     */
+    [[nodiscard]] size_t queueSize() const;
+
+    /**
+     * @brief Get the total number of successfully dispatched events
+     */
+    [[nodiscard]] size_t dispatchedCount() const;
+
+    /**
+     * @brief Get the total number of events dropped due to queue overflow
+     */
+    [[nodiscard]] size_t droppedCount() const;
+
+    /**
+     * @brief Set the maximum queue depth
+     * @param depth New maximum depth (0 = unlimited)
+     */
+    void setMaxQueueDepth(uint32_t depth);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::services

--- a/include/services/render/websocket_frame_streamer.hpp
+++ b/include/services/render/websocket_frame_streamer.hpp
@@ -98,12 +98,17 @@ struct WebSocketStreamConfig {
  */
 struct InputEvent {
     std::string sessionId;
-    std::string type;       ///< "mouse_move", "mouse_down", "mouse_up", "key_down", etc.
+    std::string type;       ///< "mouse_move", "mouse_down", "mouse_up", "key_down", "key_up", "scroll"
     double x = 0;
     double y = 0;
-    int buttons = 0;        ///< Mouse button bitmask
+    int buttons = 0;        ///< Mouse button bitmask (1=left, 2=right, 4=middle)
     int keyCode = 0;
     uint64_t timestamp = 0;
+    double delta = 0;       ///< Scroll wheel delta (positive=forward, negative=backward)
+    bool shiftKey = false;
+    bool ctrlKey = false;
+    bool altKey = false;
+    std::string keySym;     ///< Key symbol string (e.g., "ArrowUp", "Escape")
 };
 
 /**

--- a/src/services/render/input_event_dispatcher.cpp
+++ b/src/services/render/input_event_dispatcher.cpp
@@ -1,0 +1,353 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "services/render/input_event_dispatcher.hpp"
+#include "services/render/websocket_frame_streamer.hpp"
+
+#include <vtkCommand.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
+
+#include <algorithm>
+#include <cmath>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace dicom_viewer::services {
+
+// ---------------------------------------------------------------------------
+// Key symbol mapping: web key names -> VTK key symbols
+// ---------------------------------------------------------------------------
+static const char* mapKeySym(const std::string& webKey)
+{
+    static const std::unordered_map<std::string, const char*> keyMap = {
+        {"ArrowUp", "Up"},
+        {"ArrowDown", "Down"},
+        {"ArrowLeft", "Left"},
+        {"ArrowRight", "Right"},
+        {"Escape", "Escape"},
+        {"Enter", "Return"},
+        {"Backspace", "BackSpace"},
+        {"Tab", "Tab"},
+        {"Delete", "Delete"},
+        {"Home", "Home"},
+        {"End", "End"},
+        {"PageUp", "Prior"},
+        {"PageDown", "Next"},
+        {"Space", "space"},
+        {" ", "space"},
+        {"Shift", "Shift_L"},
+        {"Control", "Control_L"},
+        {"Alt", "Alt_L"},
+    };
+    auto it = keyMap.find(webKey);
+    if (it != keyMap.end()) {
+        return it->second;
+    }
+    // Single character keys: return as-is (VTK uses the character)
+    return nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// Impl
+// ---------------------------------------------------------------------------
+class InputEventDispatcher::Impl {
+public:
+    explicit Impl(uint32_t maxDepth) : maxQueueDepth(maxDepth) {}
+
+    bool dispatchSingle(vtkRenderWindowInteractor* interactor,
+                        const InputEvent& event,
+                        uint32_t clientWidth, uint32_t clientHeight)
+    {
+        if (!interactor) {
+            return false;
+        }
+
+        auto* renderWindow = interactor->GetRenderWindow();
+        if (!renderWindow) {
+            return false;
+        }
+
+        const int* windowSize = renderWindow->GetSize();
+        auto serverWidth = static_cast<uint32_t>(windowSize[0]);
+        auto serverHeight = static_cast<uint32_t>(windowSize[1]);
+
+        auto [sx, sy] = InputEventDispatcher::remapCoordinates(
+            event.x, event.y,
+            clientWidth, clientHeight,
+            serverWidth, serverHeight);
+
+        int ctrl = event.ctrlKey ? 1 : 0;
+        int shift = event.shiftKey ? 1 : 0;
+
+        if (event.type == "mouse_move") {
+            interactor->SetEventInformation(sx, sy, ctrl, shift);
+            interactor->InvokeEvent(vtkCommand::MouseMoveEvent);
+        } else if (event.type == "mouse_down") {
+            interactor->SetEventInformation(sx, sy, ctrl, shift);
+            dispatchButtonPress(interactor, event.buttons);
+        } else if (event.type == "mouse_up") {
+            interactor->SetEventInformation(sx, sy, ctrl, shift);
+            dispatchButtonRelease(interactor, event.buttons);
+        } else if (event.type == "scroll") {
+            interactor->SetEventInformation(sx, sy, ctrl, shift);
+            if (event.delta > 0) {
+                interactor->InvokeEvent(vtkCommand::MouseWheelForwardEvent);
+            } else if (event.delta < 0) {
+                interactor->InvokeEvent(vtkCommand::MouseWheelBackwardEvent);
+            }
+        } else if (event.type == "key_down") {
+            dispatchKeyPress(interactor, event, ctrl, shift);
+        } else if (event.type == "key_up") {
+            dispatchKeyRelease(interactor, event, ctrl, shift);
+        } else {
+            return false; // Unknown event type
+        }
+
+        ++dispatched;
+        return true;
+    }
+
+    // Thread-safe queue operations
+    void enqueueEvent(const InputEvent& event)
+    {
+        std::lock_guard<std::mutex> lock(queueMutex);
+        if (maxQueueDepth > 0 && queue.size() >= maxQueueDepth) {
+            queue.pop_front();
+            ++dropped;
+        }
+        queue.push_back(event);
+    }
+
+    std::deque<InputEvent> drainQueue()
+    {
+        std::lock_guard<std::mutex> lock(queueMutex);
+        std::deque<InputEvent> result;
+        result.swap(queue);
+        return result;
+    }
+
+    size_t currentQueueSize() const
+    {
+        std::lock_guard<std::mutex> lock(queueMutex);
+        return queue.size();
+    }
+
+    uint32_t maxQueueDepth;
+    size_t dispatched = 0;
+    size_t dropped = 0;
+
+private:
+    static void dispatchButtonPress(vtkRenderWindowInteractor* interactor, int buttons)
+    {
+        if (buttons & 1) {
+            interactor->InvokeEvent(vtkCommand::LeftButtonPressEvent);
+        }
+        if (buttons & 2) {
+            interactor->InvokeEvent(vtkCommand::RightButtonPressEvent);
+        }
+        if (buttons & 4) {
+            interactor->InvokeEvent(vtkCommand::MiddleButtonPressEvent);
+        }
+        // Default to left if no button specified
+        if (buttons == 0) {
+            interactor->InvokeEvent(vtkCommand::LeftButtonPressEvent);
+        }
+    }
+
+    static void dispatchButtonRelease(vtkRenderWindowInteractor* interactor, int buttons)
+    {
+        if (buttons & 1) {
+            interactor->InvokeEvent(vtkCommand::LeftButtonReleaseEvent);
+        }
+        if (buttons & 2) {
+            interactor->InvokeEvent(vtkCommand::RightButtonReleaseEvent);
+        }
+        if (buttons & 4) {
+            interactor->InvokeEvent(vtkCommand::MiddleButtonReleaseEvent);
+        }
+        if (buttons == 0) {
+            interactor->InvokeEvent(vtkCommand::LeftButtonReleaseEvent);
+        }
+    }
+
+    static void dispatchKeyPress(vtkRenderWindowInteractor* interactor,
+                                 const InputEvent& event,
+                                 int ctrl, int shift)
+    {
+        const char* vtkKeySym = mapKeySym(event.keySym);
+        char keyChar = 0;
+        if (event.keyCode > 0 && event.keyCode < 128) {
+            keyChar = static_cast<char>(event.keyCode);
+        } else if (event.keySym.size() == 1) {
+            keyChar = event.keySym[0];
+        }
+
+        if (vtkKeySym) {
+            interactor->SetKeyEventInformation(ctrl, shift, keyChar, 0, vtkKeySym);
+        } else if (keyChar != 0) {
+            // Single printable character
+            char keySym[2] = {keyChar, '\0'};
+            interactor->SetKeyEventInformation(ctrl, shift, keyChar, 0, keySym);
+        } else {
+            interactor->SetKeyEventInformation(ctrl, shift, 0, 0, nullptr);
+        }
+        interactor->InvokeEvent(vtkCommand::KeyPressEvent);
+        if (keyChar != 0) {
+            interactor->InvokeEvent(vtkCommand::CharEvent);
+        }
+    }
+
+    static void dispatchKeyRelease(vtkRenderWindowInteractor* interactor,
+                                   const InputEvent& event,
+                                   int ctrl, int shift)
+    {
+        const char* vtkKeySym = mapKeySym(event.keySym);
+        char keyChar = 0;
+        if (event.keyCode > 0 && event.keyCode < 128) {
+            keyChar = static_cast<char>(event.keyCode);
+        } else if (event.keySym.size() == 1) {
+            keyChar = event.keySym[0];
+        }
+
+        if (vtkKeySym) {
+            interactor->SetKeyEventInformation(ctrl, shift, keyChar, 0, vtkKeySym);
+        } else if (keyChar != 0) {
+            char keySym[2] = {keyChar, '\0'};
+            interactor->SetKeyEventInformation(ctrl, shift, keyChar, 0, keySym);
+        } else {
+            interactor->SetKeyEventInformation(ctrl, shift, 0, 0, nullptr);
+        }
+        interactor->InvokeEvent(vtkCommand::KeyReleaseEvent);
+    }
+
+    mutable std::mutex queueMutex;
+    std::deque<InputEvent> queue;
+};
+
+// ---------------------------------------------------------------------------
+// Coordinate remapping
+// ---------------------------------------------------------------------------
+std::pair<int, int> InputEventDispatcher::remapCoordinates(
+    double clientX, double clientY,
+    uint32_t clientWidth, uint32_t clientHeight,
+    uint32_t serverWidth, uint32_t serverHeight)
+{
+    if (clientWidth == 0 || clientHeight == 0) {
+        return {0, 0};
+    }
+
+    // Normalize to [0, 1]
+    double normX = clientX / static_cast<double>(clientWidth);
+    double normY = clientY / static_cast<double>(clientHeight);
+
+    // Clamp to valid range
+    normX = std::clamp(normX, 0.0, 1.0);
+    normY = std::clamp(normY, 0.0, 1.0);
+
+    // Scale to server coordinates
+    int sx = static_cast<int>(std::round(normX * (serverWidth - 1)));
+
+    // Flip Y: client top-left origin -> VTK bottom-left origin
+    int sy = static_cast<int>(std::round((1.0 - normY) * (serverHeight - 1)));
+
+    return {sx, sy};
+}
+
+// ---------------------------------------------------------------------------
+// InputEventDispatcher lifecycle
+// ---------------------------------------------------------------------------
+InputEventDispatcher::InputEventDispatcher(uint32_t maxQueueDepth)
+    : impl_(std::make_unique<Impl>(maxQueueDepth))
+{
+}
+
+InputEventDispatcher::~InputEventDispatcher() = default;
+
+InputEventDispatcher::InputEventDispatcher(InputEventDispatcher&&) noexcept = default;
+InputEventDispatcher& InputEventDispatcher::operator=(InputEventDispatcher&&) noexcept = default;
+
+bool InputEventDispatcher::dispatch(
+    vtkRenderWindowInteractor* interactor,
+    const InputEvent& event,
+    uint32_t clientWidth, uint32_t clientHeight)
+{
+    if (!impl_) return false;
+    return impl_->dispatchSingle(interactor, event, clientWidth, clientHeight);
+}
+
+void InputEventDispatcher::enqueue(const InputEvent& event)
+{
+    if (!impl_) return;
+    impl_->enqueueEvent(event);
+}
+
+size_t InputEventDispatcher::processAll(
+    vtkRenderWindowInteractor* interactor,
+    uint32_t clientWidth, uint32_t clientHeight)
+{
+    if (!impl_) return 0;
+
+    auto events = impl_->drainQueue();
+    size_t processed = 0;
+    for (const auto& event : events) {
+        if (impl_->dispatchSingle(interactor, event, clientWidth, clientHeight)) {
+            ++processed;
+        }
+    }
+    return processed;
+}
+
+size_t InputEventDispatcher::queueSize() const
+{
+    if (!impl_) return 0;
+    return impl_->currentQueueSize();
+}
+
+size_t InputEventDispatcher::dispatchedCount() const
+{
+    if (!impl_) return 0;
+    return impl_->dispatched;
+}
+
+size_t InputEventDispatcher::droppedCount() const
+{
+    if (!impl_) return 0;
+    return impl_->dropped;
+}
+
+void InputEventDispatcher::setMaxQueueDepth(uint32_t depth)
+{
+    if (!impl_) return;
+    impl_->maxQueueDepth = depth;
+}
+
+} // namespace dicom_viewer::services

--- a/src/services/render/websocket_frame_streamer.cpp
+++ b/src/services/render/websocket_frame_streamer.cpp
@@ -224,6 +224,11 @@ private:
             event.buttons = json.value("buttons", 0);
             event.keyCode = json.value("key_code", 0);
             event.timestamp = json.value("ts", uint64_t{0});
+            event.delta = json.value("delta", 0.0);
+            event.shiftKey = json.value("shift", false);
+            event.ctrlKey = json.value("ctrl", false);
+            event.altKey = json.value("alt", false);
+            event.keySym = json.value("key", std::string{});
 
             cb(event);
         } catch (const nlohmann::json::exception&) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2103,3 +2103,21 @@ target_include_directories(websocket_frame_streamer_test PRIVATE
 )
 
 gtest_discover_tests(websocket_frame_streamer_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for InputEventDispatcher
+add_executable(input_event_dispatcher_test
+    unit/input_event_dispatcher_test.cpp
+)
+
+target_link_libraries(input_event_dispatcher_test PRIVATE
+    render_service
+    GTest::gtest
+    GTest::gtest_main
+    ${VTK_LIBRARIES}
+)
+
+target_include_directories(input_event_dispatcher_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(input_event_dispatcher_test DISCOVERY_TIMEOUT 60)

--- a/tests/unit/input_event_dispatcher_test.cpp
+++ b/tests/unit/input_event_dispatcher_test.cpp
@@ -1,0 +1,419 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include "services/render/input_event_dispatcher.hpp"
+#include "services/render/websocket_frame_streamer.hpp"
+
+#include <vtkCallbackCommand.h>
+#include <vtkCommand.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
+#include <vtkSmartPointer.h>
+
+#include <thread>
+#include <vector>
+
+using namespace dicom_viewer::services;
+
+// =============================================================================
+// Test fixture with off-screen VTK interactor
+// =============================================================================
+
+class InputEventDispatcherTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        renderWindow = vtkSmartPointer<vtkRenderWindow>::New();
+        renderWindow->SetOffScreenRendering(1);
+        renderWindow->SetSize(640, 480);
+
+        interactor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+        interactor->SetRenderWindow(renderWindow);
+        // Do not call Initialize() to avoid display requirements
+    }
+
+    InputEventDispatcher dispatcher;
+    vtkSmartPointer<vtkRenderWindow> renderWindow;
+    vtkSmartPointer<vtkRenderWindowInteractor> interactor;
+
+    static InputEvent makeMouseEvent(const std::string& type,
+                                     double x, double y,
+                                     int buttons = 0)
+    {
+        InputEvent event;
+        event.type = type;
+        event.x = x;
+        event.y = y;
+        event.buttons = buttons;
+        return event;
+    }
+
+    static InputEvent makeScrollEvent(double x, double y, double delta)
+    {
+        InputEvent event;
+        event.type = "scroll";
+        event.x = x;
+        event.y = y;
+        event.delta = delta;
+        return event;
+    }
+
+    static InputEvent makeKeyEvent(const std::string& type,
+                                   const std::string& keySym,
+                                   int keyCode = 0)
+    {
+        InputEvent event;
+        event.type = type;
+        event.x = 320;
+        event.y = 240;
+        event.keySym = keySym;
+        event.keyCode = keyCode;
+        return event;
+    }
+};
+
+// =============================================================================
+// Construction and lifecycle
+// =============================================================================
+
+TEST_F(InputEventDispatcherTest, DefaultConstruction) {
+    EXPECT_EQ(dispatcher.dispatchedCount(), 0u);
+    EXPECT_EQ(dispatcher.droppedCount(), 0u);
+    EXPECT_EQ(dispatcher.queueSize(), 0u);
+}
+
+TEST_F(InputEventDispatcherTest, MoveConstructor) {
+    InputEventDispatcher moved(std::move(dispatcher));
+    EXPECT_EQ(moved.dispatchedCount(), 0u);
+}
+
+TEST_F(InputEventDispatcherTest, MoveAssignment) {
+    InputEventDispatcher other;
+    other = std::move(dispatcher);
+    EXPECT_EQ(other.dispatchedCount(), 0u);
+}
+
+// =============================================================================
+// Coordinate remapping
+// =============================================================================
+
+TEST_F(InputEventDispatcherTest, RemapCoordinatesSameSize) {
+    // 1:1 mapping, top-left (0,0) -> bottom-left (0, height-1)
+    auto [x, y] = InputEventDispatcher::remapCoordinates(
+        0, 0, 640, 480, 640, 480);
+    EXPECT_EQ(x, 0);
+    EXPECT_EQ(y, 479);
+}
+
+TEST_F(InputEventDispatcherTest, RemapCoordinatesBottomRight) {
+    // Bottom-right in client -> top-right in VTK is (width-1, 0)
+    auto [x, y] = InputEventDispatcher::remapCoordinates(
+        640, 480, 640, 480, 640, 480);
+    EXPECT_EQ(x, 639);
+    EXPECT_EQ(y, 0);
+}
+
+TEST_F(InputEventDispatcherTest, RemapCoordinatesCenter) {
+    auto [x, y] = InputEventDispatcher::remapCoordinates(
+        320, 240, 640, 480, 640, 480);
+    EXPECT_EQ(x, 320);
+    EXPECT_EQ(y, 240);
+}
+
+TEST_F(InputEventDispatcherTest, RemapCoordinatesScale2x) {
+    // Client 800x600 -> Server 400x300
+    auto [x, y] = InputEventDispatcher::remapCoordinates(
+        400, 300, 800, 600, 400, 300);
+    EXPECT_EQ(x, 200);
+    EXPECT_EQ(y, 150);
+}
+
+TEST_F(InputEventDispatcherTest, RemapCoordinatesZeroSize) {
+    auto [x, y] = InputEventDispatcher::remapCoordinates(
+        100, 100, 0, 0, 640, 480);
+    EXPECT_EQ(x, 0);
+    EXPECT_EQ(y, 0);
+}
+
+TEST_F(InputEventDispatcherTest, RemapCoordinatesClampNegative) {
+    auto [x, y] = InputEventDispatcher::remapCoordinates(
+        -10, -10, 640, 480, 640, 480);
+    EXPECT_EQ(x, 0);
+    EXPECT_EQ(y, 479);
+}
+
+TEST_F(InputEventDispatcherTest, RemapCoordinatesClampOverflow) {
+    auto [x, y] = InputEventDispatcher::remapCoordinates(
+        1000, 800, 640, 480, 640, 480);
+    EXPECT_EQ(x, 639);
+    EXPECT_EQ(y, 0);
+}
+
+// =============================================================================
+// Mouse event dispatch
+// =============================================================================
+
+TEST_F(InputEventDispatcherTest, DispatchMouseMove) {
+    auto event = makeMouseEvent("mouse_move", 320, 240);
+    EXPECT_TRUE(dispatcher.dispatch(interactor, event, 640, 480));
+    EXPECT_EQ(dispatcher.dispatchedCount(), 1u);
+}
+
+TEST_F(InputEventDispatcherTest, DispatchMouseDownLeft) {
+    auto event = makeMouseEvent("mouse_down", 100, 200, 1);
+    EXPECT_TRUE(dispatcher.dispatch(interactor, event, 640, 480));
+    EXPECT_EQ(dispatcher.dispatchedCount(), 1u);
+}
+
+TEST_F(InputEventDispatcherTest, DispatchMouseDownRight) {
+    auto event = makeMouseEvent("mouse_down", 100, 200, 2);
+    EXPECT_TRUE(dispatcher.dispatch(interactor, event, 640, 480));
+    EXPECT_EQ(dispatcher.dispatchedCount(), 1u);
+}
+
+TEST_F(InputEventDispatcherTest, DispatchMouseDownMiddle) {
+    auto event = makeMouseEvent("mouse_down", 100, 200, 4);
+    EXPECT_TRUE(dispatcher.dispatch(interactor, event, 640, 480));
+    EXPECT_EQ(dispatcher.dispatchedCount(), 1u);
+}
+
+TEST_F(InputEventDispatcherTest, DispatchMouseUp) {
+    auto event = makeMouseEvent("mouse_up", 100, 200, 1);
+    EXPECT_TRUE(dispatcher.dispatch(interactor, event, 640, 480));
+    EXPECT_EQ(dispatcher.dispatchedCount(), 1u);
+}
+
+TEST_F(InputEventDispatcherTest, DispatchMouseMoveWithModifiers) {
+    InputEvent event;
+    event.type = "mouse_move";
+    event.x = 320;
+    event.y = 240;
+    event.shiftKey = true;
+    event.ctrlKey = true;
+    EXPECT_TRUE(dispatcher.dispatch(interactor, event, 640, 480));
+    EXPECT_EQ(dispatcher.dispatchedCount(), 1u);
+}
+
+// =============================================================================
+// Scroll event dispatch
+// =============================================================================
+
+TEST_F(InputEventDispatcherTest, DispatchScrollForward) {
+    auto event = makeScrollEvent(320, 240, 3.0);
+    EXPECT_TRUE(dispatcher.dispatch(interactor, event, 640, 480));
+    EXPECT_EQ(dispatcher.dispatchedCount(), 1u);
+}
+
+TEST_F(InputEventDispatcherTest, DispatchScrollBackward) {
+    auto event = makeScrollEvent(320, 240, -3.0);
+    EXPECT_TRUE(dispatcher.dispatch(interactor, event, 640, 480));
+    EXPECT_EQ(dispatcher.dispatchedCount(), 1u);
+}
+
+// =============================================================================
+// Keyboard event dispatch
+// =============================================================================
+
+TEST_F(InputEventDispatcherTest, DispatchKeyDown) {
+    auto event = makeKeyEvent("key_down", "ArrowUp");
+    EXPECT_TRUE(dispatcher.dispatch(interactor, event, 640, 480));
+    EXPECT_EQ(dispatcher.dispatchedCount(), 1u);
+}
+
+TEST_F(InputEventDispatcherTest, DispatchKeyUp) {
+    auto event = makeKeyEvent("key_up", "Escape");
+    EXPECT_TRUE(dispatcher.dispatch(interactor, event, 640, 480));
+    EXPECT_EQ(dispatcher.dispatchedCount(), 1u);
+}
+
+TEST_F(InputEventDispatcherTest, DispatchPrintableKey) {
+    auto event = makeKeyEvent("key_down", "a", 'a');
+    EXPECT_TRUE(dispatcher.dispatch(interactor, event, 640, 480));
+    EXPECT_EQ(dispatcher.dispatchedCount(), 1u);
+}
+
+// =============================================================================
+// Invalid event handling
+// =============================================================================
+
+TEST_F(InputEventDispatcherTest, DispatchUnknownType) {
+    InputEvent event;
+    event.type = "unknown_event";
+    EXPECT_FALSE(dispatcher.dispatch(interactor, event, 640, 480));
+    EXPECT_EQ(dispatcher.dispatchedCount(), 0u);
+}
+
+TEST_F(InputEventDispatcherTest, DispatchNullInteractor) {
+    auto event = makeMouseEvent("mouse_move", 320, 240);
+    EXPECT_FALSE(dispatcher.dispatch(nullptr, event, 640, 480));
+    EXPECT_EQ(dispatcher.dispatchedCount(), 0u);
+}
+
+// =============================================================================
+// Event queue and burst protection
+// =============================================================================
+
+TEST_F(InputEventDispatcherTest, EnqueueAndProcess) {
+    dispatcher.enqueue(makeMouseEvent("mouse_move", 100, 100));
+    dispatcher.enqueue(makeMouseEvent("mouse_move", 200, 200));
+    dispatcher.enqueue(makeMouseEvent("mouse_move", 300, 300));
+
+    EXPECT_EQ(dispatcher.queueSize(), 3u);
+
+    size_t processed = dispatcher.processAll(interactor, 640, 480);
+    EXPECT_EQ(processed, 3u);
+    EXPECT_EQ(dispatcher.queueSize(), 0u);
+    EXPECT_EQ(dispatcher.dispatchedCount(), 3u);
+}
+
+TEST_F(InputEventDispatcherTest, QueueOverflowDropsOldest) {
+    InputEventDispatcher smallQueue(4);
+
+    for (int i = 0; i < 10; ++i) {
+        smallQueue.enqueue(makeMouseEvent("mouse_move",
+                                          static_cast<double>(i * 10),
+                                          static_cast<double>(i * 10)));
+    }
+
+    EXPECT_EQ(smallQueue.queueSize(), 4u);
+    EXPECT_EQ(smallQueue.droppedCount(), 6u);
+
+    size_t processed = smallQueue.processAll(interactor, 640, 480);
+    EXPECT_EQ(processed, 4u);
+}
+
+TEST_F(InputEventDispatcherTest, ProcessEmptyQueue) {
+    size_t processed = dispatcher.processAll(interactor, 640, 480);
+    EXPECT_EQ(processed, 0u);
+}
+
+TEST_F(InputEventDispatcherTest, SetMaxQueueDepth) {
+    dispatcher.setMaxQueueDepth(2);
+
+    dispatcher.enqueue(makeMouseEvent("mouse_move", 10, 10));
+    dispatcher.enqueue(makeMouseEvent("mouse_move", 20, 20));
+    dispatcher.enqueue(makeMouseEvent("mouse_move", 30, 30));
+
+    EXPECT_EQ(dispatcher.queueSize(), 2u);
+    EXPECT_EQ(dispatcher.droppedCount(), 1u);
+}
+
+// =============================================================================
+// Thread-safe enqueue
+// =============================================================================
+
+TEST_F(InputEventDispatcherTest, ConcurrentEnqueue) {
+    InputEventDispatcher largeQueue(1000);
+
+    auto enqueueN = [&](int start, int count) {
+        for (int i = start; i < start + count; ++i) {
+            largeQueue.enqueue(makeMouseEvent("mouse_move",
+                                              static_cast<double>(i),
+                                              static_cast<double>(i)));
+        }
+    };
+
+    std::thread t1(enqueueN, 0, 100);
+    std::thread t2(enqueueN, 100, 100);
+    std::thread t3(enqueueN, 200, 100);
+
+    t1.join();
+    t2.join();
+    t3.join();
+
+    EXPECT_EQ(largeQueue.queueSize(), 300u);
+    EXPECT_EQ(largeQueue.droppedCount(), 0u);
+}
+
+// =============================================================================
+// Event position verification
+// =============================================================================
+
+TEST_F(InputEventDispatcherTest, EventPositionSetCorrectly) {
+    // Dispatch mouse event at center of client canvas
+    auto event = makeMouseEvent("mouse_move", 320, 240);
+    dispatcher.dispatch(interactor, event, 640, 480);
+
+    int* pos = interactor->GetEventPosition();
+    // Center should map to (320, 240) in VTK coords for same-size windows
+    EXPECT_EQ(pos[0], 320);
+    EXPECT_EQ(pos[1], 240);
+}
+
+TEST_F(InputEventDispatcherTest, EventPositionTopLeftFlipsY) {
+    // Client top-left (0,0) -> VTK bottom-left (0, 479)
+    auto event = makeMouseEvent("mouse_move", 0, 0);
+    dispatcher.dispatch(interactor, event, 640, 480);
+
+    int* pos = interactor->GetEventPosition();
+    EXPECT_EQ(pos[0], 0);
+    EXPECT_EQ(pos[1], 479);
+}
+
+// =============================================================================
+// Full interaction sequence
+// =============================================================================
+
+TEST_F(InputEventDispatcherTest, FullDragSequence) {
+    // Simulate left-button drag: press -> move -> move -> release
+    EXPECT_TRUE(dispatcher.dispatch(
+        interactor, makeMouseEvent("mouse_down", 100, 100, 1), 640, 480));
+    EXPECT_TRUE(dispatcher.dispatch(
+        interactor, makeMouseEvent("mouse_move", 200, 150), 640, 480));
+    EXPECT_TRUE(dispatcher.dispatch(
+        interactor, makeMouseEvent("mouse_move", 300, 200), 640, 480));
+    EXPECT_TRUE(dispatcher.dispatch(
+        interactor, makeMouseEvent("mouse_up", 300, 200, 1), 640, 480));
+
+    EXPECT_EQ(dispatcher.dispatchedCount(), 4u);
+}
+
+TEST_F(InputEventDispatcherTest, ScrollSequence) {
+    // Simulate multiple scroll events (e.g., MPR slice navigation)
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_TRUE(dispatcher.dispatch(
+            interactor, makeScrollEvent(320, 240, 1.0), 640, 480));
+    }
+    EXPECT_EQ(dispatcher.dispatchedCount(), 5u);
+}
+
+// =============================================================================
+// InputEvent extended fields
+// =============================================================================
+
+TEST_F(InputEventDispatcherTest, InputEventExtendedDefaults) {
+    InputEvent event;
+    EXPECT_DOUBLE_EQ(event.delta, 0.0);
+    EXPECT_FALSE(event.shiftKey);
+    EXPECT_FALSE(event.ctrlKey);
+    EXPECT_FALSE(event.altKey);
+    EXPECT_TRUE(event.keySym.empty());
+}


### PR DESCRIPTION
Closes #472

## Summary
- Implements InputEventDispatcher that translates WebSocket JSON input events into synthetic VTK interactor events
- Coordinate remapping from client canvas (top-left origin) to VTK render window (bottom-left origin) with resolution scaling
- Supports mouse (move, press, release), scroll (forward/backward), and keyboard (press, release) events
- Thread-safe event queue with configurable max depth for burst protection
- Extended InputEvent struct with scroll delta, modifier keys (shift/ctrl/alt), and key symbol fields
- Web key symbol mapping to VTK key symbols (ArrowUp->Up, Escape->Escape, etc.)

## Architecture
- InputEventDispatcher receives InputEvent and injects via vtkRenderWindowInteractor::SetEventInformation + InvokeEvent
- Bounded deque queue: enqueue() is thread-safe, processAll() drains and dispatches in order
- Queue overflow drops oldest events (FIFO eviction) with drop counter for monitoring
- Button bitmask (1=left, 2=right, 4=middle) maps to individual VTK button events

## Files Changed
| File | Change |
|------|--------|
| include/services/render/input_event_dispatcher.hpp | New dispatcher class header |
| src/services/render/input_event_dispatcher.cpp | VTK event injection implementation |
| tests/unit/input_event_dispatcher_test.cpp | 33 unit tests |
| include/services/render/websocket_frame_streamer.hpp | Extended InputEvent with delta, modifiers, keySym |
| src/services/render/websocket_frame_streamer.cpp | JSON parsing for new InputEvent fields |
| CMakeLists.txt | Added source file |
| tests/CMakeLists.txt | Added test target |

## Test Plan
- [x] 33 InputEventDispatcher tests pass (coordinate remapping, all event types, queue, concurrency)
- [x] 12 WebSocketFrameStreamer tests still pass (no regression from InputEvent extension)
- [x] Coordinate remapping verified: top-left flip, scaling, clamping, zero-size edge cases
- [x] Event position verified on VTK interactor after dispatch
- [x] Full drag sequence (press->move->move->release) verified
- [x] Concurrent enqueue from 3 threads verified