### PR TITLE
feat(ui): implement input event capture and serialization for RemoteViewportWidget (#484)

### DIFF
--- a/include/ui/widgets/remote_viewport_widget.hpp
+++ b/include/ui/widgets/remote_viewport_widget.hpp
@@ -61,6 +61,8 @@
 
 #include <cstdint>
 #include <memory>
+#include <string>
+#include <QByteArray>
 #include <QWidget>
 
 namespace dicom_viewer::ui {
@@ -151,6 +153,33 @@ public:
     static bool parseFrameHeader(const char* data, size_t size,
                                  FrameHeader& header);
 
+    /**
+     * @brief Serialize an input event to JSON for transmission to server
+     * @param type Event type (e.g. "mouse_move", "mouse_down", "key_down")
+     * @param sessionId Session identifier
+     * @param x Normalized X coordinate (0.0-1.0)
+     * @param y Normalized Y coordinate (0.0-1.0)
+     * @param buttons Mouse button bitmask (1=left, 2=right, 4=middle)
+     * @param keyCode Key code (Qt::Key value)
+     * @param keySym Key symbol string (e.g. "ArrowUp", "Escape")
+     * @param delta Scroll wheel delta
+     * @param shiftKey Shift modifier
+     * @param ctrlKey Ctrl modifier
+     * @param altKey Alt modifier
+     * @return JSON bytes ready for WebSocket transmission
+     */
+    static QByteArray serializeInputEvent(
+        const std::string& type,
+        const std::string& sessionId,
+        double x, double y,
+        int buttons = 0,
+        int keyCode = 0,
+        const std::string& keySym = {},
+        double delta = 0.0,
+        bool shiftKey = false,
+        bool ctrlKey = false,
+        bool altKey = false);
+
 signals:
     /**
      * @brief Connection state changed
@@ -163,8 +192,20 @@ signals:
      */
     void frameDisplayed(uint32_t frameSeq);
 
+    /**
+     * @brief An input event was serialized and sent to the server
+     * @param type Event type string
+     */
+    void inputEventSent(const QString& type);
+
 protected:
     void paintEvent(QPaintEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+    void wheelEvent(QWheelEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
+    void keyReleaseEvent(QKeyEvent* event) override;
 
 private:
     class Impl;

--- a/src/ui/widgets/remote_viewport_widget.cpp
+++ b/src/ui/widgets/remote_viewport_widget.cpp
@@ -30,12 +30,18 @@
 #include "ui/widgets/remote_viewport_widget.hpp"
 
 #include <QImage>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QKeyEvent>
+#include <QMouseEvent>
 #include <QPainter>
 #include <QPaintEvent>
 #include <QTimer>
 #include <QUrl>
 #include <QWebSocket>
+#include <QWheelEvent>
 
+#include <chrono>
 #include <cstring>
 
 namespace dicom_viewer::ui {
@@ -74,8 +80,17 @@ public:
 
     RemoteConnectionState state() const { return state_; }
     QString sessionId() const { return sessionId_; }
+    std::string sessionIdStd() const { return sessionId_.toStdString(); }
     uint64_t framesReceived() const { return framesReceived_; }
     uint32_t lastFrameSeq() const { return lastFrameSeq_; }
+
+    void sendInputEvent(const QByteArray& json)
+    {
+        if (state_ != RemoteConnectionState::Connected || !socket_) {
+            return;
+        }
+        socket_->sendTextMessage(QString::fromUtf8(json));
+    }
 
     QImage currentFrame_;
 
@@ -353,6 +368,236 @@ void RemoteViewportWidget::paintEvent(QPaintEvent* /*event*/)
             painter.drawText(widgetRect, Qt::AlignCenter, statusText);
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Input event serialization
+// ---------------------------------------------------------------------------
+
+namespace {
+
+std::string qtKeyToKeySym(int key)
+{
+    switch (key) {
+    case Qt::Key_Left:      return "ArrowLeft";
+    case Qt::Key_Right:     return "ArrowRight";
+    case Qt::Key_Up:        return "ArrowUp";
+    case Qt::Key_Down:      return "ArrowDown";
+    case Qt::Key_Return:
+    case Qt::Key_Enter:     return "Enter";
+    case Qt::Key_Escape:    return "Escape";
+    case Qt::Key_Space:     return "Space";
+    case Qt::Key_Backspace: return "Backspace";
+    case Qt::Key_Tab:       return "Tab";
+    case Qt::Key_Delete:    return "Delete";
+    case Qt::Key_Home:      return "Home";
+    case Qt::Key_End:       return "End";
+    case Qt::Key_PageUp:    return "PageUp";
+    case Qt::Key_PageDown:  return "PageDown";
+    case Qt::Key_Shift:     return "Shift";
+    case Qt::Key_Control:   return "Control";
+    case Qt::Key_Alt:       return "Alt";
+    default: {
+        if (key >= Qt::Key_A && key <= Qt::Key_Z) {
+            return std::string(1, static_cast<char>('a' + (key - Qt::Key_A)));
+        }
+        if (key >= Qt::Key_0 && key <= Qt::Key_9) {
+            return std::string(1, static_cast<char>('0' + (key - Qt::Key_0)));
+        }
+        if (key >= Qt::Key_F1 && key <= Qt::Key_F12) {
+            return "F" + std::to_string(key - Qt::Key_F1 + 1);
+        }
+        return {};
+    }
+    }
+}
+
+int qtButtonsToMask(Qt::MouseButtons buttons)
+{
+    int mask = 0;
+    if (buttons & Qt::LeftButton)   mask |= 1;
+    if (buttons & Qt::RightButton)  mask |= 2;
+    if (buttons & Qt::MiddleButton) mask |= 4;
+    return mask;
+}
+
+uint64_t currentTimestampMs()
+{
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now().time_since_epoch())
+            .count());
+}
+
+} // anonymous namespace
+
+QByteArray RemoteViewportWidget::serializeInputEvent(
+    const std::string& type,
+    const std::string& sessionId,
+    double x, double y,
+    int buttons,
+    int keyCode,
+    const std::string& keySym,
+    double delta,
+    bool shiftKey,
+    bool ctrlKey,
+    bool altKey)
+{
+    QJsonObject obj;
+    obj["session_id"] = QString::fromStdString(sessionId);
+    obj["type"] = QString::fromStdString(type);
+    obj["x"] = x;
+    obj["y"] = y;
+    obj["buttons"] = buttons;
+    obj["key_code"] = keyCode;
+    obj["key"] = QString::fromStdString(keySym);
+    obj["ts"] = static_cast<qint64>(currentTimestampMs());
+    obj["delta"] = delta;
+    obj["shift"] = shiftKey;
+    obj["ctrl"] = ctrlKey;
+    obj["alt"] = altKey;
+
+    return QJsonDocument(obj).toJson(QJsonDocument::Compact);
+}
+
+// ---------------------------------------------------------------------------
+// Event handlers
+// ---------------------------------------------------------------------------
+
+void RemoteViewportWidget::mouseMoveEvent(QMouseEvent* event)
+{
+    double nx = static_cast<double>(event->position().x()) / width();
+    double ny = static_cast<double>(event->position().y()) / height();
+    auto mods = event->modifiers();
+
+    auto json = serializeInputEvent(
+        "mouse_move", impl_->sessionIdStd(),
+        nx, ny,
+        qtButtonsToMask(event->buttons()),
+        0, {},
+        0.0,
+        mods & Qt::ShiftModifier,
+        mods & Qt::ControlModifier,
+        mods & Qt::AltModifier);
+
+    impl_->sendInputEvent(json);
+    emit inputEventSent("mouse_move");
+    event->accept();
+}
+
+void RemoteViewportWidget::mousePressEvent(QMouseEvent* event)
+{
+    double nx = static_cast<double>(event->position().x()) / width();
+    double ny = static_cast<double>(event->position().y()) / height();
+    auto mods = event->modifiers();
+
+    auto json = serializeInputEvent(
+        "mouse_down", impl_->sessionIdStd(),
+        nx, ny,
+        qtButtonsToMask(event->buttons()),
+        0, {},
+        0.0,
+        mods & Qt::ShiftModifier,
+        mods & Qt::ControlModifier,
+        mods & Qt::AltModifier);
+
+    impl_->sendInputEvent(json);
+    emit inputEventSent("mouse_down");
+    event->accept();
+}
+
+void RemoteViewportWidget::mouseReleaseEvent(QMouseEvent* event)
+{
+    double nx = static_cast<double>(event->position().x()) / width();
+    double ny = static_cast<double>(event->position().y()) / height();
+    auto mods = event->modifiers();
+
+    // buttons() returns buttons still held; add the released button
+    int mask = qtButtonsToMask(event->buttons())
+             | qtButtonsToMask(event->button());
+
+    auto json = serializeInputEvent(
+        "mouse_up", impl_->sessionIdStd(),
+        nx, ny, mask,
+        0, {},
+        0.0,
+        mods & Qt::ShiftModifier,
+        mods & Qt::ControlModifier,
+        mods & Qt::AltModifier);
+
+    impl_->sendInputEvent(json);
+    emit inputEventSent("mouse_up");
+    event->accept();
+}
+
+void RemoteViewportWidget::wheelEvent(QWheelEvent* event)
+{
+    double nx = static_cast<double>(event->position().x()) / width();
+    double ny = static_cast<double>(event->position().y()) / height();
+    auto mods = event->modifiers();
+
+    // angleDelta().y() is in 1/8 degree increments; normalize to whole steps
+    double delta = event->angleDelta().y() / 120.0;
+
+    auto json = serializeInputEvent(
+        "scroll", impl_->sessionIdStd(),
+        nx, ny,
+        qtButtonsToMask(event->buttons()),
+        0, {},
+        delta,
+        mods & Qt::ShiftModifier,
+        mods & Qt::ControlModifier,
+        mods & Qt::AltModifier);
+
+    impl_->sendInputEvent(json);
+    emit inputEventSent("scroll");
+    event->accept();
+}
+
+void RemoteViewportWidget::keyPressEvent(QKeyEvent* event)
+{
+    if (event->isAutoRepeat()) {
+        event->accept();
+        return;
+    }
+
+    auto mods = event->modifiers();
+    auto json = serializeInputEvent(
+        "key_down", impl_->sessionIdStd(),
+        0.0, 0.0, 0,
+        event->key(),
+        qtKeyToKeySym(event->key()),
+        0.0,
+        mods & Qt::ShiftModifier,
+        mods & Qt::ControlModifier,
+        mods & Qt::AltModifier);
+
+    impl_->sendInputEvent(json);
+    emit inputEventSent("key_down");
+    event->accept();
+}
+
+void RemoteViewportWidget::keyReleaseEvent(QKeyEvent* event)
+{
+    if (event->isAutoRepeat()) {
+        event->accept();
+        return;
+    }
+
+    auto mods = event->modifiers();
+    auto json = serializeInputEvent(
+        "key_up", impl_->sessionIdStd(),
+        0.0, 0.0, 0,
+        event->key(),
+        qtKeyToKeySym(event->key()),
+        0.0,
+        mods & Qt::ShiftModifier,
+        mods & Qt::ControlModifier,
+        mods & Qt::AltModifier);
+
+    impl_->sendInputEvent(json);
+    emit inputEventSent("key_up");
+    event->accept();
 }
 
 } // namespace dicom_viewer::ui

--- a/tests/unit/remote_viewport_widget_test.cpp
+++ b/tests/unit/remote_viewport_widget_test.cpp
@@ -32,6 +32,8 @@
 #include "ui/widgets/remote_viewport_widget.hpp"
 
 #include <QApplication>
+#include <QJsonDocument>
+#include <QJsonObject>
 
 #include <cstring>
 #include <string>
@@ -282,4 +284,195 @@ TEST_F(RemoteViewportWidgetTest, FrameHeaderDefaults) {
     EXPECT_EQ(header.height, 0u);
     EXPECT_EQ(header.imageData, nullptr);
     EXPECT_EQ(header.imageDataSize, 0u);
+}
+
+// =============================================================================
+// Input event serialization
+// =============================================================================
+
+TEST_F(RemoteViewportWidgetTest, SerializeMouseMoveEvent) {
+    auto json = RemoteViewportWidget::serializeInputEvent(
+        "mouse_move", "sess-42",
+        0.5, 0.75,
+        1, // left button
+        0, {},
+        0.0,
+        false, false, false);
+
+    QJsonDocument doc = QJsonDocument::fromJson(json);
+    ASSERT_FALSE(doc.isNull());
+
+    QJsonObject obj = doc.object();
+    EXPECT_EQ(obj["type"].toString().toStdString(), "mouse_move");
+    EXPECT_EQ(obj["session_id"].toString().toStdString(), "sess-42");
+    EXPECT_DOUBLE_EQ(obj["x"].toDouble(), 0.5);
+    EXPECT_DOUBLE_EQ(obj["y"].toDouble(), 0.75);
+    EXPECT_EQ(obj["buttons"].toInt(), 1);
+    EXPECT_EQ(obj["key_code"].toInt(), 0);
+    EXPECT_TRUE(obj["key"].toString().isEmpty());
+    EXPECT_DOUBLE_EQ(obj["delta"].toDouble(), 0.0);
+    EXPECT_FALSE(obj["shift"].toBool());
+    EXPECT_FALSE(obj["ctrl"].toBool());
+    EXPECT_FALSE(obj["alt"].toBool());
+    EXPECT_TRUE(obj.contains("ts"));
+    EXPECT_GT(obj["ts"].toInteger(), 0);
+}
+
+TEST_F(RemoteViewportWidgetTest, SerializeMouseDownEvent) {
+    auto json = RemoteViewportWidget::serializeInputEvent(
+        "mouse_down", "session-1",
+        0.25, 0.50,
+        2, // right button
+        0, {},
+        0.0,
+        true, false, true); // shift + alt
+
+    QJsonDocument doc = QJsonDocument::fromJson(json);
+    QJsonObject obj = doc.object();
+
+    EXPECT_EQ(obj["type"].toString().toStdString(), "mouse_down");
+    EXPECT_EQ(obj["buttons"].toInt(), 2);
+    EXPECT_DOUBLE_EQ(obj["x"].toDouble(), 0.25);
+    EXPECT_DOUBLE_EQ(obj["y"].toDouble(), 0.50);
+    EXPECT_TRUE(obj["shift"].toBool());
+    EXPECT_FALSE(obj["ctrl"].toBool());
+    EXPECT_TRUE(obj["alt"].toBool());
+}
+
+TEST_F(RemoteViewportWidgetTest, SerializeMouseUpEvent) {
+    auto json = RemoteViewportWidget::serializeInputEvent(
+        "mouse_up", "session-1",
+        0.1, 0.9,
+        5, // left + middle
+        0, {},
+        0.0,
+        false, true, false); // ctrl
+
+    QJsonDocument doc = QJsonDocument::fromJson(json);
+    QJsonObject obj = doc.object();
+
+    EXPECT_EQ(obj["type"].toString().toStdString(), "mouse_up");
+    EXPECT_EQ(obj["buttons"].toInt(), 5);
+    EXPECT_TRUE(obj["ctrl"].toBool());
+}
+
+TEST_F(RemoteViewportWidgetTest, SerializeScrollEvent) {
+    auto json = RemoteViewportWidget::serializeInputEvent(
+        "scroll", "session-1",
+        0.5, 0.5,
+        0,
+        0, {},
+        -2.5, // scroll backward
+        false, false, false);
+
+    QJsonDocument doc = QJsonDocument::fromJson(json);
+    QJsonObject obj = doc.object();
+
+    EXPECT_EQ(obj["type"].toString().toStdString(), "scroll");
+    EXPECT_DOUBLE_EQ(obj["delta"].toDouble(), -2.5);
+    EXPECT_EQ(obj["buttons"].toInt(), 0);
+}
+
+TEST_F(RemoteViewportWidgetTest, SerializeKeyDownEvent) {
+    auto json = RemoteViewportWidget::serializeInputEvent(
+        "key_down", "session-1",
+        0.0, 0.0, 0,
+        Qt::Key_A,
+        "a",
+        0.0,
+        false, true, false); // ctrl+a
+
+    QJsonDocument doc = QJsonDocument::fromJson(json);
+    QJsonObject obj = doc.object();
+
+    EXPECT_EQ(obj["type"].toString().toStdString(), "key_down");
+    EXPECT_EQ(obj["key_code"].toInt(), Qt::Key_A);
+    EXPECT_EQ(obj["key"].toString().toStdString(), "a");
+    EXPECT_TRUE(obj["ctrl"].toBool());
+    EXPECT_DOUBLE_EQ(obj["x"].toDouble(), 0.0);
+    EXPECT_DOUBLE_EQ(obj["y"].toDouble(), 0.0);
+}
+
+TEST_F(RemoteViewportWidgetTest, SerializeKeyUpEvent) {
+    auto json = RemoteViewportWidget::serializeInputEvent(
+        "key_up", "session-1",
+        0.0, 0.0, 0,
+        Qt::Key_Escape,
+        "Escape",
+        0.0,
+        false, false, false);
+
+    QJsonDocument doc = QJsonDocument::fromJson(json);
+    QJsonObject obj = doc.object();
+
+    EXPECT_EQ(obj["type"].toString().toStdString(), "key_up");
+    EXPECT_EQ(obj["key_code"].toInt(), Qt::Key_Escape);
+    EXPECT_EQ(obj["key"].toString().toStdString(), "Escape");
+}
+
+TEST_F(RemoteViewportWidgetTest, SerializeContainsAllServerFields) {
+    // Verify all 11 fields expected by the server are present
+    auto json = RemoteViewportWidget::serializeInputEvent(
+        "mouse_move", "s1",
+        0.0, 0.0, 0, 0, {}, 0.0, false, false, false);
+
+    QJsonDocument doc = QJsonDocument::fromJson(json);
+    QJsonObject obj = doc.object();
+
+    EXPECT_TRUE(obj.contains("session_id"));
+    EXPECT_TRUE(obj.contains("type"));
+    EXPECT_TRUE(obj.contains("x"));
+    EXPECT_TRUE(obj.contains("y"));
+    EXPECT_TRUE(obj.contains("buttons"));
+    EXPECT_TRUE(obj.contains("key_code"));
+    EXPECT_TRUE(obj.contains("key"));
+    EXPECT_TRUE(obj.contains("ts"));
+    EXPECT_TRUE(obj.contains("delta"));
+    EXPECT_TRUE(obj.contains("shift"));
+    EXPECT_TRUE(obj.contains("ctrl"));
+    EXPECT_TRUE(obj.contains("alt"));
+}
+
+TEST_F(RemoteViewportWidgetTest, SerializeEmptySessionId) {
+    auto json = RemoteViewportWidget::serializeInputEvent(
+        "mouse_move", "",
+        0.5, 0.5, 0, 0, {}, 0.0, false, false, false);
+
+    QJsonDocument doc = QJsonDocument::fromJson(json);
+    QJsonObject obj = doc.object();
+
+    EXPECT_TRUE(obj["session_id"].toString().isEmpty());
+}
+
+TEST_F(RemoteViewportWidgetTest, SerializeArrowKeySymbol) {
+    auto json = RemoteViewportWidget::serializeInputEvent(
+        "key_down", "session-1",
+        0.0, 0.0, 0,
+        Qt::Key_Up,
+        "ArrowUp",
+        0.0,
+        false, false, false);
+
+    QJsonDocument doc = QJsonDocument::fromJson(json);
+    QJsonObject obj = doc.object();
+
+    EXPECT_EQ(obj["key"].toString().toStdString(), "ArrowUp");
+    EXPECT_EQ(obj["key_code"].toInt(), Qt::Key_Up);
+}
+
+TEST_F(RemoteViewportWidgetTest, SerializeAllModifiers) {
+    auto json = RemoteViewportWidget::serializeInputEvent(
+        "key_down", "session-1",
+        0.0, 0.0, 0,
+        Qt::Key_S,
+        "s",
+        0.0,
+        true, true, true); // shift + ctrl + alt
+
+    QJsonDocument doc = QJsonDocument::fromJson(json);
+    QJsonObject obj = doc.object();
+
+    EXPECT_TRUE(obj["shift"].toBool());
+    EXPECT_TRUE(obj["ctrl"].toBool());
+    EXPECT_TRUE(obj["alt"].toBool());
 }


### PR DESCRIPTION
Closes #484

## Summary
- Add mouse (move/press/release), wheel, and keyboard (press/release) event handlers to `RemoteViewportWidget`
- Serialize Qt input events to JSON matching the server-side `InputEvent` schema (`websocket_frame_streamer.hpp`)
- Normalize mouse coordinates to 0.0-1.0 range for resolution-independent client/server communication
- Map Qt key codes to web-standard key symbols (e.g., `Qt::Key_Up` -> `"ArrowUp"`)
- Send events via `QWebSocket::sendTextMessage()` only when connected
- Add `inputEventSent` signal for event tracking
- Add static `serializeInputEvent()` method for testable JSON serialization without requiring a WebSocket connection
- Filter `isAutoRepeat()` key events to prevent flooding the server

## Test Plan
- [x] 10 new unit tests for JSON serialization covering all event types
- [x] All 27 tests pass (17 existing + 10 new)
- [x] Full project build succeeds
- [x] JSON output matches server-side parsing keys: `session_id`, `type`, `x`, `y`, `buttons`, `key_code`, `key`, `ts`, `delta`, `shift`, `ctrl`, `alt`

Part of #474