### PR TITLE
feat(ui): add settings dialog and MainWindow mode switch for remote rendering

### DIFF
--- a/include/ui/dialogs/settings_dialog.hpp
+++ b/include/ui/dialogs/settings_dialog.hpp
@@ -43,8 +43,10 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <QDialog>
+#include <QString>
 
 namespace dicom_viewer::ui {
 
@@ -68,11 +70,27 @@ public:
     SettingsDialog(const SettingsDialog&) = delete;
     SettingsDialog& operator=(const SettingsDialog&) = delete;
 
+    /**
+     * @brief Check if remote rendering is enabled in current dialog state
+     */
+    [[nodiscard]] bool isRemoteRenderingEnabled() const;
+
+    /**
+     * @brief Get the configured remote server host
+     */
+    [[nodiscard]] QString remoteHost() const;
+
+    /**
+     * @brief Get the configured remote server port
+     */
+    [[nodiscard]] uint16_t remotePort() const;
+
 public slots:
     void accept() override;
 
 private slots:
     void onLogLevelChanged(int index);
+    void onRemoteEnabledToggled(bool checked);
 
 private:
     void setupUI();

--- a/include/ui/widgets/remote_viewport_widget.hpp
+++ b/include/ui/widgets/remote_viewport_widget.hpp
@@ -144,6 +144,11 @@ public:
     [[nodiscard]] uint32_t lastFrameSeq() const;
 
     /**
+     * @brief Toggle frame statistics overlay (FPS, latency)
+     */
+    void setShowStatistics(bool show);
+
+    /**
      * @brief Parse a binary frame from the render server
      * @param data Raw binary data
      * @param size Data size in bytes
@@ -206,6 +211,7 @@ protected:
     void wheelEvent(QWheelEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
     void keyReleaseEvent(QKeyEvent* event) override;
+    void contextMenuEvent(QContextMenuEvent* event) override;
 
 private:
     class Impl;

--- a/src/ui/dialogs/settings_dialog.cpp
+++ b/src/ui/dialogs/settings_dialog.cpp
@@ -33,11 +33,14 @@
 #include "ui/dialogs/settings_dialog.hpp"
 #include "core/app_log_level.hpp"
 
+#include <QCheckBox>
 #include <QComboBox>
 #include <QDialogButtonBox>
 #include <QGroupBox>
 #include <QLabel>
+#include <QLineEdit>
 #include <QSettings>
+#include <QSpinBox>
 #include <QVBoxLayout>
 
 namespace dicom_viewer::ui {
@@ -64,6 +67,11 @@ public:
     QComboBox* logLevelCombo = nullptr;
     QLabel* descriptionLabel = nullptr;
     int initialLevelIndex = 2; // Information
+
+    // Remote rendering
+    QCheckBox* remoteEnabledCheck = nullptr;
+    QLineEdit* remoteHostEdit = nullptr;
+    QSpinBox* remotePortSpin = nullptr;
 };
 
 SettingsDialog::SettingsDialog(QWidget* parent)
@@ -103,7 +111,39 @@ void SettingsDialog::setupUI()
     loggingLayout->addWidget(impl_->descriptionLabel);
 
     mainLayout->addWidget(loggingGroup);
+
+    // Remote rendering group box
+    auto* remoteGroup = new QGroupBox(tr("Remote Rendering"));
+    auto* remoteLayout = new QVBoxLayout(remoteGroup);
+
+    impl_->remoteEnabledCheck = new QCheckBox(tr("Enable remote rendering mode"));
+    remoteLayout->addWidget(impl_->remoteEnabledCheck);
+
+    auto* hostLayout = new QHBoxLayout;
+    hostLayout->addWidget(new QLabel(tr("Server Host:")));
+    impl_->remoteHostEdit = new QLineEdit;
+    impl_->remoteHostEdit->setPlaceholderText("localhost");
+    hostLayout->addWidget(impl_->remoteHostEdit, 1);
+    remoteLayout->addLayout(hostLayout);
+
+    auto* portLayout = new QHBoxLayout;
+    portLayout->addWidget(new QLabel(tr("Server Port:")));
+    impl_->remotePortSpin = new QSpinBox;
+    impl_->remotePortSpin->setRange(1, 65535);
+    impl_->remotePortSpin->setValue(8081);
+    portLayout->addWidget(impl_->remotePortSpin);
+    portLayout->addStretch();
+    remoteLayout->addLayout(portLayout);
+
+    // Disable host/port when remote rendering is off
+    impl_->remoteHostEdit->setEnabled(false);
+    impl_->remotePortSpin->setEnabled(false);
+
+    mainLayout->addWidget(remoteGroup);
     mainLayout->addStretch();
+
+    connect(impl_->remoteEnabledCheck, &QCheckBox::toggled,
+            this, &SettingsDialog::onRemoteEnabledToggled);
 
     // Dialog buttons
     auto* buttons = new QDialogButtonBox(
@@ -126,6 +166,14 @@ void SettingsDialog::loadSettings()
     impl_->logLevelCombo->setCurrentIndex(index);
     impl_->initialLevelIndex = index;
     onLogLevelChanged(index);
+
+    // Remote rendering
+    impl_->remoteEnabledCheck->setChecked(
+        settings.value("remote/enabled", false).toBool());
+    impl_->remoteHostEdit->setText(
+        settings.value("remote/host", "localhost").toString());
+    impl_->remotePortSpin->setValue(
+        settings.value("remote/port", 8081).toInt());
 }
 
 void SettingsDialog::saveSettings()
@@ -135,6 +183,15 @@ void SettingsDialog::saveSettings()
 
     QSettings settings;
     settings.setValue("logging/level", to_settings_value(level));
+
+    // Remote rendering
+    settings.setValue("remote/enabled", impl_->remoteEnabledCheck->isChecked());
+    QString host = impl_->remoteHostEdit->text().trimmed();
+    if (host.isEmpty()) {
+        host = "localhost";
+    }
+    settings.setValue("remote/host", host);
+    settings.setValue("remote/port", impl_->remotePortSpin->value());
 }
 
 void SettingsDialog::applyLogLevel()
@@ -162,6 +219,28 @@ void SettingsDialog::onLogLevelChanged(int index)
     if (index >= 0 && index < static_cast<int>(std::size(kLogLevels))) {
         impl_->descriptionLabel->setText(tr(kLogLevels[index].description));
     }
+}
+
+void SettingsDialog::onRemoteEnabledToggled(bool checked)
+{
+    impl_->remoteHostEdit->setEnabled(checked);
+    impl_->remotePortSpin->setEnabled(checked);
+}
+
+bool SettingsDialog::isRemoteRenderingEnabled() const
+{
+    return impl_->remoteEnabledCheck->isChecked();
+}
+
+QString SettingsDialog::remoteHost() const
+{
+    QString host = impl_->remoteHostEdit->text().trimmed();
+    return host.isEmpty() ? "localhost" : host;
+}
+
+uint16_t SettingsDialog::remotePort() const
+{
+    return static_cast<uint16_t>(impl_->remotePortSpin->value());
 }
 
 } // namespace dicom_viewer::ui

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -31,6 +31,7 @@
 #include "ui/intro_page.hpp"
 #include "ui/viewport_widget.hpp"
 #include "ui/viewport_layout_manager.hpp"
+#include "ui/widgets/remote_viewport_widget.hpp"
 #include "ui/widgets/phase_slider_widget.hpp"
 #include "ui/widgets/sp_mode_toggle.hpp"
 #include "ui/panels/patient_browser.hpp"
@@ -178,6 +179,10 @@ public:
     std::unique_ptr<core::ProjectManager> projectManager;
     QMenu* recentProjectsMenu = nullptr;
     QAction* closeCaseAction = nullptr;
+
+    // Remote rendering
+    RemoteViewportWidget* remoteViewport = nullptr;
+    QAction* toggleRemoteRenderingAction = nullptr;
 };
 
 MainWindow::MainWindow(QWidget* parent)
@@ -231,6 +236,10 @@ void MainWindow::setupUI()
     impl_->layoutManager = new ViewportLayoutManager(this);
     impl_->viewport = impl_->layoutManager->primaryViewport();
     impl_->centralStack->addWidget(impl_->layoutManager);
+
+    // Page 2: Remote rendering viewport
+    impl_->remoteViewport = new RemoteViewportWidget(this);
+    impl_->centralStack->addWidget(impl_->remoteViewport);
 
     // Start on intro page
     impl_->centralStack->setCurrentIndex(0);
@@ -531,6 +540,31 @@ void MainWindow::setupMenuBar()
 
     auto cascadeAction = displayMenu->addAction(tr("&Cascade Windows"));
     auto tileAction = displayMenu->addAction(tr("&Tile Windows"));
+
+    displayMenu->addSeparator();
+
+    impl_->toggleRemoteRenderingAction = displayMenu->addAction(
+        tr("Remote &Rendering Mode"));
+    impl_->toggleRemoteRenderingAction->setCheckable(true);
+    impl_->toggleRemoteRenderingAction->setChecked(false);
+    impl_->toggleRemoteRenderingAction->setShortcut(
+        QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_R));
+    connect(impl_->toggleRemoteRenderingAction, &QAction::toggled,
+            this, [this](bool enabled) {
+        if (enabled) {
+            QSettings settings;
+            QString host = settings.value("remote/host", "localhost").toString();
+            uint16_t port = static_cast<uint16_t>(
+                settings.value("remote/port", 8081).toInt());
+            QString sessionId = "default";
+
+            impl_->remoteViewport->connectToServer(host, port, sessionId);
+            impl_->centralStack->setCurrentIndex(2);
+        } else {
+            impl_->remoteViewport->disconnectFromServer();
+            impl_->centralStack->setCurrentIndex(1);
+        }
+    });
 
     // =========================================================================
     // Measure menu — distance, angle, ROI, quantification
@@ -1798,7 +1832,12 @@ void MainWindow::onToggleStorageSCP()
 void MainWindow::onShowSettings()
 {
     SettingsDialog dialog(this);
-    dialog.exec();
+    if (dialog.exec() == QDialog::Accepted) {
+        bool remoteEnabled = dialog.isRemoteRenderingEnabled();
+        if (impl_->toggleRemoteRenderingAction->isChecked() != remoteEnabled) {
+            impl_->toggleRemoteRenderingAction->setChecked(remoteEnabled);
+        }
+    }
 }
 
 void MainWindow::onShowAbout()

--- a/src/ui/widgets/remote_viewport_widget.cpp
+++ b/src/ui/widgets/remote_viewport_widget.cpp
@@ -29,10 +29,13 @@
 
 #include "ui/widgets/remote_viewport_widget.hpp"
 
+#include <QAction>
+#include <QContextMenuEvent>
 #include <QImage>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QKeyEvent>
+#include <QMenu>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPaintEvent>
@@ -43,6 +46,7 @@
 
 #include <chrono>
 #include <cstring>
+#include <deque>
 
 namespace dicom_viewer::ui {
 
@@ -93,6 +97,22 @@ public:
     }
 
     QImage currentFrame_;
+    bool showStatistics_ = false;
+    std::deque<std::chrono::steady_clock::time_point> frameTimestamps_;
+
+    double currentFps() const
+    {
+        if (frameTimestamps_.size() < 2) {
+            return 0.0;
+        }
+        auto elapsed = std::chrono::duration<double>(
+            frameTimestamps_.back() - frameTimestamps_.front());
+        if (elapsed.count() <= 0.0) {
+            return 0.0;
+        }
+        return static_cast<double>(frameTimestamps_.size() - 1)
+               / elapsed.count();
+    }
 
 private:
     void setupConnections()
@@ -179,6 +199,12 @@ private:
         currentFrame_ = std::move(frame);
         lastFrameSeq_ = header.frameSeq;
         ++framesReceived_;
+
+        // Track frame timestamps for FPS calculation (keep last 60 samples)
+        frameTimestamps_.push_back(std::chrono::steady_clock::now());
+        while (frameTimestamps_.size() > 60) {
+            frameTimestamps_.pop_front();
+        }
 
         owner_->update();
         emit owner_->frameDisplayed(header.frameSeq);
@@ -367,6 +393,33 @@ void RemoteViewportWidget::paintEvent(QPaintEvent* /*event*/)
             painter.setPen(Qt::white);
             painter.drawText(widgetRect, Qt::AlignCenter, statusText);
         }
