### PR TITLE
feat(auth): integrate session token authentication with ATNA audit trail (#477)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -543,6 +543,7 @@ add_library(render_service STATIC
     src/services/render/render_session_manager.cpp
     src/services/render/adaptive_quality_controller.cpp
     src/services/render/dirty_region_tracker.cpp
+    src/services/render/session_token_validator.cpp
 )
 
 # Crow WebSocket framework (header-only)

--- a/include/services/render/render_session_manager.hpp
+++ b/include/services/render/render_session_manager.hpp
@@ -65,6 +65,8 @@ namespace dicom_viewer::services {
 
 class AdaptiveQualityController;
 class RenderSession;
+class SessionTokenValidator;
+enum class TokenValidationResult;
 
 /**
  * @brief Configuration for the render session manager
@@ -213,6 +215,32 @@ public:
      * @brief Get the manager configuration
      */
     [[nodiscard]] const RenderSessionManagerConfig& config() const;
+
+    /**
+     * @brief Get the session token validator
+     * @return Pointer to the token validator
+     */
+    [[nodiscard]] SessionTokenValidator* tokenValidator();
+
+    /**
+     * @brief Validate a token for a session
+     * @param token Token string to validate
+     * @param requiredStudyUid Study UID that the token must grant access to
+     * @return Token validation result
+     */
+    [[nodiscard]] TokenValidationResult validateSessionToken(
+        const std::string& token,
+        const std::string& requiredStudyUid = {});
+
+    /**
+     * @brief Generate a session access token
+     * @param userId User identity
+     * @param studyUid Study Instance UID to grant access to
+     * @return Signed token string
+     */
+    [[nodiscard]] std::string generateSessionToken(
+        const std::string& userId,
+        const std::string& studyUid);
 
 private:
     class Impl;

--- a/include/services/render/session_token_validator.hpp
+++ b/include/services/render/session_token_validator.hpp
@@ -1,0 +1,164 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file session_token_validator.hpp
+ * @brief Token-based authentication for render session access
+ * @details Generates and validates signed opaque tokens that bind a user
+ *          identity to a specific Study Instance UID with an expiry time.
+ *
+ * ## Token Format (opaque, base64url-encoded)
+ * ```
+ * base64url(study_uid:user_id:expiry_epoch:signature)
+ * ```
+ *
+ * The signature is computed over the payload using a server-side secret key.
+ * Tokens are short-lived (default 1 hour) and non-renewable.
+ *
+ * ## Thread Safety
+ * - All methods are thread-safe (internal mutex)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Configuration for session token validation
+ */
+struct SessionTokenConfig {
+    /// Server-side secret key for token signing
+    std::string secretKey = "dicom-viewer-default-secret";
+
+    /// Token expiry duration in seconds (default: 1 hour)
+    uint32_t expirySeconds = 3600;
+
+    /// Allow unauthenticated local connections for development
+    bool allowUnauthenticatedLocal = false;
+};
+
+/**
+ * @brief Result of token validation
+ */
+enum class TokenValidationResult {
+    Valid,              ///< Token is valid and authorized
+    Expired,            ///< Token has expired
+    InvalidSignature,   ///< Token signature does not match
+    InvalidFormat,      ///< Token format is malformed
+    StudyMismatch,      ///< Token was issued for a different study
+    Empty               ///< No token provided
+};
+
+/**
+ * @brief Decoded token payload
+ */
+struct TokenPayload {
+    std::string studyUid;    ///< Study Instance UID this token grants access to
+    std::string userId;      ///< User identity
+    uint64_t expiryEpoch = 0; ///< Expiry time as Unix epoch seconds
+};
+
+/**
+ * @brief Token-based authentication for render sessions
+ *
+ * Generates opaque tokens that bind a user to a specific study with
+ * an expiry time. Validates tokens on WebSocket connection to ensure
+ * only authorized clients can access render sessions.
+ *
+ * @trace SRS-FR-REMOTE-008
+ */
+class SessionTokenValidator {
+public:
+    explicit SessionTokenValidator(const SessionTokenConfig& config = {});
+    ~SessionTokenValidator();
+
+    // Non-copyable, movable
+    SessionTokenValidator(const SessionTokenValidator&) = delete;
+    SessionTokenValidator& operator=(const SessionTokenValidator&) = delete;
+    SessionTokenValidator(SessionTokenValidator&&) noexcept;
+    SessionTokenValidator& operator=(SessionTokenValidator&&) noexcept;
+
+    /**
+     * @brief Generate a new token for a user and study
+     * @param userId User identity
+     * @param studyUid Study Instance UID to grant access to
+     * @return Signed token string
+     */
+    [[nodiscard]] std::string generateToken(
+        const std::string& userId,
+        const std::string& studyUid) const;
+
+    /**
+     * @brief Validate a token
+     * @param token Token string to validate
+     * @param requiredStudyUid Study UID that the token must grant access to
+     * @return Validation result
+     */
+    [[nodiscard]] TokenValidationResult validateToken(
+        const std::string& token,
+        const std::string& requiredStudyUid = {}) const;
+
+    /**
+     * @brief Validate a token and extract its payload
+     * @param token Token string to validate
+     * @param[out] payload Decoded payload (populated on success)
+     * @return Validation result
+     */
+    [[nodiscard]] TokenValidationResult validateToken(
+        const std::string& token,
+        TokenPayload& payload) const;
+
+    /**
+     * @brief Check if unauthenticated local access is allowed
+     */
+    [[nodiscard]] bool allowsUnauthenticatedLocal() const;
+
+    /**
+     * @brief Get the current configuration
+     */
+    [[nodiscard]] const SessionTokenConfig& config() const;
+
+    /**
+     * @brief Update configuration
+     */
+    void setConfig(const SessionTokenConfig& config);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::services

--- a/include/services/render/websocket_frame_streamer.hpp
+++ b/include/services/render/websocket_frame_streamer.hpp
@@ -73,6 +73,9 @@
 
 namespace dicom_viewer::services {
 
+class AuditService;
+class SessionTokenValidator;
+
 /**
  * @brief Configuration for the WebSocket frame streaming server
  */
@@ -187,6 +190,23 @@ public:
      * @param sessionId Session to check
      */
     [[nodiscard]] bool hasClients(const std::string& sessionId) const;
+
+    /**
+     * @brief Set the token validator for WebSocket authentication
+     * @details When set, clients must pass a valid token as query parameter:
+     *          ws://host:port/render/{session_id}?token=<token>
+     *          If nullptr, no authentication is required.
+     * @param validator Non-owning pointer to a token validator
+     */
+    void setTokenValidator(SessionTokenValidator* validator);
+
+    /**
+     * @brief Set the audit service for ATNA audit trail logging
+     * @details When set, emits audit events for session connect, disconnect,
+     *          and authentication failures.
+     * @param audit Non-owning pointer to an audit service
+     */
+    void setAuditService(AuditService* audit);
 
 private:
     class Impl;

--- a/src/services/render/render_session_manager.cpp
+++ b/src/services/render/render_session_manager.cpp
@@ -30,6 +30,7 @@
 #include "services/render/render_session_manager.hpp"
 #include "services/render/adaptive_quality_controller.hpp"
 #include "services/render/render_session.hpp"
+#include "services/render/session_token_validator.hpp"
 
 #include <atomic>
 #include <chrono>
@@ -224,6 +225,8 @@ public:
 
     const RenderSessionManagerConfig& config() const { return config_; }
 
+    SessionTokenValidator& tokenValidator() { return tokenValidator_; }
+
 private:
     void renderLoop()
     {
@@ -290,6 +293,7 @@ private:
     }
 
     RenderSessionManagerConfig config_;
+    SessionTokenValidator tokenValidator_;
 
     mutable std::mutex mutex_;
     std::unordered_map<std::string, SessionEntry> sessions_;
@@ -394,6 +398,25 @@ std::vector<std::string> RenderSessionManager::activeSessionIds() const
 const RenderSessionManagerConfig& RenderSessionManager::config() const
 {
     return impl_->config();
+}
+
+SessionTokenValidator* RenderSessionManager::tokenValidator()
+{
+    return &impl_->tokenValidator();
+}
+
+TokenValidationResult RenderSessionManager::validateSessionToken(
+    const std::string& token,
+    const std::string& requiredStudyUid)
+{
+    return impl_->tokenValidator().validateToken(token, requiredStudyUid);
+}
+
+std::string RenderSessionManager::generateSessionToken(
+    const std::string& userId,
+    const std::string& studyUid)
+{
+    return impl_->tokenValidator().generateToken(userId, studyUid);
 }
 
 } // namespace dicom_viewer::services

--- a/src/services/render/session_token_validator.cpp
+++ b/src/services/render/session_token_validator.cpp
@@ -1,0 +1,306 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "services/render/session_token_validator.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <functional>
+#include <mutex>
+#include <sstream>
+
+namespace dicom_viewer::services {
+
+namespace {
+
+// Simple base64url encoding (no padding)
+std::string base64urlEncode(const std::string& input)
+{
+    static constexpr char table[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+    std::string result;
+    result.reserve((input.size() + 2) / 3 * 4);
+
+    size_t i = 0;
+    while (i < input.size()) {
+        size_t start = i;
+        uint32_t a = static_cast<uint8_t>(input[i++]);
+        uint32_t b = (i < input.size()) ? static_cast<uint8_t>(input[i++]) : 0;
+        uint32_t c = (i < input.size()) ? static_cast<uint8_t>(input[i++]) : 0;
+
+        uint32_t triple = (a << 16) | (b << 8) | c;
+
+        size_t remaining = input.size() - start;
+        result.push_back(table[(triple >> 18) & 0x3F]);
+        result.push_back(table[(triple >> 12) & 0x3F]);
+        if (remaining > 1) {
+            result.push_back(table[(triple >> 6) & 0x3F]);
+        }
+        if (remaining > 2) {
+            result.push_back(table[triple & 0x3F]);
+        }
+    }
+
+    return result;
+}
+
+// Simple base64url decoding
+std::string base64urlDecode(const std::string& input)
+{
+    auto decodeChar = [](char c) -> int {
+        if (c >= 'A' && c <= 'Z') return c - 'A';
+        if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+        if (c >= '0' && c <= '9') return c - '0' + 52;
+        if (c == '-') return 62;
+        if (c == '_') return 63;
+        return -1;
+    };
+
+    std::string result;
+    result.reserve(input.size() * 3 / 4);
+
+    size_t i = 0;
+    while (i < input.size()) {
+        int a = (i < input.size()) ? decodeChar(input[i++]) : -1;
+        int b = (i < input.size()) ? decodeChar(input[i++]) : -1;
+        int c = (i < input.size()) ? decodeChar(input[i++]) : -1;
+        int d = (i < input.size()) ? decodeChar(input[i++]) : -1;
+
+        if (a < 0 || b < 0) break;
+
+        uint32_t triple = (static_cast<uint32_t>(a) << 18)
+                         | (static_cast<uint32_t>(b) << 12);
+
+        result.push_back(static_cast<char>((triple >> 16) & 0xFF));
+
+        if (c >= 0) {
+            triple |= (static_cast<uint32_t>(c) << 6);
+            result.push_back(static_cast<char>((triple >> 8) & 0xFF));
+        }
+
+        if (d >= 0) {
+            triple |= static_cast<uint32_t>(d);
+            result.push_back(static_cast<char>(triple & 0xFF));
+        }
+    }
+
+    return result;
+}
+
+// Compute a keyed hash (HMAC-like) using std::hash for portability
+// Not cryptographically secure — suitable for same-process token validation
+std::string computeSignature(const std::string& payload,
+                              const std::string& secret)
+{
+    std::hash<std::string> hasher;
+    size_t h1 = hasher(secret + ":" + payload);
+    size_t h2 = hasher(payload + ":" + secret);
+
+    // Combine both hashes for reduced collision probability
+    uint64_t combined = (static_cast<uint64_t>(h1) << 32)
+                       | (static_cast<uint64_t>(h2) & 0xFFFFFFFF);
+
+    char buf[17];
+    std::snprintf(buf, sizeof(buf), "%016llx",
+                  static_cast<unsigned long long>(combined));
+    return std::string(buf);
+}
+
+uint64_t currentEpochSeconds()
+{
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count());
+}
+
+} // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// Impl
+// ---------------------------------------------------------------------------
+class SessionTokenValidator::Impl {
+public:
+    explicit Impl(const SessionTokenConfig& config) : config_(config) {}
+
+    std::string generateToken(const std::string& userId,
+                               const std::string& studyUid) const
+    {
+        std::lock_guard lock(mutex_);
+
+        uint64_t expiry = currentEpochSeconds() + config_.expirySeconds;
+
+        // Payload: study_uid|user_id|expiry
+        std::string payload = studyUid + "|" + userId + "|"
+                             + std::to_string(expiry);
+
+        std::string signature = computeSignature(payload, config_.secretKey);
+
+        // Token: base64url(payload|signature)
+        return base64urlEncode(payload + "|" + signature);
+    }
+
+    TokenValidationResult validateToken(
+        const std::string& token,
+        TokenPayload& payload) const
+    {
+        std::lock_guard lock(mutex_);
+
+        if (token.empty()) {
+            return TokenValidationResult::Empty;
+        }
+
+        std::string decoded = base64urlDecode(token);
+        if (decoded.empty()) {
+            return TokenValidationResult::InvalidFormat;
+        }
+
+        // Parse: study_uid|user_id|expiry|signature
+        std::vector<std::string> parts;
+        std::istringstream stream(decoded);
+        std::string part;
+        while (std::getline(stream, part, '|')) {
+            parts.push_back(part);
+        }
+
+        if (parts.size() != 4) {
+            return TokenValidationResult::InvalidFormat;
+        }
+
+        const auto& studyUid = parts[0];
+        const auto& userId = parts[1];
+        const auto& expiryStr = parts[2];
+        const auto& signature = parts[3];
+
+        // Reconstruct payload and verify signature
+        std::string payloadStr = studyUid + "|" + userId + "|" + expiryStr;
+        std::string expectedSig = computeSignature(
+            payloadStr, config_.secretKey);
+
+        if (signature != expectedSig) {
+            return TokenValidationResult::InvalidSignature;
+        }
+
+        // Parse expiry
+        uint64_t expiry = 0;
+        try {
+            expiry = std::stoull(expiryStr);
+        } catch (...) {
+            return TokenValidationResult::InvalidFormat;
+        }
+
+        // Check expiry
+        if (currentEpochSeconds() > expiry) {
+            return TokenValidationResult::Expired;
+        }
+
+        payload.studyUid = studyUid;
+        payload.userId = userId;
+        payload.expiryEpoch = expiry;
+
+        return TokenValidationResult::Valid;
+    }
+
+    TokenValidationResult validateToken(
+        const std::string& token,
+        const std::string& requiredStudyUid) const
+    {
+        TokenPayload payload;
+        auto result = validateToken(token, payload);
+
+        if (result != TokenValidationResult::Valid) {
+            return result;
+        }
+
+        if (!requiredStudyUid.empty()
+            && payload.studyUid != requiredStudyUid) {
+            return TokenValidationResult::StudyMismatch;
+        }
+
+        return TokenValidationResult::Valid;
+    }
+
+    mutable std::mutex mutex_;
+    SessionTokenConfig config_;
+};
+
+// ---------------------------------------------------------------------------
+// SessionTokenValidator lifecycle
+// ---------------------------------------------------------------------------
+SessionTokenValidator::SessionTokenValidator(const SessionTokenConfig& config)
+    : impl_(std::make_unique<Impl>(config))
+{
+}
+
+SessionTokenValidator::~SessionTokenValidator() = default;
+
+SessionTokenValidator::SessionTokenValidator(
+    SessionTokenValidator&&) noexcept = default;
+SessionTokenValidator& SessionTokenValidator::operator=(
+    SessionTokenValidator&&) noexcept = default;
+
+std::string SessionTokenValidator::generateToken(
+    const std::string& userId, const std::string& studyUid) const
+{
+    return impl_->generateToken(userId, studyUid);
+}
+
+TokenValidationResult SessionTokenValidator::validateToken(
+    const std::string& token,
+    const std::string& requiredStudyUid) const
+{
+    return impl_->validateToken(token, requiredStudyUid);
+}
+
+TokenValidationResult SessionTokenValidator::validateToken(
+    const std::string& token, TokenPayload& payload) const
+{
+    return impl_->validateToken(token, payload);
+}
+
+bool SessionTokenValidator::allowsUnauthenticatedLocal() const
+{
+    std::lock_guard lock(impl_->mutex_);
+    return impl_->config_.allowUnauthenticatedLocal;
+}
+
+const SessionTokenConfig& SessionTokenValidator::config() const
+{
+    return impl_->config_;
+}
+
+void SessionTokenValidator::setConfig(const SessionTokenConfig& config)
+{
+    std::lock_guard lock(impl_->mutex_);
+    impl_->config_ = config;
+}
+
+} // namespace dicom_viewer::services

--- a/src/services/render/websocket_frame_streamer.cpp
+++ b/src/services/render/websocket_frame_streamer.cpp
@@ -28,6 +28,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "services/render/websocket_frame_streamer.hpp"
+#include "services/audit_service.hpp"
+#include "services/render/session_token_validator.hpp"
 
 #include <crow.h>
 
@@ -67,19 +69,68 @@ public:
         CROW_WEBSOCKET_ROUTE((*app_), "/render/<string>")
             .onaccept([this](const crow::request& req, void** userdata) -> bool {
                 // Extract session_id from URL: /render/{session_id}
-                auto pos = req.url.rfind('/');
-                if (pos == std::string::npos || pos + 1 >= req.url.size()) {
+                auto urlPath = req.url;
+                // Strip query string for path parsing
+                auto qpos = urlPath.find('?');
+                if (qpos != std::string::npos) {
+                    urlPath = urlPath.substr(0, qpos);
+                }
+                auto pos = urlPath.rfind('/');
+                if (pos == std::string::npos || pos + 1 >= urlPath.size()) {
                     return false;
                 }
-                auto* sid = new std::string(req.url.substr(pos + 1));
+                std::string sessionId = urlPath.substr(pos + 1);
+
+                // Token validation (if validator is set)
+                SessionTokenValidator* validator = tokenValidator_.load();
+                if (validator) {
+                    // Extract token from query parameter: ?token=<token>
+                    std::string token;
+                    auto tokenParam = req.url_params.get("token");
+                    if (tokenParam) {
+                        token = tokenParam;
+                    }
+
+                    auto result = validator->validateToken(token, sessionId);
+                    if (result != TokenValidationResult::Valid) {
+                        // Audit authentication failure
+                        AuditService* audit = auditService_.load();
+                        if (audit) {
+                            std::string desc = "Render session auth failed for "
+                                + sessionId + ": ";
+                            switch (result) {
+                            case TokenValidationResult::Empty:
+                                desc += "no token provided";
+                                break;
+                            case TokenValidationResult::Expired:
+                                desc += "token expired";
+                                break;
+                            case TokenValidationResult::InvalidSignature:
+                                desc += "invalid signature";
+                                break;
+                            case TokenValidationResult::InvalidFormat:
+                                desc += "malformed token";
+                                break;
+                            case TokenValidationResult::StudyMismatch:
+                                desc += "study UID mismatch";
+                                break;
+                            default:
+                                desc += "unknown error";
+                                break;
+                            }
+                            audit->auditSecurityAlert("anonymous", desc);
+                        }
+                        return false;
+                    }
+                }
 
                 // Check max connections
                 std::lock_guard lock(mutex_);
                 if (connectionSessions_.size() >= config_.maxConnections) {
-                    delete sid;
                     return false;
                 }
 
+                auto* sid = new std::string(std::move(sessionId));
                 *userdata = sid;
                 return true;
             })
@@ -192,9 +243,18 @@ private:
     void onOpen(crow::websocket::connection& conn,
                 const std::string& sessionId)
     {
-        std::lock_guard lock(mutex_);
-        sessions_[sessionId].insert(&conn);
-        connectionSessions_[&conn] = sessionId;
+        {
+            std::lock_guard lock(mutex_);
+            sessions_[sessionId].insert(&conn);
+            connectionSessions_[&conn] = sessionId;
+        }
+
+        // Audit successful session connection
+        AuditService* audit = auditService_.load();
+        if (audit) {
+            audit->auditAssociation(
+                "render:" + sessionId, true /*isLogin*/, true /*success*/);
+        }
     }
 
     void onMessage(crow::websocket::connection& /*conn*/,
@@ -239,19 +299,31 @@ private:
     void onClose(crow::websocket::connection& conn,
                  const std::string& /*reason*/, uint16_t /*statusCode*/)
     {
-        std::lock_guard lock(mutex_);
+        std::string sessionId;
+        {
+            std::lock_guard lock(mutex_);
 
-        auto it = connectionSessions_.find(&conn);
-        if (it != connectionSessions_.end()) {
-            auto& sessionId = it->second;
-            auto sessIt = sessions_.find(sessionId);
-            if (sessIt != sessions_.end()) {
-                sessIt->second.erase(&conn);
-                if (sessIt->second.empty()) {
-                    sessions_.erase(sessIt);
+            auto it = connectionSessions_.find(&conn);
+            if (it != connectionSessions_.end()) {
+                sessionId = it->second;
+                auto sessIt = sessions_.find(sessionId);
+                if (sessIt != sessions_.end()) {
+                    sessIt->second.erase(&conn);
+                    if (sessIt->second.empty()) {
+                        sessions_.erase(sessIt);
+                    }
                 }
+                connectionSessions_.erase(it);
             }
-            connectionSessions_.erase(it);
+        }
+
+        // Audit session disconnection
+        if (!sessionId.empty()) {
+            AuditService* audit = auditService_.load();
+            if (audit) {
+                audit->auditAssociation(
+                    "render:" + sessionId, false /*isLogin*/, true /*success*/);
+            }
         }
     }
 
@@ -296,6 +368,10 @@ private:
                        std::string> connectionSessions_;
 
     InputEventCallback inputCallback_;
+
+public:
+    std::atomic<SessionTokenValidator*> tokenValidator_{nullptr};
+    std::atomic<AuditService*> auditService_{nullptr};
 };
 
 // ---------------------------------------------------------------------------
@@ -362,6 +438,18 @@ bool WebSocketFrameStreamer::hasClients(const std::string& sessionId) const
 {
     if (!impl_) return false;
     return impl_->hasClients(sessionId);
+}
+
+void WebSocketFrameStreamer::setTokenValidator(SessionTokenValidator* validator)
+{
+    if (!impl_) return;
+    impl_->tokenValidator_.store(validator);
+}
+
+void WebSocketFrameStreamer::setAuditService(AuditService* audit)
+{
+    if (!impl_) return;
+    impl_->auditService_.store(audit);
 }
 
 } // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2174,6 +2174,23 @@ target_include_directories(input_event_dispatcher_test PRIVATE
 
 gtest_discover_tests(input_event_dispatcher_test DISCOVERY_TIMEOUT 60)
 
+# Unit tests for SessionTokenValidator
+add_executable(session_token_validator_test
+    unit/session_token_validator_test.cpp
+)
+
+target_link_libraries(session_token_validator_test PRIVATE
+    render_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(session_token_validator_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(session_token_validator_test DISCOVERY_TIMEOUT 60)
+
 # Unit tests for RemoteViewportWidget
 add_executable(remote_viewport_widget_test
     unit/remote_viewport_widget_test.cpp

--- a/tests/unit/session_token_validator_test.cpp
+++ b/tests/unit/session_token_validator_test.cpp
@@ -1,0 +1,282 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include "services/render/session_token_validator.hpp"
+
+#include <chrono>
+#include <thread>
+
+using namespace dicom_viewer::services;
+
+// =============================================================================
+// Default construction
+// =============================================================================
+
+TEST(SessionTokenValidatorTest, DefaultConstruction) {
+    SessionTokenValidator validator;
+    EXPECT_FALSE(validator.allowsUnauthenticatedLocal());
+    EXPECT_EQ(validator.config().expirySeconds, 3600u);
+}
+
+TEST(SessionTokenValidatorTest, CustomConfig) {
+    SessionTokenConfig config;
+    config.secretKey = "my-secret";
+    config.expirySeconds = 7200;
+    config.allowUnauthenticatedLocal = true;
+
+    SessionTokenValidator validator(config);
+    EXPECT_TRUE(validator.allowsUnauthenticatedLocal());
+    EXPECT_EQ(validator.config().expirySeconds, 7200u);
+    EXPECT_EQ(validator.config().secretKey, "my-secret");
+}
+
+// =============================================================================
+// Token generation and validation
+// =============================================================================
+
+TEST(SessionTokenValidatorTest, GenerateAndValidateToken) {
+    SessionTokenValidator validator;
+
+    auto token = validator.generateToken("user1", "1.2.3.4.5");
+    EXPECT_FALSE(token.empty());
+
+    auto result = validator.validateToken(token, "1.2.3.4.5");
+    EXPECT_EQ(result, TokenValidationResult::Valid);
+}
+
+TEST(SessionTokenValidatorTest, ValidateTokenExtractPayload) {
+    SessionTokenValidator validator;
+
+    auto token = validator.generateToken("user1", "1.2.3.4.5");
+
+    TokenPayload payload;
+    auto result = validator.validateToken(token, payload);
+    EXPECT_EQ(result, TokenValidationResult::Valid);
+    EXPECT_EQ(payload.userId, "user1");
+    EXPECT_EQ(payload.studyUid, "1.2.3.4.5");
+    EXPECT_GT(payload.expiryEpoch, 0u);
+}
+
+TEST(SessionTokenValidatorTest, ValidateTokenNoStudyRestriction) {
+    SessionTokenValidator validator;
+
+    auto token = validator.generateToken("user1", "1.2.3.4.5");
+
+    // Validate without specifying a required study UID
+    auto result = validator.validateToken(token);
+    EXPECT_EQ(result, TokenValidationResult::Valid);
+}
+
+// =============================================================================
+// Token validation failures
+// =============================================================================
+
+TEST(SessionTokenValidatorTest, EmptyTokenReturnsEmpty) {
+    SessionTokenValidator validator;
+
+    auto result = validator.validateToken("");
+    EXPECT_EQ(result, TokenValidationResult::Empty);
+}
+
+TEST(SessionTokenValidatorTest, GarbageTokenReturnsInvalidFormat) {
+    SessionTokenValidator validator;
+
+    auto result = validator.validateToken("not-a-valid-token");
+    // Could be InvalidFormat or InvalidSignature depending on decode
+    EXPECT_NE(result, TokenValidationResult::Valid);
+}
+
+TEST(SessionTokenValidatorTest, WrongSecretReturnsInvalidSignature) {
+    SessionTokenConfig config1;
+    config1.secretKey = "secret-1";
+    SessionTokenValidator validator1(config1);
+
+    SessionTokenConfig config2;
+    config2.secretKey = "secret-2";
+    SessionTokenValidator validator2(config2);
+
+    auto token = validator1.generateToken("user1", "1.2.3.4.5");
+
+    // Validate with a different secret
+    auto result = validator2.validateToken(token, "1.2.3.4.5");
+    EXPECT_EQ(result, TokenValidationResult::InvalidSignature);
+}
+
+TEST(SessionTokenValidatorTest, StudyMismatchReturnsStudyMismatch) {
+    SessionTokenValidator validator;
+
+    auto token = validator.generateToken("user1", "1.2.3.4.5");
+
+    auto result = validator.validateToken(token, "9.8.7.6.5");
+    EXPECT_EQ(result, TokenValidationResult::StudyMismatch);
+}
+
+TEST(SessionTokenValidatorTest, ExpiredTokenReturnsExpired) {
+    SessionTokenConfig config;
+    config.expirySeconds = 0; // Expire immediately
+    SessionTokenValidator validator(config);
+
+    auto token = validator.generateToken("user1", "1.2.3.4.5");
+
+    // Wait briefly so current time exceeds the expiry (same-second edge case)
+    std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+
+    auto result = validator.validateToken(token, "1.2.3.4.5");
+    EXPECT_EQ(result, TokenValidationResult::Expired);
+}
+
+// =============================================================================
+// Configuration update
+// =============================================================================
+
+TEST(SessionTokenValidatorTest, SetConfigUpdatesSecret) {
+    SessionTokenValidator validator;
+
+    auto token = validator.generateToken("user1", "1.2.3.4.5");
+    EXPECT_EQ(validator.validateToken(token, "1.2.3.4.5"),
+              TokenValidationResult::Valid);
+
+    // Change secret — old tokens should no longer validate
+    SessionTokenConfig newConfig;
+    newConfig.secretKey = "new-secret-key";
+    validator.setConfig(newConfig);
+
+    auto result = validator.validateToken(token, "1.2.3.4.5");
+    EXPECT_EQ(result, TokenValidationResult::InvalidSignature);
+}
+
+TEST(SessionTokenValidatorTest, SetConfigUpdatesAllowLocal) {
+    SessionTokenValidator validator;
+    EXPECT_FALSE(validator.allowsUnauthenticatedLocal());
+
+    SessionTokenConfig config;
+    config.allowUnauthenticatedLocal = true;
+    validator.setConfig(config);
+    EXPECT_TRUE(validator.allowsUnauthenticatedLocal());
+}
+
+// =============================================================================
+// Multiple tokens
+// =============================================================================
+
+TEST(SessionTokenValidatorTest, DifferentUsersGetDifferentTokens) {
+    SessionTokenValidator validator;
+
+    auto token1 = validator.generateToken("user1", "1.2.3.4.5");
+    auto token2 = validator.generateToken("user2", "1.2.3.4.5");
+
+    EXPECT_NE(token1, token2);
+
+    // Both should be valid
+    EXPECT_EQ(validator.validateToken(token1, "1.2.3.4.5"),
+              TokenValidationResult::Valid);
+    EXPECT_EQ(validator.validateToken(token2, "1.2.3.4.5"),
+              TokenValidationResult::Valid);
+}
+
+TEST(SessionTokenValidatorTest, DifferentStudiesGetDifferentTokens) {
+    SessionTokenValidator validator;
+
+    auto token1 = validator.generateToken("user1", "1.2.3.4.5");
+    auto token2 = validator.generateToken("user1", "9.8.7.6.5");
+
+    EXPECT_NE(token1, token2);
+
+    // Each token valid for its own study
+    EXPECT_EQ(validator.validateToken(token1, "1.2.3.4.5"),
+              TokenValidationResult::Valid);
+    EXPECT_EQ(validator.validateToken(token2, "9.8.7.6.5"),
+              TokenValidationResult::Valid);
+
+    // Cross-validation should fail
+    EXPECT_EQ(validator.validateToken(token1, "9.8.7.6.5"),
+              TokenValidationResult::StudyMismatch);
+}
+
+// =============================================================================
+// Move semantics
+// =============================================================================
+
+TEST(SessionTokenValidatorTest, MoveConstruction) {
+    SessionTokenConfig config;
+    config.secretKey = "move-test";
+    SessionTokenValidator a(config);
+    auto token = a.generateToken("user1", "1.2.3.4.5");
+
+    SessionTokenValidator b(std::move(a));
+    EXPECT_EQ(b.validateToken(token, "1.2.3.4.5"),
+              TokenValidationResult::Valid);
+    EXPECT_EQ(b.config().secretKey, "move-test");
+}
+
+TEST(SessionTokenValidatorTest, MoveAssignment) {
+    SessionTokenConfig config;
+    config.secretKey = "move-assign";
+    SessionTokenValidator a(config);
+    auto token = a.generateToken("user1", "1.2.3.4.5");
+
+    SessionTokenValidator b;
+    b = std::move(a);
+    EXPECT_EQ(b.validateToken(token, "1.2.3.4.5"),
+              TokenValidationResult::Valid);
+    EXPECT_EQ(b.config().secretKey, "move-assign");
+}
+
+// =============================================================================
+// RenderSessionManager integration (token forwarding)
+// =============================================================================
+
+#include "services/render/render_session_manager.hpp"
+
+TEST(SessionTokenValidatorTest, ManagerTokenForwarding) {
+    RenderSessionManager manager;
+
+    auto token = manager.generateSessionToken("user1", "1.2.3.4.5");
+    EXPECT_FALSE(token.empty());
+
+    auto result = manager.validateSessionToken(token, "1.2.3.4.5");
+    EXPECT_EQ(result, TokenValidationResult::Valid);
+
+    // Wrong study should fail
+    result = manager.validateSessionToken(token, "9.8.7.6.5");
+    EXPECT_EQ(result, TokenValidationResult::StudyMismatch);
+}
+
+TEST(SessionTokenValidatorTest, ManagerTokenValidatorAccessible) {
+    RenderSessionManager manager;
+
+    auto* validator = manager.tokenValidator();
+    ASSERT_NE(validator, nullptr);
+
+    auto token = validator->generateToken("user1", "1.2.3.4.5");
+    EXPECT_EQ(validator->validateToken(token, "1.2.3.4.5"),
+              TokenValidationResult::Valid);
+}


### PR DESCRIPTION
Closes #477

## Summary
- Add `SessionTokenValidator` class for opaque token-based authentication binding user identity to Study Instance UID with configurable expiry
- Integrate token validation into `RenderSessionManager` with `generateSessionToken()`, `validateSessionToken()`, and `tokenValidator()` accessor
- Add token enforcement in `WebSocketFrameStreamer` `onaccept` handler — clients pass token as `?token=` query parameter
- Emit ATNA audit events via existing `AuditService`: `auditAssociation` for session connect/disconnect, `auditSecurityAlert` for authentication failures
- Fix base64url encoder bug where `remaining` bytes calculation was incorrect for partial blocks (caused signature mismatch on roundtrip)

## Architecture

### Token Flow
```
Client                     WebSocket Server               RenderSessionManager
  |                              |                              |
  |-- GET /render/{sid}?token=T ->|                              |
  |                              |-- validateToken(T, sid) ----->|
  |                              |<-- Valid/Invalid ------------|
  |                              |                              |
  |                              |-- auditAssociation (login) ->| (if valid)
  |<--- 101 Switching Protocols -|                              |
  |                              |-- auditSecurityAlert ------->| (if invalid)
  |<--- 403 Rejected ------------|                              |
```

### Token Format
`base64url(study_uid|user_id|expiry_epoch|signature)` with `std::hash`-based keyed signature (same-process validation only)

## Test Plan
- [x] 18 unit tests for `SessionTokenValidator`: valid token generation/validation, expiry, wrong secret, study mismatch, empty/garbage input, config update invalidation, move semantics, `RenderSessionManager` forwarding
- [x] All 34 existing `RenderSessionManager` tests pass unchanged
- [x] All 34 existing `FrameEncoder` tests pass unchanged
- [x] All 19 existing `DirtyRegionTracker` tests pass unchanged