### PR TITLE
feat(rendering): implement adaptive quality control for render streaming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,6 +541,7 @@ add_library(render_service STATIC
     src/services/render/websocket_frame_streamer.cpp
     src/services/render/input_event_dispatcher.cpp
     src/services/render/render_session_manager.cpp
+    src/services/render/adaptive_quality_controller.cpp
 )
 
 # Crow WebSocket framework (header-only)

--- a/include/services/render/adaptive_quality_controller.hpp
+++ b/include/services/render/adaptive_quality_controller.hpp
@@ -1,0 +1,161 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file adaptive_quality_controller.hpp
+ * @brief Adaptive JPEG quality controller for render streaming
+ * @details Manages quality transitions between interaction and idle states
+ *          to balance latency during user interaction with image quality at rest.
+ *
+ * ## State Machine
+ * ```
+ * Idle ──(onInteractionStart)──> Interacting
+ * Interacting ──(onInteractionEnd)──> PostInteraction
+ * PostInteraction ──(debounce expires)──> Idle
+ * PostInteraction ──(onInteractionStart)──> Interacting
+ * ```
+ *
+ * ## Thread Safety
+ * - All methods are thread-safe (internal mutex)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Quality state for the adaptive controller
+ */
+enum class QualityState {
+    Idle,              ///< No interaction — high quality, no frame emission
+    Interacting,       ///< Active interaction — low quality, high FPS
+    PostInteraction    ///< Debounce period — emit one high-quality frame
+};
+
+/**
+ * @brief Configuration for adaptive quality control
+ */
+struct AdaptiveQualityConfig {
+    /// JPEG quality during interaction (1-100)
+    int interactionQuality = 40;
+
+    /// JPEG quality at rest / post-interaction (1-100)
+    int idleQuality = 85;
+
+    /// Target FPS during interaction
+    uint32_t interactionFps = 30;
+
+    /// Target FPS at rest (on-change only)
+    uint32_t idleFps = 1;
+
+    /// Debounce timeout in milliseconds after interaction ends
+    uint32_t debounceMs = 100;
+};
+
+/**
+ * @brief Adaptive quality controller for render streaming
+ *
+ * Tracks interaction state and provides the appropriate JPEG quality
+ * and FPS target for the current moment. During interaction, quality
+ * drops and FPS rises; after interaction stops, one high-quality
+ * frame is emitted before entering idle mode.
+ *
+ * @trace SRS-FR-REMOTE-007
+ */
+class AdaptiveQualityController {
+public:
+    explicit AdaptiveQualityController(
+        const AdaptiveQualityConfig& config = {});
+    ~AdaptiveQualityController();
+
+    // Non-copyable, movable
+    AdaptiveQualityController(const AdaptiveQualityController&) = delete;
+    AdaptiveQualityController& operator=(const AdaptiveQualityController&)
+        = delete;
+    AdaptiveQualityController(AdaptiveQualityController&&) noexcept;
+    AdaptiveQualityController& operator=(
+        AdaptiveQualityController&&) noexcept;
+
+    /**
+     * @brief Signal that user interaction has started (e.g., mouse_down)
+     */
+    void onInteractionStart();
+
+    /**
+     * @brief Signal that user interaction has ended (e.g., mouse_up)
+     */
+    void onInteractionEnd();
+
+    /**
+     * @brief Get current quality state
+     */
+    [[nodiscard]] QualityState state() const;
+
+    /**
+     * @brief Get the JPEG quality to use for the current state
+     * @return Quality value 1-100
+     */
+    [[nodiscard]] int currentQuality() const;
+
+    /**
+     * @brief Get the target FPS for the current state
+     */
+    [[nodiscard]] uint32_t currentTargetFps() const;
+
+    /**
+     * @brief Check whether a frame should be emitted in the current state
+     * @details In Idle state, returns false (no frames unless data changes).
+     *          In Interacting state, always returns true.
+     *          In PostInteraction state, returns true once (for the final
+     *          high-quality frame), then transitions to Idle.
+     */
+    [[nodiscard]] bool shouldEmitFrame();
+
+    /**
+     * @brief Update the configuration
+     */
+    void setConfig(const AdaptiveQualityConfig& config);
+
+    /**
+     * @brief Get the current configuration
+     */
+    [[nodiscard]] const AdaptiveQualityConfig& config() const;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::services

--- a/include/services/render/render_session_manager.hpp
+++ b/include/services/render/render_session_manager.hpp
@@ -63,6 +63,7 @@
 
 namespace dicom_viewer::services {
 
+class AdaptiveQualityController;
 class RenderSession;
 
 /**
@@ -149,6 +150,27 @@ public:
      * @brief Reset the idle timer for a session (e.g., on input event)
      */
     void touchSession(const std::string& sessionId);
+
+    /**
+     * @brief Notify that user interaction started on a session
+     * @details Transitions quality controller to low-quality high-FPS mode
+     * @param sessionId Session receiving interaction
+     */
+    void notifyInteractionStart(const std::string& sessionId);
+
+    /**
+     * @brief Notify that user interaction ended on a session
+     * @details Starts debounce timer for high-quality frame emission
+     * @param sessionId Session where interaction ended
+     */
+    void notifyInteractionEnd(const std::string& sessionId);
+
+    /**
+     * @brief Get the quality controller for a session
+     * @return Pointer to controller, or nullptr if session not found
+     */
+    [[nodiscard]] AdaptiveQualityController* getQualityController(
+        const std::string& sessionId);
 
     /**
      * @brief Set callback for rendered frame delivery

--- a/src/services/render/adaptive_quality_controller.cpp
+++ b/src/services/render/adaptive_quality_controller.cpp
@@ -1,0 +1,207 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "services/render/adaptive_quality_controller.hpp"
+
+#include <chrono>
+#include <mutex>
+
+namespace dicom_viewer::services {
+
+// ---------------------------------------------------------------------------
+// Impl
+// ---------------------------------------------------------------------------
+class AdaptiveQualityController::Impl {
+public:
+    explicit Impl(const AdaptiveQualityConfig& config)
+        : config_(config)
+    {
+    }
+
+    void onInteractionStart()
+    {
+        std::lock_guard lock(mutex_);
+        state_ = QualityState::Interacting;
+        postInteractionFrameEmitted_ = false;
+    }
+
+    void onInteractionEnd()
+    {
+        std::lock_guard lock(mutex_);
+        if (state_ != QualityState::Interacting) {
+            return;
+        }
+        state_ = QualityState::PostInteraction;
+        interactionEndTime_ = std::chrono::steady_clock::now();
+        postInteractionFrameEmitted_ = false;
+    }
+
+    QualityState state() const
+    {
+        std::lock_guard lock(mutex_);
+        return state_;
+    }
+
+    int currentQuality() const
+    {
+        std::lock_guard lock(mutex_);
+        switch (state_) {
+        case QualityState::Interacting:
+            return config_.interactionQuality;
+        case QualityState::PostInteraction:
+        case QualityState::Idle:
+            return config_.idleQuality;
+        }
+        return config_.idleQuality;
+    }
+
+    uint32_t currentTargetFps() const
+    {
+        std::lock_guard lock(mutex_);
+        switch (state_) {
+        case QualityState::Interacting:
+            return config_.interactionFps;
+        case QualityState::PostInteraction:
+        case QualityState::Idle:
+            return config_.idleFps;
+        }
+        return config_.idleFps;
+    }
+
+    bool shouldEmitFrame()
+    {
+        std::lock_guard lock(mutex_);
+        switch (state_) {
+        case QualityState::Idle:
+            return false;
+
+        case QualityState::Interacting:
+            return true;
+
+        case QualityState::PostInteraction: {
+            auto elapsed = std::chrono::steady_clock::now() - interactionEndTime_;
+            auto debounce = std::chrono::milliseconds(config_.debounceMs);
+
+            if (elapsed < debounce) {
+                // Still within debounce window — no frame yet
+                return false;
+            }
+
+            if (!postInteractionFrameEmitted_) {
+                // Emit one high-quality frame
+                postInteractionFrameEmitted_ = true;
+                return true;
+            }
+
+            // High-quality frame already emitted — transition to Idle
+            state_ = QualityState::Idle;
+            return false;
+        }
+        }
+        return false;
+    }
+
+    void setConfig(const AdaptiveQualityConfig& config)
+    {
+        std::lock_guard lock(mutex_);
+        config_ = config;
+    }
+
+    const AdaptiveQualityConfig& config() const
+    {
+        std::lock_guard lock(mutex_);
+        return config_;
+    }
+
+private:
+    mutable std::mutex mutex_;
+    AdaptiveQualityConfig config_;
+    QualityState state_ = QualityState::Idle;
+    std::chrono::steady_clock::time_point interactionEndTime_;
+    bool postInteractionFrameEmitted_ = false;
+};
+
+// ---------------------------------------------------------------------------
+// AdaptiveQualityController lifecycle
+// ---------------------------------------------------------------------------
+AdaptiveQualityController::AdaptiveQualityController(
+    const AdaptiveQualityConfig& config)
+    : impl_(std::make_unique<Impl>(config))
+{
+}
+
+AdaptiveQualityController::~AdaptiveQualityController() = default;
+
+AdaptiveQualityController::AdaptiveQualityController(
+    AdaptiveQualityController&&) noexcept = default;
+
+AdaptiveQualityController& AdaptiveQualityController::operator=(
+    AdaptiveQualityController&&) noexcept = default;
+
+void AdaptiveQualityController::onInteractionStart()
+{
+    impl_->onInteractionStart();
+}
+
+void AdaptiveQualityController::onInteractionEnd()
+{
+    impl_->onInteractionEnd();
+}
+
+QualityState AdaptiveQualityController::state() const
+{
+    return impl_->state();
+}
+
+int AdaptiveQualityController::currentQuality() const
+{
+    return impl_->currentQuality();
+}
+
+uint32_t AdaptiveQualityController::currentTargetFps() const
+{
+    return impl_->currentTargetFps();
+}
+
+bool AdaptiveQualityController::shouldEmitFrame()
+{
+    return impl_->shouldEmitFrame();
+}
+
+void AdaptiveQualityController::setConfig(const AdaptiveQualityConfig& config)
+{
+    impl_->setConfig(config);
+}
+
+const AdaptiveQualityConfig& AdaptiveQualityController::config() const
+{
+    return impl_->config();
+}
+
+} // namespace dicom_viewer::services

--- a/src/services/render/render_session_manager.cpp
+++ b/src/services/render/render_session_manager.cpp
@@ -28,6 +28,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "services/render/render_session_manager.hpp"
+#include "services/render/adaptive_quality_controller.hpp"
 #include "services/render/render_session.hpp"
 
 #include <atomic>
@@ -50,6 +51,7 @@ public:
         uint32_t width;
         uint32_t height;
         uint32_t frameSeq = 0;
+        AdaptiveQualityController qualityController;
     };
 
     explicit Impl(const RenderSessionManagerConfig& config) : config_(config) {}
@@ -112,6 +114,36 @@ public:
         if (it != sessions_.end()) {
             it->second.lastActive = std::chrono::steady_clock::now();
         }
+    }
+
+    void notifyInteractionStart(const std::string& sessionId)
+    {
+        std::lock_guard lock(mutex_);
+        auto it = sessions_.find(sessionId);
+        if (it != sessions_.end()) {
+            it->second.qualityController.onInteractionStart();
+            it->second.lastActive = std::chrono::steady_clock::now();
+        }
+    }
+
+    void notifyInteractionEnd(const std::string& sessionId)
+    {
+        std::lock_guard lock(mutex_);
+        auto it = sessions_.find(sessionId);
+        if (it != sessions_.end()) {
+            it->second.qualityController.onInteractionEnd();
+        }
+    }
+
+    AdaptiveQualityController* getQualityController(
+        const std::string& sessionId)
+    {
+        std::lock_guard lock(mutex_);
+        auto it = sessions_.find(sessionId);
+        if (it == sessions_.end()) {
+            return nullptr;
+        }
+        return &it->second.qualityController;
     }
 
     void setFrameReadyCallback(FrameReadyCallback callback)
@@ -243,6 +275,12 @@ private:
             }
 
             auto& entry = it->second;
+
+            // Check adaptive quality controller
+            if (!entry.qualityController.shouldEmitFrame()) {
+                continue;
+            }
+
             auto frame = entry.session->captureVolumeFrame();
             if (!frame.empty()) {
                 cb(id, frame, entry.width, entry.height);
@@ -298,6 +336,24 @@ RenderSession* RenderSessionManager::getSession(const std::string& sessionId)
 void RenderSessionManager::touchSession(const std::string& sessionId)
 {
     impl_->touchSession(sessionId);
+}
+
+void RenderSessionManager::notifyInteractionStart(
+    const std::string& sessionId)
+{
+    impl_->notifyInteractionStart(sessionId);
+}
+
+void RenderSessionManager::notifyInteractionEnd(
+    const std::string& sessionId)
+{
+    impl_->notifyInteractionEnd(sessionId);
+}
+
+AdaptiveQualityController* RenderSessionManager::getQualityController(
+    const std::string& sessionId)
+{
+    return impl_->getQualityController(sessionId);
 }
 
 void RenderSessionManager::setFrameReadyCallback(FrameReadyCallback callback)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2105,6 +2105,23 @@ target_include_directories(frame_encoder_test PRIVATE
 
 gtest_discover_tests(frame_encoder_test DISCOVERY_TIMEOUT 60)
 
+# Unit tests for AdaptiveQualityController
+add_executable(adaptive_quality_controller_test
+    unit/adaptive_quality_controller_test.cpp
+)
+
+target_link_libraries(adaptive_quality_controller_test PRIVATE
+    render_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(adaptive_quality_controller_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(adaptive_quality_controller_test DISCOVERY_TIMEOUT 60)
+
 # Unit tests for WebSocketFrameStreamer
 add_executable(websocket_frame_streamer_test
     unit/websocket_frame_streamer_test.cpp

--- a/tests/unit/adaptive_quality_controller_test.cpp
+++ b/tests/unit/adaptive_quality_controller_test.cpp
@@ -1,0 +1,264 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include "services/render/adaptive_quality_controller.hpp"
+
+#include <chrono>
+#include <thread>
+
+using namespace dicom_viewer::services;
+
+// =============================================================================
+// Default construction and initial state
+// =============================================================================
+
+TEST(AdaptiveQualityControllerTest, DefaultConstruction) {
+    AdaptiveQualityController controller;
+    EXPECT_EQ(controller.state(), QualityState::Idle);
+}
+
+TEST(AdaptiveQualityControllerTest, DefaultConfigValues) {
+    AdaptiveQualityController controller;
+    const auto& cfg = controller.config();
+    EXPECT_EQ(cfg.interactionQuality, 40);
+    EXPECT_EQ(cfg.idleQuality, 85);
+    EXPECT_EQ(cfg.interactionFps, 30u);
+    EXPECT_EQ(cfg.idleFps, 1u);
+    EXPECT_EQ(cfg.debounceMs, 100u);
+}
+
+TEST(AdaptiveQualityControllerTest, IdleStateQuality) {
+    AdaptiveQualityController controller;
+    EXPECT_EQ(controller.currentQuality(), 85);
+    EXPECT_EQ(controller.currentTargetFps(), 1u);
+}
+
+TEST(AdaptiveQualityControllerTest, IdleDoesNotEmitFrame) {
+    AdaptiveQualityController controller;
+    EXPECT_FALSE(controller.shouldEmitFrame());
+}
+
+// =============================================================================
+// Interaction start transitions
+// =============================================================================
+
+TEST(AdaptiveQualityControllerTest, InteractionStartTransitionsToInteracting) {
+    AdaptiveQualityController controller;
+    controller.onInteractionStart();
+    EXPECT_EQ(controller.state(), QualityState::Interacting);
+}
+
+TEST(AdaptiveQualityControllerTest, InteractingStateQuality) {
+    AdaptiveQualityController controller;
+    controller.onInteractionStart();
+    EXPECT_EQ(controller.currentQuality(), 40);
+    EXPECT_EQ(controller.currentTargetFps(), 30u);
+}
+
+TEST(AdaptiveQualityControllerTest, InteractingEmitsFrames) {
+    AdaptiveQualityController controller;
+    controller.onInteractionStart();
+    EXPECT_TRUE(controller.shouldEmitFrame());
+    EXPECT_TRUE(controller.shouldEmitFrame());
+}
+
+// =============================================================================
+// Interaction end transitions
+// =============================================================================
+
+TEST(AdaptiveQualityControllerTest, InteractionEndTransitionsToPostInteraction) {
+    AdaptiveQualityController controller;
+    controller.onInteractionStart();
+    controller.onInteractionEnd();
+    EXPECT_EQ(controller.state(), QualityState::PostInteraction);
+}
+
+TEST(AdaptiveQualityControllerTest, PostInteractionQualityIsHigh) {
+    AdaptiveQualityController controller;
+    controller.onInteractionStart();
+    controller.onInteractionEnd();
+    EXPECT_EQ(controller.currentQuality(), 85);
+}
+
+TEST(AdaptiveQualityControllerTest, InteractionEndFromIdleIsNoop) {
+    AdaptiveQualityController controller;
+    controller.onInteractionEnd();
+    EXPECT_EQ(controller.state(), QualityState::Idle);
+}
+
+// =============================================================================
+// Debounce and post-interaction frame emission
+// =============================================================================
+
+TEST(AdaptiveQualityControllerTest, PostInteractionDebounce) {
+    AdaptiveQualityConfig config;
+    config.debounceMs = 10; // Short debounce for testing
+    AdaptiveQualityController controller(config);
+
+    controller.onInteractionStart();
+    controller.onInteractionEnd();
+
+    // Immediately after end — within debounce, no frame
+    EXPECT_FALSE(controller.shouldEmitFrame());
+
+    // Wait for debounce to expire
+    std::this_thread::sleep_for(std::chrono::milliseconds(15));
+
+    // First call after debounce — emit high-quality frame
+    EXPECT_TRUE(controller.shouldEmitFrame());
+
+    // Second call — transitions to Idle, no more frames
+    EXPECT_FALSE(controller.shouldEmitFrame());
+    EXPECT_EQ(controller.state(), QualityState::Idle);
+}
+
+// =============================================================================
+// Re-interaction during post-interaction
+// =============================================================================
+
+TEST(AdaptiveQualityControllerTest, ReinteractionDuringPostInteraction) {
+    AdaptiveQualityConfig config;
+    config.debounceMs = 50;
+    AdaptiveQualityController controller(config);
+
+    controller.onInteractionStart();
+    controller.onInteractionEnd();
+    EXPECT_EQ(controller.state(), QualityState::PostInteraction);
+
+    // Start interacting again before debounce expires
+    controller.onInteractionStart();
+    EXPECT_EQ(controller.state(), QualityState::Interacting);
+    EXPECT_EQ(controller.currentQuality(), 40);
+    EXPECT_TRUE(controller.shouldEmitFrame());
+}
+
+// =============================================================================
+// Full cycle: Idle -> Interacting -> PostInteraction -> Idle
+// =============================================================================
+
+TEST(AdaptiveQualityControllerTest, FullCycle) {
+    AdaptiveQualityConfig config;
+    config.debounceMs = 5;
+    AdaptiveQualityController controller(config);
+
+    // Start idle
+    EXPECT_EQ(controller.state(), QualityState::Idle);
+    EXPECT_FALSE(controller.shouldEmitFrame());
+
+    // Begin interaction
+    controller.onInteractionStart();
+    EXPECT_EQ(controller.state(), QualityState::Interacting);
+    EXPECT_EQ(controller.currentQuality(), 40);
+    EXPECT_TRUE(controller.shouldEmitFrame());
+
+    // End interaction
+    controller.onInteractionEnd();
+    EXPECT_EQ(controller.state(), QualityState::PostInteraction);
+    EXPECT_EQ(controller.currentQuality(), 85);
+
+    // Wait for debounce
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    // Emit final high-quality frame
+    EXPECT_TRUE(controller.shouldEmitFrame());
+
+    // Transition to idle
+    EXPECT_FALSE(controller.shouldEmitFrame());
+    EXPECT_EQ(controller.state(), QualityState::Idle);
+}
+
+// =============================================================================
+// Custom configuration
+// =============================================================================
+
+TEST(AdaptiveQualityControllerTest, CustomConfig) {
+    AdaptiveQualityConfig config;
+    config.interactionQuality = 30;
+    config.idleQuality = 90;
+    config.interactionFps = 60;
+    config.idleFps = 5;
+    config.debounceMs = 200;
+
+    AdaptiveQualityController controller(config);
+
+    EXPECT_EQ(controller.currentQuality(), 90);
+    EXPECT_EQ(controller.currentTargetFps(), 5u);
+
+    controller.onInteractionStart();
+    EXPECT_EQ(controller.currentQuality(), 30);
+    EXPECT_EQ(controller.currentTargetFps(), 60u);
+}
+
+TEST(AdaptiveQualityControllerTest, SetConfigUpdatesValues) {
+    AdaptiveQualityController controller;
+    EXPECT_EQ(controller.currentQuality(), 85);
+
+    AdaptiveQualityConfig newConfig;
+    newConfig.idleQuality = 95;
+    controller.setConfig(newConfig);
+    EXPECT_EQ(controller.currentQuality(), 95);
+}
+
+// =============================================================================
+// Move semantics
+// =============================================================================
+
+TEST(AdaptiveQualityControllerTest, MoveConstruction) {
+    AdaptiveQualityController a;
+    a.onInteractionStart();
+    EXPECT_EQ(a.state(), QualityState::Interacting);
+
+    AdaptiveQualityController b(std::move(a));
+    EXPECT_EQ(b.state(), QualityState::Interacting);
+    EXPECT_EQ(b.currentQuality(), 40);
+}
+
+TEST(AdaptiveQualityControllerTest, MoveAssignment) {
+    AdaptiveQualityController a;
+    a.onInteractionStart();
+
+    AdaptiveQualityController b;
+    b = std::move(a);
+    EXPECT_EQ(b.state(), QualityState::Interacting);
+}
+
+// =============================================================================
+// QualityState enum distinctness
+// =============================================================================
+
+TEST(AdaptiveQualityControllerTest, QualityStateEnumValues) {
+    EXPECT_NE(static_cast<int>(QualityState::Idle),
+              static_cast<int>(QualityState::Interacting));
+    EXPECT_NE(static_cast<int>(QualityState::Interacting),
+              static_cast<int>(QualityState::PostInteraction));
+    EXPECT_NE(static_cast<int>(QualityState::Idle),
+              static_cast<int>(QualityState::PostInteraction));
+}

--- a/tests/unit/render_session_manager_test.cpp
+++ b/tests/unit/render_session_manager_test.cpp
@@ -30,6 +30,7 @@
 #include <gtest/gtest.h>
 
 #include "services/render/render_session_manager.hpp"
+#include "services/render/adaptive_quality_controller.hpp"
 #include "services/render/render_session.hpp"
 
 #include <algorithm>
@@ -469,4 +470,59 @@ TEST_F(RenderSessionManagerTest, GetSessionReturnsValidPointer) {
 
     // The RenderSession should be a valid object we can interact with
     // (VolumeRenderer and MPRRenderer are initialized in off-screen mode)
+}
+
+// =============================================================================
+// Adaptive quality controller integration
+// =============================================================================
+
+TEST_F(RenderSessionManagerTest, GetQualityControllerReturnsNullForMissing) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    EXPECT_EQ(mgr.getQualityController("nonexistent"), nullptr);
+}
+
+TEST_F(RenderSessionManagerTest, GetQualityControllerReturnsValidPointer) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    mgr.createSession("s1");
+    auto* qc = mgr.getQualityController("s1");
+    ASSERT_NE(qc, nullptr);
+    EXPECT_EQ(qc->state(), QualityState::Idle);
+}
+
+TEST_F(RenderSessionManagerTest, NotifyInteractionStartChangesState) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    mgr.createSession("s1");
+    mgr.notifyInteractionStart("s1");
+
+    auto* qc = mgr.getQualityController("s1");
+    ASSERT_NE(qc, nullptr);
+    EXPECT_EQ(qc->state(), QualityState::Interacting);
+}
+
+TEST_F(RenderSessionManagerTest, NotifyInteractionEndChangesState) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    mgr.createSession("s1");
+    mgr.notifyInteractionStart("s1");
+    mgr.notifyInteractionEnd("s1");
+
+    auto* qc = mgr.getQualityController("s1");
+    ASSERT_NE(qc, nullptr);
+    EXPECT_EQ(qc->state(), QualityState::PostInteraction);
+}
+
+TEST_F(RenderSessionManagerTest, NotifyInteractionOnMissingSessionIsNoop) {
+    auto cfg = defaultConfig();
+    RenderSessionManager mgr(cfg);
+
+    // Should not crash
+    mgr.notifyInteractionStart("nonexistent");
+    mgr.notifyInteractionEnd("nonexistent");
 }


### PR DESCRIPTION
Closes #475

## Summary
- Add `AdaptiveQualityController` class with a 3-state machine (Idle, Interacting, PostInteraction) that dynamically adjusts JPEG quality and FPS targets based on user interaction
- Integrate quality controller into `RenderSessionManager` — each session owns a quality controller, and `renderAllSessions()` gates frame emission via `shouldEmitFrame()`
- Add `notifyInteractionStart/End()` and `getQualityController()` public API to `RenderSessionManager` for wiring input events to quality transitions

## Design

### State Machine
```
Idle --(onInteractionStart)--> Interacting --(onInteractionEnd)--> PostInteraction --(debounce)--> Idle
```

### Quality Parameters
| State | Quality | FPS | Bandwidth (1024x768) |
|-------|---------|-----|---------------------|
| Idle | q=85 | 0 (on-change) | ~0 Kbps |
| Interacting | q=40 | 30 | ~6 Mbps |
| PostInteraction | q=85 | 1 (single frame) | ~0.8 Mbps |

## Test Plan
- [x] 18 AdaptiveQualityController unit tests pass (state transitions, debounce, config, move semantics)
- [x] 34 RenderSessionManager tests pass (29 existing + 5 new quality integration tests)
- [x] Full build succeeds with no new warnings