+    }
+
+    // Frame statistics overlay (bottom-left corner)
+    if (impl_->showStatistics_
+        && impl_->state() == RemoteConnectionState::Connected) {
+        double fps = impl_->currentFps();
+        QString statsText = QString("FPS: %1 | Frames: %2 | Seq: %3")
+                                .arg(fps, 0, 'f', 1)
+                                .arg(impl_->framesReceived())
+                                .arg(impl_->lastFrameSeq());
+
+        QFont statsFont = painter.font();
+        statsFont.setPointSize(10);
+        painter.setFont(statsFont);
+
+        QFontMetrics sfm(statsFont);
+        QRect statsRect = sfm.boundingRect(statsText);
+        statsRect.moveBottomLeft(
+            QPoint(8, widgetRect.height() - 8));
+        statsRect.adjust(-4, -2, 4, 2);
+
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(QColor(0, 0, 0, 180));
+        painter.drawRoundedRect(statsRect, 4, 4);
+
+        painter.setPen(QColor(0, 255, 0));
+        painter.drawText(statsRect, Qt::AlignCenter, statsText);
     }
 }
 
@@ -597,6 +650,27 @@ void RemoteViewportWidget::keyReleaseEvent(QKeyEvent* event)
 
     impl_->sendInputEvent(json);
     emit inputEventSent("key_up");
