### PR TITLE
feat(rendering): implement dirty region delta frame updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -542,6 +542,7 @@ add_library(render_service STATIC
     src/services/render/input_event_dispatcher.cpp
     src/services/render/render_session_manager.cpp
     src/services/render/adaptive_quality_controller.cpp
+    src/services/render/dirty_region_tracker.cpp
 )
 
 # Crow WebSocket framework (header-only)

--- a/include/services/render/dirty_region_tracker.hpp
+++ b/include/services/render/dirty_region_tracker.hpp
@@ -1,0 +1,160 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file dirty_region_tracker.hpp
+ * @brief Tracks changed pixel regions between consecutive rendered frames
+ * @details Computes XOR between two RGBA frames to identify bounding boxes
+ *          of changed regions. Adjacent dirty regions within a configurable
+ *          gap threshold are merged to reduce tile count.
+ *
+ * ## Algorithm
+ * ```
+ * frame_N (RGBA)
+ *   -> XOR with frame_{N-1}
+ *   -> scan for non-zero rows/columns
+ *   -> compute bounding boxes of contiguous dirty regions
+ *   -> merge nearby boxes (gap < mergeGap pixels)
+ *   -> return vector of DirtyRect + dirty ratio
+ * ```
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Axis-aligned bounding box of a changed region
+ */
+struct DirtyRect {
+    uint32_t x = 0;      ///< Left edge (pixels from frame left)
+    uint32_t y = 0;      ///< Top edge (pixels from frame top)
+    uint32_t width = 0;   ///< Width in pixels
+    uint32_t height = 0;  ///< Height in pixels
+};
+
+/**
+ * @brief Result of dirty region detection between two frames
+ */
+struct DirtyRegionResult {
+    std::vector<DirtyRect> regions;  ///< Bounding boxes of changed areas
+    double dirtyRatio = 0.0;         ///< Fraction of frame area that changed (0.0-1.0)
+    bool fullFrameRequired = false;  ///< True if dirty area exceeds threshold
+};
+
+/**
+ * @brief Configuration for dirty region tracking
+ */
+struct DirtyRegionConfig {
+    /// Gap threshold for merging nearby dirty regions (pixels)
+    uint32_t mergeGap = 16;
+
+    /// Dirty area ratio above which a full frame is required (0.0-1.0)
+    double fullFrameThreshold = 0.60;
+};
+
+/**
+ * @brief Detects changed pixel regions between consecutive RGBA frames
+ *
+ * Uses XOR-based pixel comparison to find bounding boxes of changed areas.
+ * Merges nearby regions to reduce tile count. Returns full-frame flag when
+ * the dirty area exceeds a configurable threshold.
+ *
+ * @trace SRS-FR-REMOTE-007
+ */
+class DirtyRegionTracker {
+public:
+    explicit DirtyRegionTracker(const DirtyRegionConfig& config = {});
+    ~DirtyRegionTracker();
+
+    // Non-copyable, movable
+    DirtyRegionTracker(const DirtyRegionTracker&) = delete;
+    DirtyRegionTracker& operator=(const DirtyRegionTracker&) = delete;
+    DirtyRegionTracker(DirtyRegionTracker&&) noexcept;
+    DirtyRegionTracker& operator=(DirtyRegionTracker&&) noexcept;
+
+    /**
+     * @brief Detect dirty regions between two RGBA frames
+     * @param current Current frame RGBA data (width * height * 4 bytes)
+     * @param previous Previous frame RGBA data (same dimensions)
+     * @param width Frame width in pixels
+     * @param height Frame height in pixels
+     * @return Dirty region detection result
+     */
+    [[nodiscard]] DirtyRegionResult detect(
+        const uint8_t* current, const uint8_t* previous,
+        uint32_t width, uint32_t height) const;
+
+    /**
+     * @brief Extract a rectangular sub-region from an RGBA frame
+     * @param rgba Source frame RGBA data
+     * @param frameWidth Full frame width
+     * @param frameHeight Full frame height
+     * @param rect Region to extract
+     * @return RGBA pixel data for the sub-region
+     */
+    [[nodiscard]] static std::vector<uint8_t> extractRegion(
+        const uint8_t* rgba, uint32_t frameWidth, uint32_t frameHeight,
+        const DirtyRect& rect);
+
+    /**
+     * @brief Apply a tile's RGBA data onto a base frame
+     * @param base Base frame RGBA data (modified in place)
+     * @param frameWidth Full frame width
+     * @param frameHeight Full frame height
+     * @param tile RGBA pixel data for the tile
+     * @param rect Position and size of the tile
+     */
+    static void applyRegion(
+        uint8_t* base, uint32_t frameWidth, uint32_t frameHeight,
+        const uint8_t* tile, const DirtyRect& rect);
+
+    /**
+     * @brief Get the current configuration
+     */
+    [[nodiscard]] const DirtyRegionConfig& config() const;
+
+    /**
+     * @brief Update configuration
+     */
+    void setConfig(const DirtyRegionConfig& config);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::services

--- a/include/services/render/frame_encoder.hpp
+++ b/include/services/render/frame_encoder.hpp
@@ -58,6 +58,9 @@
 
 namespace dicom_viewer::services {
 
+struct DirtyRect;
+struct DirtyRegionResult;
+
 /**
  * @brief Encoding format for frame compression
  */
@@ -65,6 +68,26 @@ enum class EncodeFormat {
     Jpeg,       ///< Lossy JPEG compression (quality-adjustable)
     Png,        ///< Lossless PNG compression
     H264Stream  ///< H.264 temporal compression (requires ffmpeg)
+};
+
+/**
+ * @brief A single encoded dirty tile for delta frame transmission
+ */
+struct EncodedTile {
+    uint16_t x = 0;       ///< Tile X position in frame
+    uint16_t y = 0;       ///< Tile Y position in frame
+    uint16_t width = 0;   ///< Tile width in pixels
+    uint16_t height = 0;  ///< Tile height in pixels
+    std::vector<uint8_t> jpegData;  ///< Compressed JPEG data for this tile
+};
+
+/**
+ * @brief Result of delta frame encoding
+ */
+struct DeltaFrame {
+    std::vector<EncodedTile> tiles;  ///< Encoded dirty tiles
+    bool fullFrame = false;          ///< True if this is a full frame (not delta)
+    double dirtyRatio = 0.0;         ///< Fraction of frame that changed
 };
 
 /**
@@ -121,6 +144,37 @@ public:
     [[nodiscard]] std::vector<uint8_t> encode(
         const uint8_t* rgba, uint32_t width, uint32_t height,
         EncodeFormat format, int quality = 85);
+
+    /**
+     * @brief Encode a delta frame: only changed tiles between current and previous
+     * @param current Current frame RGBA data (width * height * 4 bytes)
+     * @param previous Previous frame RGBA data (same dimensions)
+     * @param width Frame width in pixels
+     * @param height Frame height in pixels
+     * @param quality JPEG quality for tile encoding (1-100)
+     * @return Delta frame with encoded tiles, or full frame if dirty ratio exceeds threshold
+     */
+    [[nodiscard]] DeltaFrame encodeDelta(
+        const uint8_t* current, const uint8_t* previous,
+        uint32_t width, uint32_t height,
+        int quality = 85);
+
+    /**
+     * @brief Serialize a DeltaFrame to binary wire format
+     * @details Wire format per tile: [2B x][2B y][2B w][2B h][4B jpeg_size][N bytes JPEG]
+     * @param delta The delta frame to serialize
+     * @return Binary data ready for network transmission
+     */
+    [[nodiscard]] static std::vector<uint8_t> serializeDelta(
+        const DeltaFrame& delta);
+
+    /**
+     * @brief Deserialize binary wire format back to a DeltaFrame
+     * @param data Binary data from serializeDelta
+     * @return Deserialized delta frame
+     */
+    [[nodiscard]] static DeltaFrame deserializeDelta(
+        const std::vector<uint8_t>& data);
 
     /**
      * @brief Check if H.264 encoding is available

--- a/include/ui/widgets/remote_viewport_widget.hpp
+++ b/include/ui/widgets/remote_viewport_widget.hpp
@@ -78,6 +78,14 @@ enum class RemoteConnectionState {
 };
 
 /**
+ * @brief Frame type in the binary protocol
+ */
+enum class FrameType : uint8_t {
+    FullFrame = 0x00,  ///< Complete JPEG frame
+    DeltaFrame = 0x01  ///< Delta-encoded tiles
+};
+
+/**
  * @brief Parsed binary frame header from the render server
  */
 struct FrameHeader {
@@ -85,6 +93,7 @@ struct FrameHeader {
     uint32_t frameSeq = 0;
     uint32_t width = 0;
     uint32_t height = 0;
+    FrameType frameType = FrameType::FullFrame;
     const uint8_t* imageData = nullptr;
     size_t imageDataSize = 0;
 };

--- a/src/services/render/dirty_region_tracker.cpp
+++ b/src/services/render/dirty_region_tracker.cpp
@@ -1,0 +1,320 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "services/render/dirty_region_tracker.hpp"
+
+#include <algorithm>
+#include <cstring>
+
+namespace dicom_viewer::services {
+
+// ---------------------------------------------------------------------------
+// Impl
+// ---------------------------------------------------------------------------
+class DirtyRegionTracker::Impl {
+public:
+    struct RowSpan {
+        uint32_t minCol = UINT32_MAX;
+        uint32_t maxCol = 0;
+        bool dirty = false;
+    };
+
+    explicit Impl(const DirtyRegionConfig& config) : config_(config) {}
+
+    DirtyRegionResult detect(
+        const uint8_t* current, const uint8_t* previous,
+        uint32_t width, uint32_t height) const
+    {
+        DirtyRegionResult result;
+
+        if (!current || !previous || width == 0 || height == 0) {
+            return result;
+        }
+
+        // Build a per-row dirty column mask using XOR comparison.
+        // For each row, find the leftmost and rightmost dirty pixel.
+        std::vector<RowSpan> rowSpans(height);
+        size_t dirtyPixelCount = 0;
+        const size_t stride = static_cast<size_t>(width) * 4;
+
+        for (uint32_t y = 0; y < height; ++y) {
+            const uint8_t* curRow = current + y * stride;
+            const uint8_t* prevRow = previous + y * stride;
+
+            for (uint32_t x = 0; x < width; ++x) {
+                size_t off = static_cast<size_t>(x) * 4;
+                // Compare RGB channels (ignore alpha for change detection)
+                if (curRow[off] != prevRow[off]
+                    || curRow[off + 1] != prevRow[off + 1]
+                    || curRow[off + 2] != prevRow[off + 2]) {
+                    rowSpans[y].dirty = true;
+                    rowSpans[y].minCol = std::min(rowSpans[y].minCol, x);
+                    rowSpans[y].maxCol = std::max(rowSpans[y].maxCol, x);
+                    ++dirtyPixelCount;
+                }
+            }
+        }
+
+        size_t totalPixels = static_cast<size_t>(width) * height;
+        result.dirtyRatio = static_cast<double>(dirtyPixelCount)
+                            / static_cast<double>(totalPixels);
+
+        if (dirtyPixelCount == 0) {
+            return result;
+        }
+
+        if (result.dirtyRatio > config_.fullFrameThreshold) {
+            result.fullFrameRequired = true;
+            DirtyRect fullRect;
+            fullRect.x = 0;
+            fullRect.y = 0;
+            fullRect.width = width;
+            fullRect.height = height;
+            result.regions.push_back(fullRect);
+            return result;
+        }
+
+        // Extract contiguous vertical runs of dirty rows into bounding boxes
+        auto boxes = extractBoundingBoxes(rowSpans, width, height);
+
+        // Merge nearby boxes
+        result.regions = mergeBoxes(boxes, config_.mergeGap);
+
+        return result;
+    }
+
+    DirtyRegionConfig config_;
+
+private:
+    static std::vector<DirtyRect> extractBoundingBoxes(
+        const std::vector<RowSpan>& rowSpans,
+        uint32_t /*width*/, uint32_t height)
+    {
+        std::vector<DirtyRect> boxes;
+        uint32_t y = 0;
+
+        while (y < height) {
+            // Skip clean rows
+            while (y < height && !rowSpans[y].dirty) {
+                ++y;
+            }
+            if (y >= height) {
+                break;
+            }
+
+            // Start a new dirty run
+            uint32_t startY = y;
+            uint32_t minCol = rowSpans[y].minCol;
+            uint32_t maxCol = rowSpans[y].maxCol;
+
+            while (y < height && rowSpans[y].dirty) {
+                minCol = std::min(minCol, rowSpans[y].minCol);
+                maxCol = std::max(maxCol, rowSpans[y].maxCol);
+                ++y;
+            }
+
+            DirtyRect box;
+            box.x = minCol;
+            box.y = startY;
+            box.width = maxCol - minCol + 1;
+            box.height = y - startY;
+            boxes.push_back(box);
+        }
+
+        return boxes;
+    }
+
+    static std::vector<DirtyRect> mergeBoxes(
+        const std::vector<DirtyRect>& boxes, uint32_t gap)
+    {
+        if (boxes.size() <= 1) {
+            return boxes;
+        }
+
+        // Greedy merge: repeatedly merge overlapping/nearby boxes
+        std::vector<DirtyRect> merged = boxes;
+        bool changed = true;
+
+        while (changed) {
+            changed = false;
+            std::vector<DirtyRect> next;
+
+            std::vector<bool> consumed(merged.size(), false);
+
+            for (size_t i = 0; i < merged.size(); ++i) {
+                if (consumed[i]) {
+                    continue;
+                }
+
+                DirtyRect current = merged[i];
+
+                for (size_t j = i + 1; j < merged.size(); ++j) {
+                    if (consumed[j]) {
+                        continue;
+                    }
+
+                    if (shouldMerge(current, merged[j], gap)) {
+                        current = unionRect(current, merged[j]);
+                        consumed[j] = true;
+                        changed = true;
+                    }
+                }
+
+                next.push_back(current);
+            }
+
+            merged = std::move(next);
+        }
+
+        return merged;
+    }
+
+    static bool shouldMerge(const DirtyRect& a, const DirtyRect& b,
+                            uint32_t gap)
+    {
+        // Check if boxes overlap or are within gap pixels of each other
+        uint32_t aRight = a.x + a.width;
+        uint32_t aBottom = a.y + a.height;
+        uint32_t bRight = b.x + b.width;
+        uint32_t bBottom = b.y + b.height;
+
+        bool xOverlap = (a.x <= bRight + gap) && (b.x <= aRight + gap);
+        bool yOverlap = (a.y <= bBottom + gap) && (b.y <= aBottom + gap);
+
+        return xOverlap && yOverlap;
+    }
+
+    static DirtyRect unionRect(const DirtyRect& a, const DirtyRect& b)
+    {
+        uint32_t minX = std::min(a.x, b.x);
+        uint32_t minY = std::min(a.y, b.y);
+        uint32_t maxX = std::max(a.x + a.width, b.x + b.width);
+        uint32_t maxY = std::max(a.y + a.height, b.y + b.height);
+
+        DirtyRect r;
+        r.x = minX;
+        r.y = minY;
+        r.width = maxX - minX;
+        r.height = maxY - minY;
+        return r;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// DirtyRegionTracker lifecycle
+// ---------------------------------------------------------------------------
+DirtyRegionTracker::DirtyRegionTracker(const DirtyRegionConfig& config)
+    : impl_(std::make_unique<Impl>(config))
+{
+}
+
+DirtyRegionTracker::~DirtyRegionTracker() = default;
+
+DirtyRegionTracker::DirtyRegionTracker(DirtyRegionTracker&&) noexcept = default;
+DirtyRegionTracker& DirtyRegionTracker::operator=(DirtyRegionTracker&&) noexcept
+    = default;
+
+DirtyRegionResult DirtyRegionTracker::detect(
+    const uint8_t* current, const uint8_t* previous,
+    uint32_t width, uint32_t height) const
+{
+    return impl_->detect(current, previous, width, height);
+}
+
+std::vector<uint8_t> DirtyRegionTracker::extractRegion(
+    const uint8_t* rgba, uint32_t frameWidth, uint32_t frameHeight,
+    const DirtyRect& rect)
+{
+    if (!rgba || frameWidth == 0 || frameHeight == 0
+        || rect.width == 0 || rect.height == 0) {
+        return {};
+    }
+
+    // Clamp rect to frame bounds
+    uint32_t x = std::min(rect.x, frameWidth);
+    uint32_t y = std::min(rect.y, frameHeight);
+    uint32_t w = std::min(rect.width, frameWidth - x);
+    uint32_t h = std::min(rect.height, frameHeight - y);
+
+    if (w == 0 || h == 0) {
+        return {};
+    }
+
+    std::vector<uint8_t> tile(static_cast<size_t>(w) * h * 4);
+    const size_t frameStride = static_cast<size_t>(frameWidth) * 4;
+    const size_t tileStride = static_cast<size_t>(w) * 4;
+
+    for (uint32_t row = 0; row < h; ++row) {
+        const uint8_t* src = rgba + (y + row) * frameStride + x * 4;
+        uint8_t* dst = tile.data() + row * tileStride;
+        std::memcpy(dst, src, tileStride);
+    }
+
+    return tile;
+}
+
+void DirtyRegionTracker::applyRegion(
+    uint8_t* base, uint32_t frameWidth, uint32_t frameHeight,
+    const uint8_t* tile, const DirtyRect& rect)
+{
+    if (!base || !tile || frameWidth == 0 || frameHeight == 0
+        || rect.width == 0 || rect.height == 0) {
+        return;
+    }
+
+    uint32_t x = std::min(rect.x, frameWidth);
+    uint32_t y = std::min(rect.y, frameHeight);
+    uint32_t w = std::min(rect.width, frameWidth - x);
+    uint32_t h = std::min(rect.height, frameHeight - y);
+
+    if (w == 0 || h == 0) {
+        return;
+    }
+
+    const size_t frameStride = static_cast<size_t>(frameWidth) * 4;
+    const size_t tileStride = static_cast<size_t>(w) * 4;
+
+    for (uint32_t row = 0; row < h; ++row) {
+        uint8_t* dst = base + (y + row) * frameStride + x * 4;
+        const uint8_t* src = tile + row * tileStride;
+        std::memcpy(dst, src, tileStride);
+    }
+}
+
+const DirtyRegionConfig& DirtyRegionTracker::config() const
+{
+    return impl_->config_;
+}
+
+void DirtyRegionTracker::setConfig(const DirtyRegionConfig& config)
+{
+    impl_->config_ = config;
+}
+
+} // namespace dicom_viewer::services

--- a/src/services/render/frame_encoder.cpp
+++ b/src/services/render/frame_encoder.cpp
@@ -28,6 +28,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "services/render/frame_encoder.hpp"
+#include "services/render/dirty_region_tracker.hpp"
 
 #include <vtkImageData.h>
 #include <vtkJPEGWriter.h>
@@ -174,6 +175,168 @@ std::vector<uint8_t> FrameEncoder::encode(
         return {};
     }
     return {};
+}
+
+// ---------------------------------------------------------------------------
+// Delta frame encoding
+// ---------------------------------------------------------------------------
+DeltaFrame FrameEncoder::encodeDelta(
+    const uint8_t* current, const uint8_t* previous,
+    uint32_t width, uint32_t height, int quality)
+{
+    DeltaFrame result;
+
+    if (!current || !previous || width == 0 || height == 0) {
+        return result;
+    }
+
+    quality = std::clamp(quality, 1, 100);
+
+    DirtyRegionTracker tracker;
+    auto detection = tracker.detect(current, previous, width, height);
+
+    result.dirtyRatio = detection.dirtyRatio;
+    result.fullFrame = detection.fullFrameRequired;
+
+    if (detection.regions.empty()) {
+        return result;
+    }
+
+    if (detection.fullFrameRequired) {
+        // Encode the entire frame as a single tile
+        EncodedTile tile;
+        tile.x = 0;
+        tile.y = 0;
+        tile.width = static_cast<uint16_t>(std::min(width, uint32_t(UINT16_MAX)));
+        tile.height = static_cast<uint16_t>(std::min(height, uint32_t(UINT16_MAX)));
+        tile.jpegData = encodeJpeg(current, width, height, quality);
+        if (!tile.jpegData.empty()) {
+            result.tiles.push_back(std::move(tile));
+        }
+        return result;
+    }
+
+    // Encode each dirty region as a JPEG tile
+    for (const auto& rect : detection.regions) {
+        auto tileRgba = DirtyRegionTracker::extractRegion(
+            current, width, height, rect);
+        if (tileRgba.empty()) {
+            continue;
+        }
+
+        EncodedTile tile;
+        tile.x = static_cast<uint16_t>(rect.x);
+        tile.y = static_cast<uint16_t>(rect.y);
+        tile.width = static_cast<uint16_t>(rect.width);
+        tile.height = static_cast<uint16_t>(rect.height);
+        tile.jpegData = encodeJpeg(
+            tileRgba.data(), rect.width, rect.height, quality);
+
+        if (!tile.jpegData.empty()) {
+            result.tiles.push_back(std::move(tile));
+        }
+    }
+
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Delta serialization
+// ---------------------------------------------------------------------------
+std::vector<uint8_t> FrameEncoder::serializeDelta(const DeltaFrame& delta)
+{
+    // Header: [1B flags][4B tile_count]
+    // Per tile: [2B x][2B y][2B w][2B h][4B jpeg_size][N bytes JPEG]
+
+    // Calculate total size
+    size_t totalSize = 1 + 4; // flags + tile_count
+    for (const auto& tile : delta.tiles) {
+        totalSize += 2 + 2 + 2 + 2 + 4 + tile.jpegData.size();
+    }
+
+    std::vector<uint8_t> data(totalSize);
+    size_t offset = 0;
+
+    // Flags byte: bit 0 = fullFrame
+    uint8_t flags = delta.fullFrame ? 0x01 : 0x00;
+    data[offset++] = flags;
+
+    // Tile count (4 bytes, little-endian)
+    uint32_t tileCount = static_cast<uint32_t>(delta.tiles.size());
+    std::memcpy(data.data() + offset, &tileCount, 4);
+    offset += 4;
+
+    // Tiles
+    for (const auto& tile : delta.tiles) {
+        std::memcpy(data.data() + offset, &tile.x, 2);
+        offset += 2;
+        std::memcpy(data.data() + offset, &tile.y, 2);
+        offset += 2;
+        std::memcpy(data.data() + offset, &tile.width, 2);
+        offset += 2;
+        std::memcpy(data.data() + offset, &tile.height, 2);
+        offset += 2;
+
+        uint32_t jpegSize = static_cast<uint32_t>(tile.jpegData.size());
+        std::memcpy(data.data() + offset, &jpegSize, 4);
+        offset += 4;
+
+        std::memcpy(data.data() + offset, tile.jpegData.data(), jpegSize);
+        offset += jpegSize;
+    }
+
+    return data;
+}
+
+DeltaFrame FrameEncoder::deserializeDelta(const std::vector<uint8_t>& data)
+{
+    DeltaFrame result;
+
+    // Minimum: 1B flags + 4B tile_count
+    if (data.size() < 5) {
+        return result;
+    }
+
+    size_t offset = 0;
+
+    uint8_t flags = data[offset++];
+    result.fullFrame = (flags & 0x01) != 0;
+
+    uint32_t tileCount = 0;
+    std::memcpy(&tileCount, data.data() + offset, 4);
+    offset += 4;
+
+    for (uint32_t i = 0; i < tileCount; ++i) {
+        if (offset + 12 > data.size()) {
+            break; // Not enough data for tile header
+        }
+
+        EncodedTile tile;
+        std::memcpy(&tile.x, data.data() + offset, 2);
+        offset += 2;
+        std::memcpy(&tile.y, data.data() + offset, 2);
+        offset += 2;
+        std::memcpy(&tile.width, data.data() + offset, 2);
+        offset += 2;
+        std::memcpy(&tile.height, data.data() + offset, 2);
+        offset += 2;
+
+        uint32_t jpegSize = 0;
+        std::memcpy(&jpegSize, data.data() + offset, 4);
+        offset += 4;
+
+        if (offset + jpegSize > data.size()) {
+            break; // Not enough data for JPEG payload
+        }
+
+        tile.jpegData.assign(
+            data.data() + offset, data.data() + offset + jpegSize);
+        offset += jpegSize;
+
+        result.tiles.push_back(std::move(tile));
+    }
+
+    return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ui/widgets/remote_viewport_widget.cpp
+++ b/src/ui/widgets/remote_viewport_widget.cpp
@@ -28,6 +28,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "ui/widgets/remote_viewport_widget.hpp"
+#include "services/render/frame_encoder.hpp"
 
 #include <QAction>
 #include <QContextMenuEvent>
@@ -97,8 +98,11 @@ public:
     }
 
     QImage currentFrame_;
+    QImage baseFrame_;  // Stored base frame for delta tile compositing
     bool showStatistics_ = false;
     std::deque<std::chrono::steady_clock::time_point> frameTimestamps_;
+    uint32_t deltaFramesReceived_ = 0;
+    uint32_t fullFramesReceived_ = 0;
 
     double currentFps() const
     {
@@ -189,14 +193,12 @@ private:
             return;
         }
 
-        QImage frame = QImage::fromData(
-            header.imageData,
-            static_cast<int>(header.imageDataSize), "JPEG");
-        if (frame.isNull()) {
-            return;
+        if (header.frameType == FrameType::DeltaFrame) {
+            applyDeltaFrame(header);
+        } else {
+            applyFullFrame(header);
         }
 
-        currentFrame_ = std::move(frame);
         lastFrameSeq_ = header.frameSeq;
         ++framesReceived_;
 
@@ -208,6 +210,65 @@ private:
 
         owner_->update();
         emit owner_->frameDisplayed(header.frameSeq);
+    }
+
+    void applyFullFrame(const FrameHeader& header)
+    {
+        QImage frame = QImage::fromData(
+            header.imageData,
+            static_cast<int>(header.imageDataSize), "JPEG");
+        if (frame.isNull()) {
+            return;
+        }
+
+        currentFrame_ = frame;
+        baseFrame_ = frame.convertToFormat(QImage::Format_RGBA8888);
+        ++fullFramesReceived_;
+    }
+
+    void applyDeltaFrame(const FrameHeader& header)
+    {
+        std::vector<uint8_t> deltaData(
+            header.imageData,
+            header.imageData + header.imageDataSize);
+        auto delta = dicom_viewer::services::FrameEncoder::deserializeDelta(
+            deltaData);
+
+        if (delta.fullFrame || baseFrame_.isNull()) {
+            // Full frame fallback or no base frame yet
+            if (!delta.tiles.empty()) {
+                QImage frame = QImage::fromData(
+                    delta.tiles[0].jpegData.data(),
+                    static_cast<int>(delta.tiles[0].jpegData.size()),
+                    "JPEG");
+                if (!frame.isNull()) {
+                    currentFrame_ = frame;
+                    baseFrame_ = frame.convertToFormat(
+                        QImage::Format_RGBA8888);
+                }
+            }
+            ++fullFramesReceived_;
+            return;
+        }
+
+        // Apply tiles onto base frame
+        QImage composited = baseFrame_.copy();
+
+        for (const auto& tile : delta.tiles) {
+            QImage tileImage = QImage::fromData(
+                tile.jpegData.data(),
+                static_cast<int>(tile.jpegData.size()), "JPEG");
+            if (tileImage.isNull()) {
+                continue;
+            }
+
+            QPainter tilePainter(&composited);
+            tilePainter.drawImage(tile.x, tile.y, tileImage);
+        }
+
+        baseFrame_ = composited;
+        currentFrame_ = composited;
+        ++deltaFramesReceived_;
     }
 
     void setState(RemoteConnectionState newState)
@@ -399,10 +460,12 @@ void RemoteViewportWidget::paintEvent(QPaintEvent* /*event*/)
     if (impl_->showStatistics_
         && impl_->state() == RemoteConnectionState::Connected) {
         double fps = impl_->currentFps();
-        QString statsText = QString("FPS: %1 | Frames: %2 | Seq: %3")
+        QString statsText = QString("FPS: %1 | Frames: %2 | Seq: %3 | Delta: %4 | Full: %5")
                                 .arg(fps, 0, 'f', 1)
                                 .arg(impl_->framesReceived())
-                                .arg(impl_->lastFrameSeq());
+                                .arg(impl_->lastFrameSeq())
+                                .arg(impl_->deltaFramesReceived_)
+                                .arg(impl_->fullFramesReceived_);
 
         QFont statsFont = painter.font();
         statsFont.setPointSize(10);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2105,6 +2105,23 @@ target_include_directories(frame_encoder_test PRIVATE
 
 gtest_discover_tests(frame_encoder_test DISCOVERY_TIMEOUT 60)
 
+# Unit tests for DirtyRegionTracker
+add_executable(dirty_region_tracker_test
+    unit/dirty_region_tracker_test.cpp
+)
+
+target_link_libraries(dirty_region_tracker_test PRIVATE
+    render_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(dirty_region_tracker_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(dirty_region_tracker_test DISCOVERY_TIMEOUT 60)
+
 # Unit tests for AdaptiveQualityController
 add_executable(adaptive_quality_controller_test
     unit/adaptive_quality_controller_test.cpp

--- a/tests/unit/dirty_region_tracker_test.cpp
+++ b/tests/unit/dirty_region_tracker_test.cpp
@@ -1,0 +1,419 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include "services/render/dirty_region_tracker.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <numeric>
+#include <vector>
+
+using namespace dicom_viewer::services;
+
+namespace {
+
+// Create a solid RGBA frame
+std::vector<uint8_t> createSolidFrame(uint32_t w, uint32_t h,
+                                       uint8_t r, uint8_t g, uint8_t b)
+{
+    std::vector<uint8_t> frame(static_cast<size_t>(w) * h * 4);
+    for (size_t i = 0; i < frame.size(); i += 4) {
+        frame[i + 0] = r;
+        frame[i + 1] = g;
+        frame[i + 2] = b;
+        frame[i + 3] = 255;
+    }
+    return frame;
+}
+
+// Modify a rectangular region in a frame
+void fillRect(std::vector<uint8_t>& frame, uint32_t frameW,
+              uint32_t rx, uint32_t ry, uint32_t rw, uint32_t rh,
+              uint8_t r, uint8_t g, uint8_t b)
+{
+    for (uint32_t y = ry; y < ry + rh; ++y) {
+        for (uint32_t x = rx; x < rx + rw; ++x) {
+            size_t idx = (static_cast<size_t>(y) * frameW + x) * 4;
+            frame[idx + 0] = r;
+            frame[idx + 1] = g;
+            frame[idx + 2] = b;
+        }
+    }
+}
+
+} // anonymous namespace
+
+// =============================================================================
+// Default construction
+// =============================================================================
+
+TEST(DirtyRegionTrackerTest, DefaultConstruction) {
+    DirtyRegionTracker tracker;
+    EXPECT_EQ(tracker.config().mergeGap, 16u);
+    EXPECT_DOUBLE_EQ(tracker.config().fullFrameThreshold, 0.60);
+}
+
+TEST(DirtyRegionTrackerTest, CustomConfig) {
+    DirtyRegionConfig config;
+    config.mergeGap = 32;
+    config.fullFrameThreshold = 0.75;
+    DirtyRegionTracker tracker(config);
+    EXPECT_EQ(tracker.config().mergeGap, 32u);
+    EXPECT_DOUBLE_EQ(tracker.config().fullFrameThreshold, 0.75);
+}
+
+TEST(DirtyRegionTrackerTest, SetConfig) {
+    DirtyRegionTracker tracker;
+    DirtyRegionConfig config;
+    config.mergeGap = 8;
+    tracker.setConfig(config);
+    EXPECT_EQ(tracker.config().mergeGap, 8u);
+}
+
+// =============================================================================
+// Identical frames — no dirty regions
+// =============================================================================
+
+TEST(DirtyRegionTrackerTest, IdenticalFramesNoDirtyRegions) {
+    DirtyRegionTracker tracker;
+    auto frame = createSolidFrame(64, 64, 128, 128, 128);
+    auto result = tracker.detect(frame.data(), frame.data(), 64, 64);
+
+    EXPECT_TRUE(result.regions.empty());
+    EXPECT_DOUBLE_EQ(result.dirtyRatio, 0.0);
+    EXPECT_FALSE(result.fullFrameRequired);
+}
+
+// =============================================================================
+// Single dirty region detection
+// =============================================================================
+
+TEST(DirtyRegionTrackerTest, SingleDirtyRegion) {
+    DirtyRegionTracker tracker;
+    constexpr uint32_t W = 100, H = 100;
+
+    auto prev = createSolidFrame(W, H, 0, 0, 0);
+    auto curr = createSolidFrame(W, H, 0, 0, 0);
+
+    // Change a 10x10 block at (20, 30)
+    fillRect(curr, W, 20, 30, 10, 10, 255, 0, 0);
+
+    auto result = tracker.detect(curr.data(), prev.data(), W, H);
+
+    EXPECT_FALSE(result.fullFrameRequired);
+    EXPECT_GT(result.dirtyRatio, 0.0);
+    EXPECT_LE(result.dirtyRatio, 0.02); // 100 pixels out of 10000
+    ASSERT_EQ(result.regions.size(), 1u);
+
+    auto& r = result.regions[0];
+    EXPECT_EQ(r.x, 20u);
+    EXPECT_EQ(r.y, 30u);
+    EXPECT_EQ(r.width, 10u);
+    EXPECT_EQ(r.height, 10u);
+}
+
+// =============================================================================
+// Multiple disjoint dirty regions
+// =============================================================================
+
+TEST(DirtyRegionTrackerTest, MultipleDisjointRegions) {
+    DirtyRegionConfig config;
+    config.mergeGap = 0; // Disable merging for this test
+    DirtyRegionTracker tracker(config);
+    constexpr uint32_t W = 200, H = 200;
+
+    auto prev = createSolidFrame(W, H, 0, 0, 0);
+    auto curr = createSolidFrame(W, H, 0, 0, 0);
+
+    // Two distant dirty regions
+    fillRect(curr, W, 10, 10, 5, 5, 255, 0, 0);     // Top-left
+    fillRect(curr, W, 150, 150, 5, 5, 0, 255, 0);    // Bottom-right
+
+    auto result = tracker.detect(curr.data(), prev.data(), W, H);
+
+    EXPECT_FALSE(result.fullFrameRequired);
+    EXPECT_EQ(result.regions.size(), 2u);
+}
+
+// =============================================================================
+// Nearby regions merge
+// =============================================================================
+
+TEST(DirtyRegionTrackerTest, NearbyRegionsMerge) {
+    DirtyRegionConfig config;
+    config.mergeGap = 20;
+    DirtyRegionTracker tracker(config);
+    constexpr uint32_t W = 200, H = 200;
+
+    auto prev = createSolidFrame(W, H, 0, 0, 0);
+    auto curr = createSolidFrame(W, H, 0, 0, 0);
+
+    // Two regions within merge gap (vertical gap = 10 < 20)
+    fillRect(curr, W, 50, 10, 10, 10, 255, 0, 0);
+    fillRect(curr, W, 50, 30, 10, 10, 0, 255, 0);
+
+    auto result = tracker.detect(curr.data(), prev.data(), W, H);
+
+    EXPECT_FALSE(result.fullFrameRequired);
+    // Regions should be merged into one
+    EXPECT_EQ(result.regions.size(), 1u);
+}
+
+// =============================================================================
+// Full frame threshold
+// =============================================================================
+
+TEST(DirtyRegionTrackerTest, FullFrameThresholdTriggered) {
+    DirtyRegionConfig config;
+    config.fullFrameThreshold = 0.60;
+    DirtyRegionTracker tracker(config);
+    constexpr uint32_t W = 100, H = 100;
+
+    auto prev = createSolidFrame(W, H, 0, 0, 0);
+    auto curr = createSolidFrame(W, H, 0, 0, 0);
+
+    // Change 70% of pixels (7000 out of 10000)
+    fillRect(curr, W, 0, 0, 100, 70, 255, 255, 255);
+
+    auto result = tracker.detect(curr.data(), prev.data(), W, H);
+
+    EXPECT_TRUE(result.fullFrameRequired);
+    EXPECT_GT(result.dirtyRatio, 0.60);
+    EXPECT_EQ(result.regions.size(), 1u);
+    // Full-frame region should cover entire frame
+    EXPECT_EQ(result.regions[0].x, 0u);
+    EXPECT_EQ(result.regions[0].y, 0u);
+    EXPECT_EQ(result.regions[0].width, W);
+    EXPECT_EQ(result.regions[0].height, H);
+}
+
+TEST(DirtyRegionTrackerTest, JustBelowThresholdNotFullFrame) {
+    DirtyRegionConfig config;
+    config.fullFrameThreshold = 0.60;
+    DirtyRegionTracker tracker(config);
+    constexpr uint32_t W = 100, H = 100;
+
+    auto prev = createSolidFrame(W, H, 0, 0, 0);
+    auto curr = createSolidFrame(W, H, 0, 0, 0);
+
+    // Change 50% of pixels
+    fillRect(curr, W, 0, 0, 100, 50, 255, 255, 255);
+
+    auto result = tracker.detect(curr.data(), prev.data(), W, H);
+
+    EXPECT_FALSE(result.fullFrameRequired);
+    EXPECT_LT(result.dirtyRatio, 0.60);
+}
+
+// =============================================================================
+// Extract and apply region
+// =============================================================================
+
+TEST(DirtyRegionTrackerTest, ExtractRegion) {
+    constexpr uint32_t W = 10, H = 10;
+    auto frame = createSolidFrame(W, H, 100, 100, 100);
+    fillRect(frame, W, 2, 3, 4, 5, 200, 200, 200);
+
+    DirtyRect rect;
+    rect.x = 2;
+    rect.y = 3;
+    rect.width = 4;
+    rect.height = 5;
+
+    auto tile = DirtyRegionTracker::extractRegion(
+        frame.data(), W, H, rect);
+
+    ASSERT_EQ(tile.size(), static_cast<size_t>(4 * 5 * 4));
+
+    // All pixels in the tile should be (200, 200, 200, 255)
+    for (size_t i = 0; i < tile.size(); i += 4) {
+        EXPECT_EQ(tile[i + 0], 200);
+        EXPECT_EQ(tile[i + 1], 200);
+        EXPECT_EQ(tile[i + 2], 200);
+    }
+}
+
+TEST(DirtyRegionTrackerTest, ApplyRegion) {
+    constexpr uint32_t W = 10, H = 10;
+    auto base = createSolidFrame(W, H, 0, 0, 0);
+
+    DirtyRect rect;
+    rect.x = 3;
+    rect.y = 4;
+    rect.width = 2;
+    rect.height = 2;
+
+    // Create a tile with red pixels
+    std::vector<uint8_t> tile(2 * 2 * 4);
+    for (size_t i = 0; i < tile.size(); i += 4) {
+        tile[i + 0] = 255;
+        tile[i + 1] = 0;
+        tile[i + 2] = 0;
+        tile[i + 3] = 255;
+    }
+
+    DirtyRegionTracker::applyRegion(
+        base.data(), W, H, tile.data(), rect);
+
+    // Check that the tile was applied at (3,4)
+    size_t idx = (4 * W + 3) * 4;
+    EXPECT_EQ(base[idx + 0], 255);
+    EXPECT_EQ(base[idx + 1], 0);
+    EXPECT_EQ(base[idx + 2], 0);
+
+    // Check that surrounding pixel is still black
+    size_t idxOutside = (0 * W + 0) * 4;
+    EXPECT_EQ(base[idxOutside + 0], 0);
+    EXPECT_EQ(base[idxOutside + 1], 0);
+    EXPECT_EQ(base[idxOutside + 2], 0);
+}
+
+TEST(DirtyRegionTrackerTest, ExtractAndApplyRoundtrip) {
+    constexpr uint32_t W = 20, H = 20;
+    auto original = createSolidFrame(W, H, 50, 50, 50);
+    fillRect(original, W, 5, 5, 8, 8, 200, 100, 50);
+
+    DirtyRect rect;
+    rect.x = 5;
+    rect.y = 5;
+    rect.width = 8;
+    rect.height = 8;
+
+    auto tile = DirtyRegionTracker::extractRegion(
+        original.data(), W, H, rect);
+
+    // Apply to a blank frame
+    auto target = createSolidFrame(W, H, 50, 50, 50);
+    DirtyRegionTracker::applyRegion(
+        target.data(), W, H, tile.data(), rect);
+
+    // The target should now match the original in the rect area
+    for (uint32_t y = 5; y < 13; ++y) {
+        for (uint32_t x = 5; x < 13; ++x) {
+            size_t idx = (static_cast<size_t>(y) * W + x) * 4;
+            EXPECT_EQ(target[idx + 0], original[idx + 0]);
+            EXPECT_EQ(target[idx + 1], original[idx + 1]);
+            EXPECT_EQ(target[idx + 2], original[idx + 2]);
+        }
+    }
+}
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+TEST(DirtyRegionTrackerTest, NullPointerReturnsEmpty) {
+    DirtyRegionTracker tracker;
+    auto frame = createSolidFrame(10, 10, 0, 0, 0);
+
+    auto result = tracker.detect(nullptr, frame.data(), 10, 10);
+    EXPECT_TRUE(result.regions.empty());
+
+    result = tracker.detect(frame.data(), nullptr, 10, 10);
+    EXPECT_TRUE(result.regions.empty());
+}
+
+TEST(DirtyRegionTrackerTest, ZeroDimensionsReturnsEmpty) {
+    DirtyRegionTracker tracker;
+    auto frame = createSolidFrame(10, 10, 0, 0, 0);
+
+    auto result = tracker.detect(frame.data(), frame.data(), 0, 10);
+    EXPECT_TRUE(result.regions.empty());
+
+    result = tracker.detect(frame.data(), frame.data(), 10, 0);
+    EXPECT_TRUE(result.regions.empty());
+}
+
+TEST(DirtyRegionTrackerTest, ExtractRegionNullReturnsEmpty) {
+    DirtyRect rect;
+    rect.x = 0;
+    rect.y = 0;
+    rect.width = 5;
+    rect.height = 5;
+
+    auto tile = DirtyRegionTracker::extractRegion(nullptr, 10, 10, rect);
+    EXPECT_TRUE(tile.empty());
+}
+
+TEST(DirtyRegionTrackerTest, ExtractRegionZeroSizeReturnsEmpty) {
+    auto frame = createSolidFrame(10, 10, 0, 0, 0);
+    DirtyRect rect;
+    rect.x = 0;
+    rect.y = 0;
+    rect.width = 0;
+    rect.height = 5;
+
+    auto tile = DirtyRegionTracker::extractRegion(
+        frame.data(), 10, 10, rect);
+    EXPECT_TRUE(tile.empty());
+}
+
+// =============================================================================
+// Move semantics
+// =============================================================================
+
+TEST(DirtyRegionTrackerTest, MoveConstruction) {
+    DirtyRegionConfig config;
+    config.mergeGap = 32;
+    DirtyRegionTracker a(config);
+
+    DirtyRegionTracker b(std::move(a));
+    EXPECT_EQ(b.config().mergeGap, 32u);
+}
+
+TEST(DirtyRegionTrackerTest, MoveAssignment) {
+    DirtyRegionConfig config;
+    config.mergeGap = 32;
+    DirtyRegionTracker a(config);
+
+    DirtyRegionTracker b;
+    b = std::move(a);
+    EXPECT_EQ(b.config().mergeGap, 32u);
+}
+
+// =============================================================================
+// Dirty ratio accuracy
+// =============================================================================
+
+TEST(DirtyRegionTrackerTest, DirtyRatioAccuracy) {
+    DirtyRegionTracker tracker;
+    constexpr uint32_t W = 100, H = 100;
+
+    auto prev = createSolidFrame(W, H, 0, 0, 0);
+    auto curr = createSolidFrame(W, H, 0, 0, 0);
+
+    // Change exactly 25% (a 50x50 block = 2500 pixels out of 10000)
+    fillRect(curr, W, 0, 0, 50, 50, 255, 255, 255);
+
+    auto result = tracker.detect(curr.data(), prev.data(), W, H);
+
+    EXPECT_NEAR(result.dirtyRatio, 0.25, 0.01);
+}

--- a/tests/unit/frame_encoder_test.cpp
+++ b/tests/unit/frame_encoder_test.cpp
@@ -30,6 +30,7 @@
 #include <gtest/gtest.h>
 
 #include "services/render/frame_encoder.hpp"
+#include "services/render/dirty_region_tracker.hpp"
 
 #include <algorithm>
 #include <chrono>
@@ -328,4 +329,163 @@ TEST_F(FrameEncoderTest, BenchmarkJpegQualityComparison) {
 
         EXPECT_FALSE(result.empty());
     }
+}
+
+// =============================================================================
+// Delta encoding
+// =============================================================================
+
+TEST_F(FrameEncoderTest, EncodeDeltaIdenticalFrames) {
+    auto frame = createTestRGBA(64, 64);
+    auto delta = encoder.encodeDelta(
+        frame.data(), frame.data(), 64, 64, 85);
+
+    EXPECT_TRUE(delta.tiles.empty());
+    EXPECT_FALSE(delta.fullFrame);
+    EXPECT_DOUBLE_EQ(delta.dirtyRatio, 0.0);
+}
+
+TEST_F(FrameEncoderTest, EncodeDeltaSmallChange) {
+    auto prev = createSolidRGBA(100, 100, 0, 0, 0);
+    auto curr = createSolidRGBA(100, 100, 0, 0, 0);
+
+    // Change a small 10x10 region
+    for (uint32_t y = 20; y < 30; ++y) {
+        for (uint32_t x = 30; x < 40; ++x) {
+            size_t idx = (static_cast<size_t>(y) * 100 + x) * 4;
+            curr[idx + 0] = 255;
+            curr[idx + 1] = 0;
+            curr[idx + 2] = 0;
+        }
+    }
+
+    auto delta = encoder.encodeDelta(
+        curr.data(), prev.data(), 100, 100, 85);
+
+    EXPECT_FALSE(delta.fullFrame);
+    EXPECT_GT(delta.dirtyRatio, 0.0);
+    EXPECT_LE(delta.dirtyRatio, 0.02);
+    ASSERT_FALSE(delta.tiles.empty());
+
+    // Each tile should contain valid JPEG data
+    for (const auto& tile : delta.tiles) {
+        ASSERT_GE(tile.jpegData.size(), 2u);
+        EXPECT_EQ(tile.jpegData[0], 0xFF);
+        EXPECT_EQ(tile.jpegData[1], 0xD8);
+    }
+}
+
+TEST_F(FrameEncoderTest, EncodeDeltaFullFrameFallback) {
+    auto prev = createSolidRGBA(100, 100, 0, 0, 0);
+    auto curr = createSolidRGBA(100, 100, 255, 255, 255); // All changed
+
+    auto delta = encoder.encodeDelta(
+        curr.data(), prev.data(), 100, 100, 85);
+
+    EXPECT_TRUE(delta.fullFrame);
+    EXPECT_GT(delta.dirtyRatio, 0.60);
+    ASSERT_EQ(delta.tiles.size(), 1u);
+    EXPECT_EQ(delta.tiles[0].x, 0);
+    EXPECT_EQ(delta.tiles[0].y, 0);
+}
+
+TEST_F(FrameEncoderTest, EncodeDeltaDeltaSmallerThanFullFrame) {
+    auto prev = createTestRGBA(128, 128);
+    auto curr = createTestRGBA(128, 128);
+
+    // Modify a small area
+    for (uint32_t y = 10; y < 20; ++y) {
+        for (uint32_t x = 10; x < 20; ++x) {
+            size_t idx = (static_cast<size_t>(y) * 128 + x) * 4;
+            curr[idx + 0] = 255;
+        }
+    }
+
+    auto delta = encoder.encodeDelta(
+        curr.data(), prev.data(), 128, 128, 85);
+    auto fullJpeg = encoder.encodeJpeg(curr.data(), 128, 128, 85);
+
+    ASSERT_FALSE(delta.fullFrame);
+    ASSERT_FALSE(delta.tiles.empty());
+
+    // Sum delta tile sizes should be less than full frame JPEG
+    size_t deltaSize = 0;
+    for (const auto& t : delta.tiles) {
+        deltaSize += t.jpegData.size();
+    }
+    EXPECT_LT(deltaSize, fullJpeg.size());
+}
+
+TEST_F(FrameEncoderTest, EncodeDeltaNullInputs) {
+    auto frame = createTestRGBA(32, 32);
+
+    auto delta1 = encoder.encodeDelta(nullptr, frame.data(), 32, 32);
+    EXPECT_TRUE(delta1.tiles.empty());
+
+    auto delta2 = encoder.encodeDelta(frame.data(), nullptr, 32, 32);
+    EXPECT_TRUE(delta2.tiles.empty());
+}
+
+// =============================================================================
+// Delta serialization round-trip
+// =============================================================================
+
+TEST_F(FrameEncoderTest, SerializeDeltaRoundTrip) {
+    auto prev = createSolidRGBA(64, 64, 0, 0, 0);
+    auto curr = createSolidRGBA(64, 64, 0, 0, 0);
+
+    // Small change
+    for (uint32_t y = 10; y < 20; ++y) {
+        for (uint32_t x = 10; x < 20; ++x) {
+            size_t idx = (static_cast<size_t>(y) * 64 + x) * 4;
+            curr[idx + 0] = 200;
+        }
+    }
+
+    auto delta = encoder.encodeDelta(
+        curr.data(), prev.data(), 64, 64, 85);
+
+    auto serialized = FrameEncoder::serializeDelta(delta);
+    ASSERT_FALSE(serialized.empty());
+
+    auto deserialized = FrameEncoder::deserializeDelta(serialized);
+
+    EXPECT_EQ(deserialized.fullFrame, delta.fullFrame);
+    ASSERT_EQ(deserialized.tiles.size(), delta.tiles.size());
+
+    for (size_t i = 0; i < delta.tiles.size(); ++i) {
+        EXPECT_EQ(deserialized.tiles[i].x, delta.tiles[i].x);
+        EXPECT_EQ(deserialized.tiles[i].y, delta.tiles[i].y);
+        EXPECT_EQ(deserialized.tiles[i].width, delta.tiles[i].width);
+        EXPECT_EQ(deserialized.tiles[i].height, delta.tiles[i].height);
+        EXPECT_EQ(deserialized.tiles[i].jpegData.size(),
+                  delta.tiles[i].jpegData.size());
+        EXPECT_EQ(deserialized.tiles[i].jpegData, delta.tiles[i].jpegData);
+    }
+}
+
+TEST_F(FrameEncoderTest, DeserializeDeltaEmptyInput) {
+    auto delta = FrameEncoder::deserializeDelta({});
+    EXPECT_TRUE(delta.tiles.empty());
+}
+
+TEST_F(FrameEncoderTest, DeserializeDeltaTruncatedInput) {
+    std::vector<uint8_t> truncated = {0x00, 0x01, 0x00};
+    auto delta = FrameEncoder::deserializeDelta(truncated);
+    EXPECT_TRUE(delta.tiles.empty());
+}
+
+TEST_F(FrameEncoderTest, SerializeDeltaFullFrame) {
+    auto prev = createSolidRGBA(32, 32, 0, 0, 0);
+    auto curr = createSolidRGBA(32, 32, 255, 255, 255);
+
+    auto delta = encoder.encodeDelta(
+        curr.data(), prev.data(), 32, 32, 85);
+    EXPECT_TRUE(delta.fullFrame);
+
+    auto serialized = FrameEncoder::serializeDelta(delta);
+    auto deserialized = FrameEncoder::deserializeDelta(serialized);
+
+    EXPECT_TRUE(deserialized.fullFrame);
+    EXPECT_EQ(deserialized.tiles.size(), 1u);
 }


### PR DESCRIPTION
Closes #476

## Summary
- Add `DirtyRegionTracker` class for XOR-based pixel change detection between consecutive RGBA frames
- Extend `FrameEncoder` with `encodeDelta()` producing per-tile JPEG encoding of changed regions only
- Implement binary serialization/deserialization for delta frame wire protocol
- Integrate client-side tile compositor into `RemoteViewportWidget` for delta frame reconstruction
- Automatic full-frame fallback when dirty area exceeds 60% threshold (e.g., volume rotation, W/L change)
- Configurable merge gap (default 16px) reduces tile count by combining nearby dirty regions

## Test Plan
- [x] 19 `DirtyRegionTrackerTest` tests: construction, single/multiple regions, merge, threshold, extract/apply roundtrip, edge cases, move semantics, ratio accuracy
- [x] 9 new `FrameEncoderTest` delta tests: identical frames, small change, full-frame fallback, delta-smaller-than-full, null inputs, serialization round-trip, truncated input
- [x] All 53 new+existing tests pass (19 dirty + 34 frame encoder)
- [x] Full project build succeeds