### PR TITLE
feat(rendering): implement render session manager for multi-client lifecycle (#473)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,6 +539,7 @@ add_library(render_service STATIC
     src/services/render/frame_encoder.cpp
     src/services/render/websocket_frame_streamer.cpp
     src/services/render/input_event_dispatcher.cpp
+    src/services/render/render_session_manager.cpp
 )
 
 # Crow WebSocket framework (header-only)

--- a/include/services/render/render_session_manager.hpp
+++ b/include/services/render/render_session_manager.hpp
@@ -1,0 +1,200 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file render_session_manager.hpp
+ * @brief Manages lifecycle of per-client headless render sessions
+ * @details Creates, tracks, and destroys RenderSession objects for remote
+ *          rendering clients. Provides idle timeout cleanup, max session
+ *          enforcement, and a background render loop that captures frames
+ *          at a configurable target FPS.
+ *
+ * ## Architecture
+ * ```
+ * RenderSessionManager
+ *   +-- session_map: {session_id -> RenderSession + metadata}
+ *   +-- render_thread: fires at target FPS, captures frames
+ *   +-- idle_timeout: destroys zombie sessions
+ *   +-- frame_callback: delivers rendered frames to caller
+ * ```
+ *
+ * ## Thread Safety
+ * - All public methods are thread-safe (internal mutex)
+ * - Frame callback is invoked from the render loop thread
+ * - Idle cleanup can be called from any thread
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace dicom_viewer::services {
+
+class RenderSession;
+
+/**
+ * @brief Configuration for the render session manager
+ */
+struct RenderSessionManagerConfig {
+    /// Maximum concurrent render sessions (0 = unlimited)
+    uint32_t maxSessions = 8;
+
+    /// Target frames per second for the render loop
+    uint32_t targetFps = 30;
+
+    /// Idle timeout in seconds (0 = no timeout)
+    uint32_t idleTimeoutSeconds = 300;
+
+    /// Default frame width when not specified per session
+    uint32_t defaultWidth = 512;
+
+    /// Default frame height when not specified per session
+    uint32_t defaultHeight = 512;
+};
+
+/**
+ * @brief Callback invoked when a frame is ready for delivery
+ * @param sessionId Session that produced the frame
+ * @param rgbaFrame RGBA pixel data (width * height * 4 bytes)
+ * @param width Frame width in pixels
+ * @param height Frame height in pixels
+ */
+using FrameReadyCallback = std::function<void(
+    const std::string& sessionId,
+    const std::vector<uint8_t>& rgbaFrame,
+    uint32_t width, uint32_t height)>;
+
+/**
+ * @brief Manages per-client headless render session lifecycles
+ *
+ * Handles creation, destruction, idle timeout, and background
+ * render loop for remote rendering sessions.
+ *
+ * @trace SRS-FR-REMOTE-005
+ */
+class RenderSessionManager {
+public:
+    explicit RenderSessionManager(
+        const RenderSessionManagerConfig& config = {});
+    ~RenderSessionManager();
+
+    // Non-copyable, non-movable (owns background thread)
+    RenderSessionManager(const RenderSessionManager&) = delete;
+    RenderSessionManager& operator=(const RenderSessionManager&) = delete;
+    RenderSessionManager(RenderSessionManager&&) = delete;
+    RenderSessionManager& operator=(RenderSessionManager&&) = delete;
+
+    /**
+     * @brief Create a new render session
+     * @param sessionId Unique session identifier
+     * @param width Frame width (0 = use default from config)
+     * @param height Frame height (0 = use default from config)
+     * @return true if created, false if session exists or limit reached
+     */
+    bool createSession(const std::string& sessionId,
+                       uint32_t width = 0, uint32_t height = 0);
+
+    /**
+     * @brief Destroy a render session and free its resources
+     * @param sessionId Session to destroy
+     * @return true if destroyed, false if session not found
+     */
+    bool destroySession(const std::string& sessionId);
+
+    /**
+     * @brief Check if a session exists
+     */
+    [[nodiscard]] bool hasSession(const std::string& sessionId) const;
+
+    /**
+     * @brief Get a session by ID
+     * @return Pointer to session, or nullptr if not found
+     */
+    [[nodiscard]] RenderSession* getSession(const std::string& sessionId);
+
+    /**
+     * @brief Reset the idle timer for a session (e.g., on input event)
+     */
+    void touchSession(const std::string& sessionId);
+
+    /**
+     * @brief Set callback for rendered frame delivery
+     * @details Called from the render loop thread at target FPS
+     */
+    void setFrameReadyCallback(FrameReadyCallback callback);
+
+    /**
+     * @brief Start the background render loop
+     */
+    void startRenderLoop();
+
+    /**
+     * @brief Stop the background render loop
+     */
+    void stopRenderLoop();
+
+    /**
+     * @brief Check if the render loop is active
+     */
+    [[nodiscard]] bool isRenderLoopRunning() const;
+
+    /**
+     * @brief Destroy sessions that have been idle beyond the timeout
+     * @return Number of sessions destroyed
+     */
+    size_t cleanupIdleSessions();
+
+    /**
+     * @brief Get the number of active sessions
+     */
+    [[nodiscard]] size_t activeSessionCount() const;
+
+    /**
+     * @brief Get all active session IDs
+     */
+    [[nodiscard]] std::vector<std::string> activeSessionIds() const;
+
+    /**
+     * @brief Get the manager configuration
+     */
+    [[nodiscard]] const RenderSessionManagerConfig& config() const;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::services

--- a/src/services/render/render_session_manager.cpp
+++ b/src/services/render/render_session_manager.cpp
@@ -1,0 +1,343 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "services/render/render_session_manager.hpp"
+#include "services/render/render_session.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+
+namespace dicom_viewer::services {
+
+// ---------------------------------------------------------------------------
+// Impl
+// ---------------------------------------------------------------------------
+class RenderSessionManager::Impl {
+public:
+    struct SessionEntry {
+        std::unique_ptr<RenderSession> session;
+        std::chrono::steady_clock::time_point lastActive;
+        uint32_t width;
+        uint32_t height;
+        uint32_t frameSeq = 0;
+    };
+
+    explicit Impl(const RenderSessionManagerConfig& config) : config_(config) {}
+
+    ~Impl() { stopLoop(); }
+
+    bool createSession(const std::string& sessionId,
+                       uint32_t width, uint32_t height)
+    {
+        std::lock_guard lock(mutex_);
+
+        if (sessions_.count(sessionId) > 0) {
+            return false;
+        }
+
+        if (config_.maxSessions > 0
+            && sessions_.size() >= config_.maxSessions) {
+            return false;
+        }
+
+        uint32_t w = (width > 0) ? width : config_.defaultWidth;
+        uint32_t h = (height > 0) ? height : config_.defaultHeight;
+
+        SessionEntry entry;
+        entry.session = std::make_unique<RenderSession>(w, h);
+        entry.lastActive = std::chrono::steady_clock::now();
+        entry.width = w;
+        entry.height = h;
+
+        sessions_.emplace(sessionId, std::move(entry));
+        return true;
+    }
+
+    bool destroySession(const std::string& sessionId)
+    {
+        std::lock_guard lock(mutex_);
+        return sessions_.erase(sessionId) > 0;
+    }
+
+    bool hasSession(const std::string& sessionId) const
+    {
+        std::lock_guard lock(mutex_);
+        return sessions_.count(sessionId) > 0;
+    }
+
+    RenderSession* getSession(const std::string& sessionId)
+    {
+        std::lock_guard lock(mutex_);
+        auto it = sessions_.find(sessionId);
+        if (it == sessions_.end()) {
+            return nullptr;
+        }
+        return it->second.session.get();
+    }
+
+    void touchSession(const std::string& sessionId)
+    {
+        std::lock_guard lock(mutex_);
+        auto it = sessions_.find(sessionId);
+        if (it != sessions_.end()) {
+            it->second.lastActive = std::chrono::steady_clock::now();
+        }
+    }
+
+    void setFrameReadyCallback(FrameReadyCallback callback)
+    {
+        std::lock_guard lock(mutex_);
+        frameCallback_ = std::move(callback);
+    }
+
+    void startLoop()
+    {
+        if (running_.load()) {
+            return;
+        }
+
+        running_.store(true);
+        renderThread_ = std::thread([this]() { renderLoop(); });
+    }
+
+    void stopLoop()
+    {
+        if (!running_.load()) {
+            return;
+        }
+
+        {
+            std::lock_guard lock(cvMutex_);
+            running_.store(false);
+        }
+        cv_.notify_one();
+
+        if (renderThread_.joinable()) {
+            renderThread_.join();
+        }
+    }
+
+    bool isRenderLoopRunning() const { return running_.load(); }
+
+    size_t cleanupIdleSessions()
+    {
+        if (config_.idleTimeoutSeconds == 0) {
+            return 0;
+        }
+
+        auto now = std::chrono::steady_clock::now();
+        auto timeout = std::chrono::seconds(config_.idleTimeoutSeconds);
+
+        std::lock_guard lock(mutex_);
+        size_t removed = 0;
+
+        for (auto it = sessions_.begin(); it != sessions_.end(); ) {
+            if ((now - it->second.lastActive) > timeout) {
+                it = sessions_.erase(it);
+                ++removed;
+            } else {
+                ++it;
+            }
+        }
+
+        return removed;
+    }
+
+    size_t activeSessionCount() const
+    {
+        std::lock_guard lock(mutex_);
+        return sessions_.size();
+    }
+
+    std::vector<std::string> activeSessionIds() const
+    {
+        std::lock_guard lock(mutex_);
+        std::vector<std::string> ids;
+        ids.reserve(sessions_.size());
+        for (const auto& [id, _] : sessions_) {
+            ids.push_back(id);
+        }
+        return ids;
+    }
+
+    const RenderSessionManagerConfig& config() const { return config_; }
+
+private:
+    void renderLoop()
+    {
+        using clock = std::chrono::steady_clock;
+        auto frameDuration = std::chrono::microseconds(
+            config_.targetFps > 0 ? 1'000'000 / config_.targetFps : 33'333);
+
+        while (running_.load()) {
+            auto frameStart = clock::now();
+
+            renderAllSessions();
+
+            // Sleep until next frame, waking early if stopped
+            auto elapsed = clock::now() - frameStart;
+            auto sleepTime = frameDuration - elapsed;
+            if (sleepTime > std::chrono::microseconds::zero()) {
+                std::unique_lock lock(cvMutex_);
+                cv_.wait_for(lock, sleepTime, [this]() {
+                    return !running_.load();
+                });
+            }
+        }
+    }
+
+    void renderAllSessions()
+    {
+        // Snapshot session IDs and callback under lock
+        std::vector<std::string> ids;
+        FrameReadyCallback cb;
+
+        {
+            std::lock_guard lock(mutex_);
+            cb = frameCallback_;
+            if (!cb || sessions_.empty()) {
+                return;
+            }
+            ids.reserve(sessions_.size());
+            for (const auto& [id, _] : sessions_) {
+                ids.push_back(id);
+            }
+        }
+
+        // Render each session (lock per session to avoid holding global lock)
+        for (const auto& id : ids) {
+            std::lock_guard lock(mutex_);
+            auto it = sessions_.find(id);
+            if (it == sessions_.end()) {
+                continue;
+            }
+
+            auto& entry = it->second;
+            auto frame = entry.session->captureVolumeFrame();
+            if (!frame.empty()) {
+                cb(id, frame, entry.width, entry.height);
+                ++entry.frameSeq;
+            }
+        }
+    }
+
+    RenderSessionManagerConfig config_;
+
+    mutable std::mutex mutex_;
+    std::unordered_map<std::string, SessionEntry> sessions_;
+    FrameReadyCallback frameCallback_;
+
+    std::atomic<bool> running_{false};
+    std::thread renderThread_;
+    std::mutex cvMutex_;
+    std::condition_variable cv_;
+};
+
+// ---------------------------------------------------------------------------
+// RenderSessionManager lifecycle
+// ---------------------------------------------------------------------------
+RenderSessionManager::RenderSessionManager(
+    const RenderSessionManagerConfig& config)
+    : impl_(std::make_unique<Impl>(config))
+{
+}
+
+RenderSessionManager::~RenderSessionManager() = default;
+
+bool RenderSessionManager::createSession(const std::string& sessionId,
+                                         uint32_t width, uint32_t height)
+{
+    return impl_->createSession(sessionId, width, height);
+}
+
+bool RenderSessionManager::destroySession(const std::string& sessionId)
+{
+    return impl_->destroySession(sessionId);
+}
+
+bool RenderSessionManager::hasSession(const std::string& sessionId) const
+{
+    return impl_->hasSession(sessionId);
+}
+
+RenderSession* RenderSessionManager::getSession(const std::string& sessionId)
+{
+    return impl_->getSession(sessionId);
+}
+
+void RenderSessionManager::touchSession(const std::string& sessionId)
+{
+    impl_->touchSession(sessionId);
+}
+
+void RenderSessionManager::setFrameReadyCallback(FrameReadyCallback callback)
+{
+    impl_->setFrameReadyCallback(std::move(callback));
+}
+
+void RenderSessionManager::startRenderLoop()
+{
+    impl_->startLoop();
+}
+
+void RenderSessionManager::stopRenderLoop()
+{
+    impl_->stopLoop();
+}
+
+bool RenderSessionManager::isRenderLoopRunning() const
+{
+    return impl_->isRenderLoopRunning();
+}
+
+size_t RenderSessionManager::cleanupIdleSessions()
+{
+    return impl_->cleanupIdleSessions();
+}
+
+size_t RenderSessionManager::activeSessionCount() const
+{
+    return impl_->activeSessionCount();
+}
+
+std::vector<std::string> RenderSessionManager::activeSessionIds() const
+{
+    return impl_->activeSessionIds();
+}
+
+const RenderSessionManagerConfig& RenderSessionManager::config() const
+{
+    return impl_->config();
+}
+
+} // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2070,6 +2070,24 @@ target_include_directories(render_session_test PRIVATE
 
 gtest_discover_tests(render_session_test DISCOVERY_TIMEOUT 60)
 
+# Unit tests for RenderSessionManager
+add_executable(render_session_manager_test
+    unit/render_session_manager_test.cpp
+)
+
+target_link_libraries(render_session_manager_test PRIVATE
+    render_service
+    segmentation_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(render_session_manager_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(render_session_manager_test DISCOVERY_TIMEOUT 60)
+
 # Unit tests for FrameEncoder
 add_executable(frame_encoder_test
     unit/frame_encoder_test.cpp

--- a/tests/unit/render_session_manager_test.cpp
+++ b/tests/unit/render_session_manager_test.cpp
@@ -1,0 +1,472 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include "services/render/render_session_manager.hpp"
+#include "services/render/render_session.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+using namespace dicom_viewer::services;
+
+// =============================================================================
+// Test fixture
+// =============================================================================
+
+class RenderSessionManagerTest : public ::testing::Test {
+protected:
+    RenderSessionManagerConfig defaultConfig()
+    {
+        RenderSessionManagerConfig cfg;
+        cfg.maxSessions = 4;
+        cfg.targetFps = 10;
+        cfg.idleTimeoutSeconds = 1;
+        cfg.defaultWidth = 64;
+        cfg.defaultHeight = 64;
+        return cfg;
+    }
+};
+
+// =============================================================================
+// Construction and configuration
+// =============================================================================
+
+TEST_F(RenderSessionManagerTest, DefaultConstruction) {
+    RenderSessionManager mgr;
+    EXPECT_EQ(mgr.activeSessionCount(), 0u);
+    EXPECT_FALSE(mgr.isRenderLoopRunning());
+}
+
+TEST_F(RenderSessionManagerTest, CustomConfig) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    EXPECT_EQ(mgr.config().maxSessions, 4u);
+    EXPECT_EQ(mgr.config().targetFps, 10u);
+    EXPECT_EQ(mgr.config().idleTimeoutSeconds, 1u);
+    EXPECT_EQ(mgr.config().defaultWidth, 64u);
+    EXPECT_EQ(mgr.config().defaultHeight, 64u);
+}
+
+TEST_F(RenderSessionManagerTest, DefaultConfigValues) {
+    RenderSessionManager mgr;
+
+    EXPECT_EQ(mgr.config().maxSessions, 8u);
+    EXPECT_EQ(mgr.config().targetFps, 30u);
+    EXPECT_EQ(mgr.config().idleTimeoutSeconds, 300u);
+    EXPECT_EQ(mgr.config().defaultWidth, 512u);
+    EXPECT_EQ(mgr.config().defaultHeight, 512u);
+}
+
+// =============================================================================
+// Session creation and destruction
+// =============================================================================
+
+TEST_F(RenderSessionManagerTest, CreateSession) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    EXPECT_TRUE(mgr.createSession("session-1"));
+    EXPECT_TRUE(mgr.hasSession("session-1"));
+    EXPECT_EQ(mgr.activeSessionCount(), 1u);
+}
+
+TEST_F(RenderSessionManagerTest, CreateSessionCustomSize) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    EXPECT_TRUE(mgr.createSession("session-1", 128, 128));
+    EXPECT_TRUE(mgr.hasSession("session-1"));
+}
+
+TEST_F(RenderSessionManagerTest, CreateDuplicateSessionFails) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    EXPECT_TRUE(mgr.createSession("session-1"));
+    EXPECT_FALSE(mgr.createSession("session-1"));
+    EXPECT_EQ(mgr.activeSessionCount(), 1u);
+}
+
+TEST_F(RenderSessionManagerTest, DestroySession) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    mgr.createSession("session-1");
+    EXPECT_TRUE(mgr.destroySession("session-1"));
+    EXPECT_FALSE(mgr.hasSession("session-1"));
+    EXPECT_EQ(mgr.activeSessionCount(), 0u);
+}
+
+TEST_F(RenderSessionManagerTest, DestroyNonexistentSessionFails) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    EXPECT_FALSE(mgr.destroySession("nonexistent"));
+}
+
+TEST_F(RenderSessionManagerTest, GetSession) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    mgr.createSession("session-1");
+    EXPECT_NE(mgr.getSession("session-1"), nullptr);
+    EXPECT_EQ(mgr.getSession("nonexistent"), nullptr);
+}
+
+TEST_F(RenderSessionManagerTest, HasSessionFalseForMissing) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    EXPECT_FALSE(mgr.hasSession("nonexistent"));
+}
+
+// =============================================================================
+// Max session enforcement
+// =============================================================================
+
+TEST_F(RenderSessionManagerTest, MaxSessionLimit) {
+    auto cfg = defaultConfig();
+    cfg.maxSessions = 2;
+    RenderSessionManager mgr(cfg);
+
+    EXPECT_TRUE(mgr.createSession("s1"));
+    EXPECT_TRUE(mgr.createSession("s2"));
+    EXPECT_FALSE(mgr.createSession("s3"));
+    EXPECT_EQ(mgr.activeSessionCount(), 2u);
+}
+
+TEST_F(RenderSessionManagerTest, MaxSessionZeroUnlimited) {
+    auto cfg = defaultConfig();
+    cfg.maxSessions = 0;
+    RenderSessionManager mgr(cfg);
+
+    for (int i = 0; i < 10; ++i) {
+        EXPECT_TRUE(mgr.createSession("s" + std::to_string(i)));
+    }
+    EXPECT_EQ(mgr.activeSessionCount(), 10u);
+}
+
+TEST_F(RenderSessionManagerTest, CreateAfterDestroyWithinLimit) {
+    auto cfg = defaultConfig();
+    cfg.maxSessions = 2;
+    RenderSessionManager mgr(cfg);
+
+    mgr.createSession("s1");
+    mgr.createSession("s2");
+    EXPECT_FALSE(mgr.createSession("s3"));
+
+    mgr.destroySession("s1");
+    EXPECT_TRUE(mgr.createSession("s3"));
+    EXPECT_EQ(mgr.activeSessionCount(), 2u);
+}
+
+// =============================================================================
+// Session IDs
+// =============================================================================
+
+TEST_F(RenderSessionManagerTest, ActiveSessionIds) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    mgr.createSession("alpha");
+    mgr.createSession("beta");
+    mgr.createSession("gamma");
+
+    auto ids = mgr.activeSessionIds();
+    EXPECT_EQ(ids.size(), 3u);
+
+    std::sort(ids.begin(), ids.end());
+    EXPECT_EQ(ids[0], "alpha");
+    EXPECT_EQ(ids[1], "beta");
+    EXPECT_EQ(ids[2], "gamma");
+}
+
+TEST_F(RenderSessionManagerTest, ActiveSessionIdsEmpty) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    EXPECT_TRUE(mgr.activeSessionIds().empty());
+}
+
+// =============================================================================
+// Idle timeout cleanup
+// =============================================================================
+
+TEST_F(RenderSessionManagerTest, CleanupIdleSessions) {
+    auto cfg = defaultConfig();
+    cfg.idleTimeoutSeconds = 1;
+    RenderSessionManager mgr(cfg);
+
+    mgr.createSession("s1");
+    mgr.createSession("s2");
+
+    // Wait for sessions to become idle
+    std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+
+    size_t removed = mgr.cleanupIdleSessions();
+    EXPECT_EQ(removed, 2u);
+    EXPECT_EQ(mgr.activeSessionCount(), 0u);
+}
+
+TEST_F(RenderSessionManagerTest, TouchPreventsCleanup) {
+    auto cfg = defaultConfig();
+    cfg.idleTimeoutSeconds = 1;
+    RenderSessionManager mgr(cfg);
+
+    mgr.createSession("s1");
+    mgr.createSession("s2");
+
+    // Wait partway through the timeout
+    std::this_thread::sleep_for(std::chrono::milliseconds(600));
+
+    // Touch one session
+    mgr.touchSession("s1");
+
+    // Wait for the rest of the timeout
+    std::this_thread::sleep_for(std::chrono::milliseconds(600));
+
+    size_t removed = mgr.cleanupIdleSessions();
+    EXPECT_EQ(removed, 1u);
+    EXPECT_TRUE(mgr.hasSession("s1"));
+    EXPECT_FALSE(mgr.hasSession("s2"));
+}
+
+TEST_F(RenderSessionManagerTest, CleanupNoTimeoutConfigured) {
+    auto cfg = defaultConfig();
+    cfg.idleTimeoutSeconds = 0;
+    RenderSessionManager mgr(cfg);
+
+    mgr.createSession("s1");
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    EXPECT_EQ(mgr.cleanupIdleSessions(), 0u);
+    EXPECT_EQ(mgr.activeSessionCount(), 1u);
+}
+
+TEST_F(RenderSessionManagerTest, CleanupEmptySessions) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    EXPECT_EQ(mgr.cleanupIdleSessions(), 0u);
+}
+
+// =============================================================================
+// Render loop lifecycle
+// =============================================================================
+
+TEST_F(RenderSessionManagerTest, StartStopRenderLoop) {
+    auto cfg = defaultConfig();
+    cfg.targetFps = 10;
+    RenderSessionManager mgr(cfg);
+
+    EXPECT_FALSE(mgr.isRenderLoopRunning());
+
+    mgr.startRenderLoop();
+    EXPECT_TRUE(mgr.isRenderLoopRunning());
+
+    mgr.stopRenderLoop();
+    EXPECT_FALSE(mgr.isRenderLoopRunning());
+}
+
+TEST_F(RenderSessionManagerTest, StartRenderLoopIdempotent) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    mgr.startRenderLoop();
+    mgr.startRenderLoop(); // Should not crash or create second thread
+    EXPECT_TRUE(mgr.isRenderLoopRunning());
+
+    mgr.stopRenderLoop();
+}
+
+TEST_F(RenderSessionManagerTest, StopRenderLoopIdempotent) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    mgr.stopRenderLoop(); // Should not crash when not running
+    EXPECT_FALSE(mgr.isRenderLoopRunning());
+}
+
+TEST_F(RenderSessionManagerTest, DestructorStopsRenderLoop) {
+    auto cfg = defaultConfig();
+    {
+        RenderSessionManager mgr(cfg);
+        mgr.startRenderLoop();
+        EXPECT_TRUE(mgr.isRenderLoopRunning());
+        // Destructor should stop cleanly
+    }
+    // If we get here without hanging, the test passes
+    SUCCEED();
+}
+
+// =============================================================================
+// Frame callback
+// =============================================================================
+
+TEST_F(RenderSessionManagerTest, SetFrameReadyCallback) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    std::atomic<int> callCount{0};
+    mgr.setFrameReadyCallback(
+        [&](const std::string&, const std::vector<uint8_t>&,
+            uint32_t, uint32_t) {
+            callCount.fetch_add(1);
+        });
+
+    // Callback is set but no sessions or loop, so nothing should fire
+    EXPECT_EQ(callCount.load(), 0);
+}
+
+// =============================================================================
+// Thread safety
+// =============================================================================
+
+TEST_F(RenderSessionManagerTest, ConcurrentCreateDestroy) {
+    auto cfg = defaultConfig();
+    cfg.maxSessions = 0; // Unlimited
+    RenderSessionManager mgr(cfg);
+
+    auto createN = [&](int start, int count) {
+        for (int i = start; i < start + count; ++i) {
+            mgr.createSession("session-" + std::to_string(i));
+        }
+    };
+
+    auto destroyN = [&](int start, int count) {
+        for (int i = start; i < start + count; ++i) {
+            mgr.destroySession("session-" + std::to_string(i));
+        }
+    };
+
+    // Create from multiple threads
+    std::thread t1(createN, 0, 50);
+    std::thread t2(createN, 50, 50);
+    t1.join();
+    t2.join();
+
+    EXPECT_EQ(mgr.activeSessionCount(), 100u);
+
+    // Destroy from multiple threads
+    std::thread t3(destroyN, 0, 50);
+    std::thread t4(destroyN, 50, 50);
+    t3.join();
+    t4.join();
+
+    EXPECT_EQ(mgr.activeSessionCount(), 0u);
+}
+
+TEST_F(RenderSessionManagerTest, ConcurrentTouchAndCleanup) {
+    auto cfg = defaultConfig();
+    cfg.idleTimeoutSeconds = 1;
+    cfg.maxSessions = 0;
+    RenderSessionManager mgr(cfg);
+
+    for (int i = 0; i < 20; ++i) {
+        mgr.createSession("s" + std::to_string(i));
+    }
+
+    // Touch sessions concurrently while cleanup runs
+    std::atomic<bool> done{false};
+    std::thread toucher([&]() {
+        while (!done.load()) {
+            for (int i = 0; i < 10; ++i) {
+                mgr.touchSession("s" + std::to_string(i));
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+    mgr.cleanupIdleSessions();
+
+    done.store(true);
+    toucher.join();
+
+    // Sessions 0-9 should still exist (touched), 10-19 should be cleaned
+    for (int i = 0; i < 10; ++i) {
+        EXPECT_TRUE(mgr.hasSession("s" + std::to_string(i)));
+    }
+    for (int i = 10; i < 20; ++i) {
+        EXPECT_FALSE(mgr.hasSession("s" + std::to_string(i)));
+    }
+}
+
+// =============================================================================
+// Touch non-existent session (no-op)
+// =============================================================================
+
+TEST_F(RenderSessionManagerTest, TouchNonexistentSession) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    // Should not crash
+    mgr.touchSession("nonexistent");
+    EXPECT_EQ(mgr.activeSessionCount(), 0u);
+}
+
+// =============================================================================
+// Multiple session operations
+// =============================================================================
+
+TEST_F(RenderSessionManagerTest, MultipleSessions) {
+    auto cfg = defaultConfig();
+    cfg.maxSessions = 4;
+    RenderSessionManager mgr(cfg);
+
+    EXPECT_TRUE(mgr.createSession("s1"));
+    EXPECT_TRUE(mgr.createSession("s2"));
+    EXPECT_TRUE(mgr.createSession("s3"));
+    EXPECT_EQ(mgr.activeSessionCount(), 3u);
+
+    EXPECT_TRUE(mgr.destroySession("s2"));
+    EXPECT_EQ(mgr.activeSessionCount(), 2u);
+
+    EXPECT_TRUE(mgr.hasSession("s1"));
+    EXPECT_FALSE(mgr.hasSession("s2"));
+    EXPECT_TRUE(mgr.hasSession("s3"));
+}
+
+TEST_F(RenderSessionManagerTest, GetSessionReturnsValidPointer) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    mgr.createSession("s1");
+    auto* session = mgr.getSession("s1");
+    ASSERT_NE(session, nullptr);
+
+    // The RenderSession should be a valid object we can interact with
+    // (VolumeRenderer and MPRRenderer are initialized in off-screen mode)
+}


### PR DESCRIPTION
Closes #473

## Summary
- Add `RenderSessionManager` class managing per-client headless render session lifecycles
- Background render loop with configurable target FPS and frame-ready callback delivery
- Idle timeout cleanup with touch-based activity tracking
- Max concurrent session enforcement with configurable limits
- Thread-safe session operations using mutex protection and condition variables

## Test Plan
- 29 unit tests covering:
  - Construction and configuration defaults
  - Session create/destroy/get/has operations
  - Max session limit enforcement (including unlimited mode)
  - Idle timeout cleanup with touch prevention
  - Render loop start/stop/idempotent lifecycle
  - Concurrent create/destroy from multiple threads
  - Concurrent touch and cleanup race condition safety