+    event->accept();
+}
+
+void RemoteViewportWidget::setShowStatistics(bool show)
+{
+    impl_->showStatistics_ = show;
+    update();
+}
+
+void RemoteViewportWidget::contextMenuEvent(QContextMenuEvent* event)
+{
+    QMenu menu(this);
+
+    auto* statsAction = menu.addAction(tr("Show Statistics"));
+    statsAction->setCheckable(true);
+    statsAction->setChecked(impl_->showStatistics_);
+
+    connect(statsAction, &QAction::toggled,
+            this, &RemoteViewportWidget::setShowStatistics);
+
+    menu.exec(event->globalPos());
     event->accept();
 }
 

--- a/tests/unit/remote_viewport_widget_test.cpp
+++ b/tests/unit/remote_viewport_widget_test.cpp
@@ -476,3 +476,16 @@ TEST_F(RemoteViewportWidgetTest, SerializeAllModifiers) {
     EXPECT_TRUE(obj["ctrl"].toBool());
     EXPECT_TRUE(obj["alt"].toBool());
 }
+
+// =============================================================================
+// Statistics overlay
+// =============================================================================
+
+TEST_F(RemoteViewportWidgetTest, SetShowStatisticsDoesNotCrash) {
+    RemoteViewportWidget widget;
+
+    // Toggle statistics on/off without connection
+    widget.setShowStatistics(true);
+    widget.setShowStatistics(false);
+    // No crash = success
+}

--- a/tests/unit/settings_dialog_test.cpp
+++ b/tests/unit/settings_dialog_test.cpp
@@ -30,11 +30,14 @@
 #include <gtest/gtest.h>
 
 #include <QApplication>
+#include <QCheckBox>
 #include <QComboBox>
 #include <QDialogButtonBox>
 #include <QLabel>
+#include <QLineEdit>
 #include <QPushButton>
 #include <QSettings>
+#include <QSpinBox>
 
 #include "ui/dialogs/settings_dialog.hpp"
 #include "core/app_log_level.hpp"
@@ -178,4 +181,121 @@ TEST(SettingsDialogTest, CancelDoesNotSave) {
 
     // Clean up
     settings.remove("logging/level");
+}
+
+// =============================================================================
+// Remote rendering settings
+// =============================================================================
+
+TEST(SettingsDialogTest, RemoteRenderingDefaultDisabled) {
+    QSettings settings;
+    settings.remove("remote/enabled");
+    settings.remove("remote/host");
+    settings.remove("remote/port");
+    settings.sync();
+
+    SettingsDialog dialog;
+    EXPECT_FALSE(dialog.isRemoteRenderingEnabled());
+    EXPECT_EQ(dialog.remoteHost(), "localhost");
+    EXPECT_EQ(dialog.remotePort(), 8081);
+
+    settings.remove("remote/enabled");
+    settings.remove("remote/host");
+    settings.remove("remote/port");
+}
+
+TEST(SettingsDialogTest, RemoteRenderingLoadFromSettings) {
+    QSettings settings;
+    settings.setValue("remote/enabled", true);
+    settings.setValue("remote/host", "render-server");
+    settings.setValue("remote/port", 9090);
+    settings.sync();
+
+    SettingsDialog dialog;
+    EXPECT_TRUE(dialog.isRemoteRenderingEnabled());
+    EXPECT_EQ(dialog.remoteHost(), "render-server");
+    EXPECT_EQ(dialog.remotePort(), 9090);
+
+    settings.remove("remote/enabled");
+    settings.remove("remote/host");
+    settings.remove("remote/port");
+}
+
+TEST(SettingsDialogTest, RemoteRenderingSavesToSettings) {
+    QSettings settings;
+    settings.remove("remote/enabled");
+    settings.remove("remote/host");
+    settings.remove("remote/port");
+    settings.sync();
+
+    SettingsDialog dialog;
+
+    auto* check = dialog.findChild<QCheckBox*>();
+    ASSERT_NE(check, nullptr);
+    check->setChecked(true);
+
+    auto* hostEdit = dialog.findChild<QLineEdit*>();
+    ASSERT_NE(hostEdit, nullptr);
+    hostEdit->setText("my-server");
+
+    auto* portSpin = dialog.findChild<QSpinBox*>();
+    ASSERT_NE(portSpin, nullptr);
+    portSpin->setValue(3000);
+
+    dialog.accept();
+
+    settings.sync();
+    EXPECT_TRUE(settings.value("remote/enabled").toBool());
+    EXPECT_EQ(settings.value("remote/host").toString(), "my-server");
+    EXPECT_EQ(settings.value("remote/port").toInt(), 3000);
+
+    settings.remove("remote/enabled");
+    settings.remove("remote/host");
+    settings.remove("remote/port");
+}
+
+TEST(SettingsDialogTest, RemoteEmptyHostNormalizesToLocalhost) {
+    QSettings settings;
+    settings.remove("remote/host");
+    settings.sync();
+
+    SettingsDialog dialog;
+
+    auto* hostEdit = dialog.findChild<QLineEdit*>();
+    ASSERT_NE(hostEdit, nullptr);
+    hostEdit->setText("   ");
+
+    dialog.accept();
+
+    settings.sync();
+    EXPECT_EQ(settings.value("remote/host").toString(), "localhost");
+
+    settings.remove("remote/enabled");
+    settings.remove("remote/host");
+    settings.remove("remote/port");
+}
+
+TEST(SettingsDialogTest, RemoteHostPortDisabledWhenUnchecked) {
+    QSettings settings;
+    settings.remove("remote/enabled");
+    settings.sync();
+
+    SettingsDialog dialog;
+
+    auto* hostEdit = dialog.findChild<QLineEdit*>();
+    auto* portSpin = dialog.findChild<QSpinBox*>();
+    ASSERT_NE(hostEdit, nullptr);
+    ASSERT_NE(portSpin, nullptr);
+
+    EXPECT_FALSE(hostEdit->isEnabled());
+    EXPECT_FALSE(portSpin->isEnabled());
+
+    auto* check = dialog.findChild<QCheckBox*>();
+    ASSERT_NE(check, nullptr);
+    check->setChecked(true);
+
+    EXPECT_TRUE(hostEdit->isEnabled());
+    EXPECT_TRUE(portSpin->isEnabled());
+
+    settings.remove("remote/enabled");
 }


### PR DESCRIPTION
Closes #485

## Summary
- Add **Remote Rendering** group box to `SettingsDialog` with enable checkbox, server host field (default: localhost), and port spinner (default: 8081), all persisted via `QSettings`
- Add `RemoteViewportWidget` as page 2 in `MainWindow`'s `QStackedWidget`, with **Remote Rendering Mode** toggle action (`Ctrl+Shift+R`) in the Display menu
- Add **frame statistics overlay** (FPS, frame count, sequence number) to `RemoteViewportWidget`, toggled via right-click context menu
- Sync `MainWindow` toggle action state with `SettingsDialog` remote enabled setting on dialog accept

## Test Plan
- [x] 13 settings dialog tests pass (8 existing + 5 new remote rendering tests)
- [x] 28 remote viewport widget tests pass (27 existing + 1 new statistics overlay test)
- [x] Full build succeeds with no new warnings
- [ ] Manual: Open Preferences, toggle Remote Rendering, verify host/port fields enable/disable
- [ ] Manual: Use Ctrl+Shift+R to toggle remote rendering mode, verify page switch
- [ ] Manual: Right-click RemoteViewportWidget and toggle Show Statistics overlay