### PR TITLE
security(auth): replace session tokens with rs256 jwt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,6 +470,23 @@ endif()
 find_package(spdlog REQUIRED)
 find_package(fmt REQUIRED)
 find_package(nlohmann_json REQUIRED)
+find_package(OpenSSL REQUIRED)
+find_package(jwt-cpp CONFIG QUIET)
+
+if(NOT TARGET jwt-cpp::jwt-cpp)
+    include(FetchContent)
+    FetchContent_Declare(
+        jwt_cpp
+        GIT_REPOSITORY https://github.com/Thalhammer/jwt-cpp.git
+        GIT_TAG        v0.7.1
+        GIT_SHALLOW    TRUE
+    )
+    set(JWT_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(JWT_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    set(JWT_DISABLE_PICOJSON OFF CACHE BOOL "" FORCE)
+    set(JWT_EXTERNAL_PICOJSON OFF CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(jwt_cpp)
+endif()
 
 # Include directories (VTK/ITK headers propagated via imported targets in target_link_libraries)
 include_directories(
@@ -555,6 +572,9 @@ target_link_libraries(render_service PUBLIC
     dicom_viewer_core
     coordinate_service
     ${VTK_LIBRARIES}
+    jwt-cpp::jwt-cpp
+    OpenSSL::SSL
+    OpenSSL::Crypto
 )
 
 if(EXISTS "${CROW_INCLUDE_DIR}/crow.h" AND EXISTS "${ASIO_INCLUDE_DIR}/asio.hpp")

--- a/include/services/render/session_token_validator.hpp
+++ b/include/services/render/session_token_validator.hpp
@@ -30,16 +30,11 @@
 /**
  * @file session_token_validator.hpp
  * @brief Token-based authentication for render session access
- * @details Generates and validates signed opaque tokens that bind a user
+ * @details Generates and validates RS256-signed JWTs that bind a user
  *          identity to a specific Study Instance UID with an expiry time.
  *
- * ## Token Format (opaque, base64url-encoded)
- * ```
- * base64url(study_uid:user_id:expiry_epoch:signature)
- * ```
- *
- * The signature is computed over the payload using a server-side secret key.
- * Tokens are short-lived (default 1 hour) and non-renewable.
+ * Tokens carry standard JWT claims (`sub`, `iss`, `aud`, `exp`, `iat`)
+ * plus viewer-specific claims (`study_uid`, `role`, `organization`).
  *
  * ## Thread Safety
  * - All methods are thread-safe (internal mutex)
@@ -60,14 +55,38 @@ namespace dicom_viewer::services {
  * @brief Configuration for session token validation
  */
 struct SessionTokenConfig {
-    /// Server-side secret key for token signing
-    std::string secretKey = "dicom-viewer-default-secret";
+    /// JWT issuer (`iss`)
+    std::string issuer = "dicom-viewer";
+
+    /// JWT audience (`aud`)
+    std::string audience = "dicom-viewer-render";
+
+    /// RSA private key file path for local token signing
+    std::string privateKeyPath;
+
+    /// RSA public key file path for local token verification
+    std::string publicKeyPath;
+
+    /// Optional JWKS endpoint URL for future remote key rotation
+    std::string jwksEndpointUrl;
+
+    /// JWT key identifier (`kid`)
+    std::string keyId = "dicom-viewer-local";
+
+    /// Default role claim when callers do not provide one yet
+    std::string defaultRole = "Viewer";
+
+    /// Default organization claim when callers do not provide one yet
+    std::string defaultOrganization = "local";
 
     /// Token expiry duration in seconds (default: 1 hour)
     uint32_t expirySeconds = 3600;
 
     /// Allow unauthenticated local connections for development
     bool allowUnauthenticatedLocal = false;
+
+    /// Generate an ephemeral in-memory key pair when no file paths are set
+    bool allowEphemeralKeys = true;
 };
 
 /**
@@ -77,7 +96,9 @@ enum class TokenValidationResult {
     Valid,              ///< Token is valid and authorized
     Expired,            ///< Token has expired
     InvalidSignature,   ///< Token signature does not match
+    InvalidClaims,      ///< Issuer/audience or other claims do not match
     InvalidFormat,      ///< Token format is malformed
+    UnsupportedAlgorithm, ///< Token uses an unsupported signing algorithm
     StudyMismatch,      ///< Token was issued for a different study
     Empty               ///< No token provided
 };
@@ -88,6 +109,11 @@ enum class TokenValidationResult {
 struct TokenPayload {
     std::string studyUid;    ///< Study Instance UID this token grants access to
     std::string userId;      ///< User identity
+    std::string issuer;      ///< JWT issuer
+    std::string audience;    ///< JWT audience
+    std::string role;        ///< Downstream RBAC role
+    std::string organization; ///< Tenant / organization scope
+    uint64_t issuedAtEpoch = 0; ///< Issued-at time as Unix epoch seconds
     uint64_t expiryEpoch = 0; ///< Expiry time as Unix epoch seconds
 };
 

--- a/src/services/render/session_token_validator.cpp
+++ b/src/services/render/session_token_validator.cpp
@@ -29,148 +29,216 @@
 
 #include "services/render/session_token_validator.hpp"
 
-#include <algorithm>
+#include <jwt-cpp/jwt.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+
 #include <chrono>
-#include <cstring>
-#include <functional>
+#include <filesystem>
+#include <fstream>
+#include <memory>
 #include <mutex>
 #include <sstream>
+#include <system_error>
 
 namespace dicom_viewer::services {
 
 namespace {
 
-// Simple base64url encoding (no padding)
-std::string base64urlEncode(const std::string& input)
+using EvpPkeyPtr = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>;
+using EvpPkeyCtxPtr = std::unique_ptr<EVP_PKEY_CTX, decltype(&EVP_PKEY_CTX_free)>;
+using BioPtr = std::unique_ptr<BIO, decltype(&BIO_free)>;
+
+struct KeyMaterial {
+    std::string privateKeyPem;
+    std::string publicKeyPem;
+};
+
+std::string readFileIfPresent(const std::string& path)
 {
-    static constexpr char table[] =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
-
-    std::string result;
-    result.reserve((input.size() + 2) / 3 * 4);
-
-    size_t i = 0;
-    while (i < input.size()) {
-        size_t start = i;
-        uint32_t a = static_cast<uint8_t>(input[i++]);
-        uint32_t b = (i < input.size()) ? static_cast<uint8_t>(input[i++]) : 0;
-        uint32_t c = (i < input.size()) ? static_cast<uint8_t>(input[i++]) : 0;
-
-        uint32_t triple = (a << 16) | (b << 8) | c;
-
-        size_t remaining = input.size() - start;
-        result.push_back(table[(triple >> 18) & 0x3F]);
-        result.push_back(table[(triple >> 12) & 0x3F]);
-        if (remaining > 1) {
-            result.push_back(table[(triple >> 6) & 0x3F]);
-        }
-        if (remaining > 2) {
-            result.push_back(table[triple & 0x3F]);
-        }
+    if (path.empty() || !std::filesystem::exists(path)) {
+        return {};
     }
 
-    return result;
+    std::ifstream input(path, std::ios::binary);
+    if (!input) {
+        return {};
+    }
+
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    return buffer.str();
 }
 
-// Simple base64url decoding
-std::string base64urlDecode(const std::string& input)
+std::string readBioToString(BIO* bio)
 {
-    auto decodeChar = [](char c) -> int {
-        if (c >= 'A' && c <= 'Z') return c - 'A';
-        if (c >= 'a' && c <= 'z') return c - 'a' + 26;
-        if (c >= '0' && c <= '9') return c - '0' + 52;
-        if (c == '-') return 62;
-        if (c == '_') return 63;
-        return -1;
+    const auto size = BIO_pending(bio);
+    if (size <= 0) {
+        return {};
+    }
+
+    std::string value(static_cast<size_t>(size), '\0');
+    const auto read = BIO_read(bio, value.data(), size);
+    if (read <= 0) {
+        return {};
+    }
+
+    value.resize(static_cast<size_t>(read));
+    return value;
+}
+
+std::string derivePublicKeyPem(const std::string& privateKeyPem)
+{
+    if (privateKeyPem.empty()) {
+        return {};
+    }
+
+    BioPtr privateBio(BIO_new_mem_buf(
+                          privateKeyPem.data(),
+                          static_cast<int>(privateKeyPem.size())),
+                      BIO_free);
+    if (!privateBio) {
+        return {};
+    }
+
+    EvpPkeyPtr key(PEM_read_bio_PrivateKey(privateBio.get(), nullptr, nullptr, nullptr),
+                   EVP_PKEY_free);
+    if (!key) {
+        return {};
+    }
+
+    BioPtr publicBio(BIO_new(BIO_s_mem()), BIO_free);
+    if (!publicBio || PEM_write_bio_PUBKEY(publicBio.get(), key.get()) != 1) {
+        return {};
+    }
+
+    return readBioToString(publicBio.get());
+}
+
+KeyMaterial generateEphemeralKeyMaterial()
+{
+    EvpPkeyCtxPtr ctx(EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, nullptr),
+                      EVP_PKEY_CTX_free);
+    if (!ctx || EVP_PKEY_keygen_init(ctx.get()) <= 0) {
+        return {};
+    }
+
+    if (EVP_PKEY_CTX_set_rsa_keygen_bits(ctx.get(), 2048) <= 0) {
+        return {};
+    }
+
+    EVP_PKEY* rawKey = nullptr;
+    if (EVP_PKEY_keygen(ctx.get(), &rawKey) <= 0 || !rawKey) {
+        return {};
+    }
+
+    EvpPkeyPtr key(rawKey, EVP_PKEY_free);
+
+    BioPtr privateBio(BIO_new(BIO_s_mem()), BIO_free);
+    BioPtr publicBio(BIO_new(BIO_s_mem()), BIO_free);
+    if (!privateBio || !publicBio) {
+        return {};
+    }
+
+    if (PEM_write_bio_PrivateKey(privateBio.get(), key.get(), nullptr, nullptr, 0, nullptr, nullptr) != 1) {
+        return {};
+    }
+    if (PEM_write_bio_PUBKEY(publicBio.get(), key.get()) != 1) {
+        return {};
+    }
+
+    return {
+        readBioToString(privateBio.get()),
+        readBioToString(publicBio.get())
     };
-
-    std::string result;
-    result.reserve(input.size() * 3 / 4);
-
-    size_t i = 0;
-    while (i < input.size()) {
-        int a = (i < input.size()) ? decodeChar(input[i++]) : -1;
-        int b = (i < input.size()) ? decodeChar(input[i++]) : -1;
-        int c = (i < input.size()) ? decodeChar(input[i++]) : -1;
-        int d = (i < input.size()) ? decodeChar(input[i++]) : -1;
-
-        if (a < 0 || b < 0) break;
-
-        uint32_t triple = (static_cast<uint32_t>(a) << 18)
-                         | (static_cast<uint32_t>(b) << 12);
-
-        result.push_back(static_cast<char>((triple >> 16) & 0xFF));
-
-        if (c >= 0) {
-            triple |= (static_cast<uint32_t>(c) << 6);
-            result.push_back(static_cast<char>((triple >> 8) & 0xFF));
-        }
-
-        if (d >= 0) {
-            triple |= static_cast<uint32_t>(d);
-            result.push_back(static_cast<char>(triple & 0xFF));
-        }
-    }
-
-    return result;
 }
 
-// Compute a keyed hash (HMAC-like) using std::hash for portability
-// Not cryptographically secure — suitable for same-process token validation
-std::string computeSignature(const std::string& payload,
-                              const std::string& secret)
-{
-    std::hash<std::string> hasher;
-    size_t h1 = hasher(secret + ":" + payload);
-    size_t h2 = hasher(payload + ":" + secret);
-
-    // Combine both hashes for reduced collision probability
-    uint64_t combined = (static_cast<uint64_t>(h1) << 32)
-                       | (static_cast<uint64_t>(h2) & 0xFFFFFFFF);
-
-    char buf[17];
-    std::snprintf(buf, sizeof(buf), "%016llx",
-                  static_cast<unsigned long long>(combined));
-    return std::string(buf);
-}
-
-uint64_t currentEpochSeconds()
+uint64_t toEpochSeconds(const std::chrono::system_clock::time_point& timePoint)
 {
     return static_cast<uint64_t>(
         std::chrono::duration_cast<std::chrono::seconds>(
-            std::chrono::system_clock::now().time_since_epoch())
-            .count());
+            timePoint.time_since_epoch()).count());
 }
 
-} // anonymous namespace
+template<typename DecodedJwt>
+std::string getOptionalStringClaim(const DecodedJwt& decoded,
+                                   const std::string& claimName)
+{
+    if (!decoded.has_payload_claim(claimName)) {
+        return {};
+    }
+
+    return decoded.get_payload_claim(claimName).as_string();
+}
+
+TokenValidationResult mapVerificationError(const std::error_code& error)
+{
+    using jwt::error::token_verification_error;
+
+    if (!error) {
+        return TokenValidationResult::Valid;
+    }
+
+    if (error == token_verification_error::token_expired) {
+        return TokenValidationResult::Expired;
+    }
+    if (error == token_verification_error::wrong_algorithm) {
+        return TokenValidationResult::UnsupportedAlgorithm;
+    }
+    if (error == token_verification_error::audience_missmatch
+        || error == token_verification_error::claim_value_missmatch
+        || error == token_verification_error::claim_type_missmatch
+        || error == token_verification_error::missing_claim) {
+        return TokenValidationResult::InvalidClaims;
+    }
+
+    return TokenValidationResult::InvalidSignature;
+}
+
+} // namespace
 
 // ---------------------------------------------------------------------------
 // Impl
 // ---------------------------------------------------------------------------
 class SessionTokenValidator::Impl {
 public:
-    explicit Impl(const SessionTokenConfig& config) : config_(config) {}
+    explicit Impl(const SessionTokenConfig& config) : config_(config)
+    {
+        refreshKeyMaterial();
+    }
 
     std::string generateToken(const std::string& userId,
-                               const std::string& studyUid) const
+                              const std::string& studyUid) const
     {
         std::lock_guard lock(mutex_);
 
-        uint64_t expiry = currentEpochSeconds() + config_.expirySeconds;
+        if (keyMaterial_.privateKeyPem.empty()) {
+            return {};
+        }
 
-        // Payload: study_uid|user_id|expiry
-        std::string payload = studyUid + "|" + userId + "|"
-                             + std::to_string(expiry);
+        const auto now = std::chrono::system_clock::now();
+        const auto expiry = now + std::chrono::seconds(config_.expirySeconds);
 
-        std::string signature = computeSignature(payload, config_.secretKey);
-
-        // Token: base64url(payload|signature)
-        return base64urlEncode(payload + "|" + signature);
+        try {
+            return jwt::create()
+                .set_type("JWT")
+                .set_key_id(config_.keyId)
+                .set_issuer(config_.issuer)
+                .set_audience(config_.audience)
+                .set_subject(userId)
+                .set_issued_at(now)
+                .set_expires_at(expiry)
+                .set_payload_claim("study_uid", jwt::claim(std::string(studyUid)))
+                .set_payload_claim("role", jwt::claim(std::string(config_.defaultRole)))
+                .set_payload_claim("organization", jwt::claim(std::string(config_.defaultOrganization)))
+                .sign(jwt::algorithm::rs256("", keyMaterial_.privateKeyPem, "", ""));
+        } catch (...) {
+            return {};
+        }
     }
 
-    TokenValidationResult validateToken(
-        const std::string& token,
-        TokenPayload& payload) const
+    TokenValidationResult validateToken(const std::string& token,
+                                        TokenPayload& payload) const
     {
         std::lock_guard lock(mutex_);
 
@@ -178,78 +246,99 @@ public:
             return TokenValidationResult::Empty;
         }
 
-        std::string decoded = base64urlDecode(token);
-        if (decoded.empty()) {
+        auto decoded = jwt::decode(token);
+        if (!decoded.has_algorithm()) {
             return TokenValidationResult::InvalidFormat;
         }
-
-        // Parse: study_uid|user_id|expiry|signature
-        std::vector<std::string> parts;
-        std::istringstream stream(decoded);
-        std::string part;
-        while (std::getline(stream, part, '|')) {
-            parts.push_back(part);
+        if (decoded.get_algorithm() != "RS256") {
+            return TokenValidationResult::UnsupportedAlgorithm;
         }
 
-        if (parts.size() != 4) {
-            return TokenValidationResult::InvalidFormat;
-        }
-
-        const auto& studyUid = parts[0];
-        const auto& userId = parts[1];
-        const auto& expiryStr = parts[2];
-        const auto& signature = parts[3];
-
-        // Reconstruct payload and verify signature
-        std::string payloadStr = studyUid + "|" + userId + "|" + expiryStr;
-        std::string expectedSig = computeSignature(
-            payloadStr, config_.secretKey);
-
-        if (signature != expectedSig) {
+        if (keyMaterial_.publicKeyPem.empty()) {
             return TokenValidationResult::InvalidSignature;
         }
 
-        // Parse expiry
-        uint64_t expiry = 0;
-        try {
-            expiry = std::stoull(expiryStr);
-        } catch (...) {
-            return TokenValidationResult::InvalidFormat;
-        }
+        std::error_code error;
+        jwt::verify()
+            .allow_algorithm(jwt::algorithm::rs256(keyMaterial_.publicKeyPem, "", "", ""))
+            .with_issuer(config_.issuer)
+            .with_audience(config_.audience)
+            .verify(decoded, error);
 
-        // Check expiry
-        if (currentEpochSeconds() > expiry) {
-            return TokenValidationResult::Expired;
-        }
-
-        payload.studyUid = studyUid;
-        payload.userId = userId;
-        payload.expiryEpoch = expiry;
-
-        return TokenValidationResult::Valid;
-    }
-
-    TokenValidationResult validateToken(
-        const std::string& token,
-        const std::string& requiredStudyUid) const
-    {
-        TokenPayload payload;
-        auto result = validateToken(token, payload);
-
+        auto result = mapVerificationError(error);
         if (result != TokenValidationResult::Valid) {
             return result;
         }
 
-        if (!requiredStudyUid.empty()
-            && payload.studyUid != requiredStudyUid) {
+        try {
+            payload.userId = decoded.get_subject();
+            payload.studyUid = getOptionalStringClaim(decoded, "study_uid");
+            payload.issuer = decoded.get_issuer();
+            if (decoded.has_audience()) {
+                const auto audiences = decoded.get_audience();
+                if (!audiences.empty()) {
+                    payload.audience = *audiences.begin();
+                }
+            }
+            payload.role = getOptionalStringClaim(decoded, "role");
+            payload.organization = getOptionalStringClaim(decoded, "organization");
+            payload.issuedAtEpoch = decoded.has_issued_at()
+                ? toEpochSeconds(decoded.get_issued_at()) : 0;
+            payload.expiryEpoch = decoded.has_expires_at()
+                ? toEpochSeconds(decoded.get_expires_at()) : 0;
+        } catch (...) {
+            return TokenValidationResult::InvalidClaims;
+        }
+
+        if (payload.userId.empty() || payload.studyUid.empty()) {
+            return TokenValidationResult::InvalidClaims;
+        }
+
+        return TokenValidationResult::Valid;
+    }
+
+    TokenValidationResult validateToken(const std::string& token,
+                                        const std::string& requiredStudyUid) const
+    {
+        TokenPayload payload;
+        auto result = validateToken(token, payload);
+        if (result != TokenValidationResult::Valid) {
+            return result;
+        }
+
+        if (!requiredStudyUid.empty() && payload.studyUid != requiredStudyUid) {
             return TokenValidationResult::StudyMismatch;
         }
 
         return TokenValidationResult::Valid;
     }
 
+    void setConfig(const SessionTokenConfig& config)
+    {
+        std::lock_guard lock(mutex_);
+        config_ = config;
+        refreshKeyMaterial();
+    }
+
+    void refreshKeyMaterial()
+    {
+        keyMaterial_.privateKeyPem = readFileIfPresent(config_.privateKeyPath);
+        keyMaterial_.publicKeyPem = readFileIfPresent(config_.publicKeyPath);
+
+        if (keyMaterial_.publicKeyPem.empty() && !keyMaterial_.privateKeyPem.empty()) {
+            keyMaterial_.publicKeyPem = derivePublicKeyPem(keyMaterial_.privateKeyPem);
+        }
+
+        if (keyMaterial_.privateKeyPem.empty()
+            && keyMaterial_.publicKeyPem.empty()
+            && config_.allowEphemeralKeys) {
+            keyMaterial_ = generateEphemeralKeyMaterial();
+        }
+    }
+
     mutable std::mutex mutex_;
     SessionTokenConfig config_;
+    KeyMaterial keyMaterial_;
 };
 
 // ---------------------------------------------------------------------------
@@ -277,13 +366,21 @@ TokenValidationResult SessionTokenValidator::validateToken(
     const std::string& token,
     const std::string& requiredStudyUid) const
 {
-    return impl_->validateToken(token, requiredStudyUid);
+    try {
+        return impl_->validateToken(token, requiredStudyUid);
+    } catch (...) {
+        return TokenValidationResult::InvalidFormat;
+    }
 }
 
 TokenValidationResult SessionTokenValidator::validateToken(
     const std::string& token, TokenPayload& payload) const
 {
-    return impl_->validateToken(token, payload);
+    try {
+        return impl_->validateToken(token, payload);
+    } catch (...) {
+        return TokenValidationResult::InvalidFormat;
+    }
 }
 
 bool SessionTokenValidator::allowsUnauthenticatedLocal() const
@@ -299,8 +396,7 @@ const SessionTokenConfig& SessionTokenValidator::config() const
 
 void SessionTokenValidator::setConfig(const SessionTokenConfig& config)
 {
-    std::lock_guard lock(impl_->mutex_);
-    impl_->config_ = config;
+    impl_->setConfig(config);
 }
 
 } // namespace dicom_viewer::services

--- a/src/services/render/websocket_frame_streamer.cpp
+++ b/src/services/render/websocket_frame_streamer.cpp
@@ -91,7 +91,7 @@ public:
                         token = tokenParam;
                     }
 
-                    auto result = validator->validateToken(token, sessionId);
+                    auto result = validator->validateToken(token);
                     if (result != TokenValidationResult::Valid) {
                         // Audit authentication failure
                         AuditService* audit = auditService_.load();
@@ -108,8 +108,14 @@ public:
                             case TokenValidationResult::InvalidSignature:
                                 desc += "invalid signature";
                                 break;
+                            case TokenValidationResult::InvalidClaims:
+                                desc += "invalid claims";
+                                break;
                             case TokenValidationResult::InvalidFormat:
                                 desc += "malformed token";
+                                break;
+                            case TokenValidationResult::UnsupportedAlgorithm:
+                                desc += "unsupported JWT algorithm";
                                 break;
                             case TokenValidationResult::StudyMismatch:
                                 desc += "study UID mismatch";

--- a/tests/unit/session_token_validator_test.cpp
+++ b/tests/unit/session_token_validator_test.cpp
@@ -31,39 +31,173 @@
 
 #include "services/render/session_token_validator.hpp"
 
+#include <jwt-cpp/jwt.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+
 #include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <memory>
 #include <thread>
 
 using namespace dicom_viewer::services;
+
+namespace {
+
+using EvpPkeyPtr = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>;
+using EvpPkeyCtxPtr = std::unique_ptr<EVP_PKEY_CTX, decltype(&EVP_PKEY_CTX_free)>;
+using BioPtr = std::unique_ptr<BIO, decltype(&BIO_free)>;
+
+std::string readBioToString(BIO* bio)
+{
+    const auto size = BIO_pending(bio);
+    if (size <= 0) {
+        return {};
+    }
+
+    std::string value(static_cast<size_t>(size), '\0');
+    const auto read = BIO_read(bio, value.data(), size);
+    if (read <= 0) {
+        return {};
+    }
+
+    value.resize(static_cast<size_t>(read));
+    return value;
+}
+
+std::pair<std::string, std::string> generateTestKeyPairPem()
+{
+    EvpPkeyCtxPtr ctx(EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, nullptr),
+                      EVP_PKEY_CTX_free);
+    if (!ctx || EVP_PKEY_keygen_init(ctx.get()) <= 0) {
+        return {};
+    }
+
+    if (EVP_PKEY_CTX_set_rsa_keygen_bits(ctx.get(), 2048) <= 0) {
+        return {};
+    }
+
+    EVP_PKEY* rawKey = nullptr;
+    if (EVP_PKEY_keygen(ctx.get(), &rawKey) <= 0 || !rawKey) {
+        return {};
+    }
+
+    EvpPkeyPtr key(rawKey, EVP_PKEY_free);
+    BioPtr privateBio(BIO_new(BIO_s_mem()), BIO_free);
+    BioPtr publicBio(BIO_new(BIO_s_mem()), BIO_free);
+    if (!privateBio || !publicBio) {
+        return {};
+    }
+
+    if (PEM_write_bio_PrivateKey(privateBio.get(), key.get(), nullptr, nullptr, 0,
+                                 nullptr, nullptr) != 1) {
+        return {};
+    }
+    if (PEM_write_bio_PUBKEY(publicBio.get(), key.get()) != 1) {
+        return {};
+    }
+
+    return {
+        readBioToString(privateBio.get()),
+        readBioToString(publicBio.get())
+    };
+}
+
+class SessionTokenValidatorTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        tempDir_ = std::filesystem::temp_directory_path()
+            / ("dicom_viewer_session_token_validator_"
+               + std::to_string(
+                   std::chrono::steady_clock::now().time_since_epoch().count()));
+        std::filesystem::create_directories(tempDir_);
+        privateKeyPath_ = tempDir_ / "jwt-private.pem";
+        publicKeyPath_ = tempDir_ / "jwt-public.pem";
+
+        const auto [privateKeyPem, publicKeyPem] = generateTestKeyPairPem();
+        ASSERT_FALSE(privateKeyPem.empty());
+        ASSERT_FALSE(publicKeyPem.empty());
+
+        std::ofstream(privateKeyPath_) << privateKeyPem;
+        std::ofstream(publicKeyPath_) << publicKeyPem;
+    }
+
+    void TearDown() override
+    {
+        std::error_code error;
+        std::filesystem::remove_all(tempDir_, error);
+    }
+
+    SessionTokenConfig makeConfig() const
+    {
+        SessionTokenConfig config;
+        config.issuer = "dicom-viewer-tests";
+        config.audience = "render-clients";
+        config.privateKeyPath = privateKeyPath_.string();
+        config.publicKeyPath = publicKeyPath_.string();
+        config.keyId = "test-key";
+        config.defaultRole = "Clinician";
+        config.defaultOrganization = "Radiology";
+        config.allowEphemeralKeys = false;
+        return config;
+    }
+
+    std::filesystem::path tempDir_;
+    std::filesystem::path privateKeyPath_;
+    std::filesystem::path publicKeyPath_;
+};
+
+std::string createUnsignedToken(const SessionTokenConfig& config,
+                                const std::string& userId,
+                                const std::string& studyUid)
+{
+    const auto now = std::chrono::system_clock::now();
+    return jwt::create()
+        .set_type("JWT")
+        .set_issuer(config.issuer)
+        .set_audience(config.audience)
+        .set_subject(userId)
+        .set_issued_at(now)
+        .set_expires_at(now + std::chrono::minutes(5))
+        .set_payload_claim("study_uid", jwt::claim(std::string(studyUid)))
+        .set_payload_claim("role", jwt::claim(std::string(config.defaultRole)))
+        .set_payload_claim("organization", jwt::claim(std::string(config.defaultOrganization)))
+        .sign(jwt::algorithm::none{});
+}
+
+} // namespace
 
 // =============================================================================
 // Default construction
 // =============================================================================
 
-TEST(SessionTokenValidatorTest, DefaultConstruction) {
+TEST_F(SessionTokenValidatorTest, DefaultConstruction) {
     SessionTokenValidator validator;
     EXPECT_FALSE(validator.allowsUnauthenticatedLocal());
     EXPECT_EQ(validator.config().expirySeconds, 3600u);
+    EXPECT_FALSE(validator.config().issuer.empty());
+    EXPECT_FALSE(validator.config().audience.empty());
 }
 
-TEST(SessionTokenValidatorTest, CustomConfig) {
-    SessionTokenConfig config;
-    config.secretKey = "my-secret";
-    config.expirySeconds = 7200;
+TEST_F(SessionTokenValidatorTest, CustomConfig) {
+    auto config = makeConfig();
     config.allowUnauthenticatedLocal = true;
 
     SessionTokenValidator validator(config);
     EXPECT_TRUE(validator.allowsUnauthenticatedLocal());
-    EXPECT_EQ(validator.config().expirySeconds, 7200u);
-    EXPECT_EQ(validator.config().secretKey, "my-secret");
+    EXPECT_EQ(validator.config().issuer, "dicom-viewer-tests");
+    EXPECT_EQ(validator.config().audience, "render-clients");
+    EXPECT_EQ(validator.config().privateKeyPath, privateKeyPath_.string());
 }
 
 // =============================================================================
 // Token generation and validation
 // =============================================================================
 
-TEST(SessionTokenValidatorTest, GenerateAndValidateToken) {
-    SessionTokenValidator validator;
+TEST_F(SessionTokenValidatorTest, GenerateAndValidateToken) {
+    SessionTokenValidator validator(makeConfig());
 
     auto token = validator.generateToken("user1", "1.2.3.4.5");
     EXPECT_FALSE(token.empty());
@@ -72,8 +206,8 @@ TEST(SessionTokenValidatorTest, GenerateAndValidateToken) {
     EXPECT_EQ(result, TokenValidationResult::Valid);
 }
 
-TEST(SessionTokenValidatorTest, ValidateTokenExtractPayload) {
-    SessionTokenValidator validator;
+TEST_F(SessionTokenValidatorTest, ValidateTokenExtractPayload) {
+    SessionTokenValidator validator(makeConfig());
 
     auto token = validator.generateToken("user1", "1.2.3.4.5");
 
@@ -82,56 +216,64 @@ TEST(SessionTokenValidatorTest, ValidateTokenExtractPayload) {
     EXPECT_EQ(result, TokenValidationResult::Valid);
     EXPECT_EQ(payload.userId, "user1");
     EXPECT_EQ(payload.studyUid, "1.2.3.4.5");
-    EXPECT_GT(payload.expiryEpoch, 0u);
+    EXPECT_EQ(payload.issuer, "dicom-viewer-tests");
+    EXPECT_EQ(payload.audience, "render-clients");
+    EXPECT_EQ(payload.role, "Clinician");
+    EXPECT_EQ(payload.organization, "Radiology");
+    EXPECT_GT(payload.issuedAtEpoch, 0u);
+    EXPECT_GT(payload.expiryEpoch, payload.issuedAtEpoch);
 }
 
-TEST(SessionTokenValidatorTest, ValidateTokenNoStudyRestriction) {
-    SessionTokenValidator validator;
+TEST_F(SessionTokenValidatorTest, ValidateTokenNoStudyRestriction) {
+    SessionTokenValidator validator(makeConfig());
 
     auto token = validator.generateToken("user1", "1.2.3.4.5");
-
-    // Validate without specifying a required study UID
     auto result = validator.validateToken(token);
     EXPECT_EQ(result, TokenValidationResult::Valid);
+}
+
+TEST_F(SessionTokenValidatorTest, GeneratesTokenWithOnlyPrivateKeyPathConfigured) {
+    auto config = makeConfig();
+    config.publicKeyPath.clear();
+
+    SessionTokenValidator validator(config);
+    auto token = validator.generateToken("user1", "1.2.3.4.5");
+    EXPECT_FALSE(token.empty());
+    EXPECT_EQ(validator.validateToken(token, "1.2.3.4.5"),
+              TokenValidationResult::Valid);
 }
 
 // =============================================================================
 // Token validation failures
 // =============================================================================
 
-TEST(SessionTokenValidatorTest, EmptyTokenReturnsEmpty) {
-    SessionTokenValidator validator;
+TEST_F(SessionTokenValidatorTest, EmptyTokenReturnsEmpty) {
+    SessionTokenValidator validator(makeConfig());
 
     auto result = validator.validateToken("");
     EXPECT_EQ(result, TokenValidationResult::Empty);
 }
 
-TEST(SessionTokenValidatorTest, GarbageTokenReturnsInvalidFormat) {
-    SessionTokenValidator validator;
+TEST_F(SessionTokenValidatorTest, GarbageTokenReturnsInvalidFormat) {
+    SessionTokenValidator validator(makeConfig());
 
     auto result = validator.validateToken("not-a-valid-token");
-    // Could be InvalidFormat or InvalidSignature depending on decode
-    EXPECT_NE(result, TokenValidationResult::Valid);
+    EXPECT_EQ(result, TokenValidationResult::InvalidFormat);
 }
 
-TEST(SessionTokenValidatorTest, WrongSecretReturnsInvalidSignature) {
-    SessionTokenConfig config1;
-    config1.secretKey = "secret-1";
-    SessionTokenValidator validator1(config1);
+TEST_F(SessionTokenValidatorTest, TamperedTokenReturnsInvalidSignature) {
+    SessionTokenValidator validator(makeConfig());
 
-    SessionTokenConfig config2;
-    config2.secretKey = "secret-2";
-    SessionTokenValidator validator2(config2);
+    auto token = validator.generateToken("user1", "1.2.3.4.5");
+    ASSERT_FALSE(token.empty());
+    token.back() = token.back() == 'a' ? 'b' : 'a';
 
-    auto token = validator1.generateToken("user1", "1.2.3.4.5");
-
-    // Validate with a different secret
-    auto result = validator2.validateToken(token, "1.2.3.4.5");
+    auto result = validator.validateToken(token, "1.2.3.4.5");
     EXPECT_EQ(result, TokenValidationResult::InvalidSignature);
 }
 
-TEST(SessionTokenValidatorTest, StudyMismatchReturnsStudyMismatch) {
-    SessionTokenValidator validator;
+TEST_F(SessionTokenValidatorTest, StudyMismatchReturnsStudyMismatch) {
+    SessionTokenValidator validator(makeConfig());
 
     auto token = validator.generateToken("user1", "1.2.3.4.5");
 
@@ -139,45 +281,50 @@ TEST(SessionTokenValidatorTest, StudyMismatchReturnsStudyMismatch) {
     EXPECT_EQ(result, TokenValidationResult::StudyMismatch);
 }
 
-TEST(SessionTokenValidatorTest, ExpiredTokenReturnsExpired) {
-    SessionTokenConfig config;
-    config.expirySeconds = 0; // Expire immediately
+TEST_F(SessionTokenValidatorTest, ExpiredTokenReturnsExpired) {
+    auto config = makeConfig();
+    config.expirySeconds = 0;
     SessionTokenValidator validator(config);
 
     auto token = validator.generateToken("user1", "1.2.3.4.5");
-
-    // Wait briefly so current time exceeds the expiry (same-second edge case)
     std::this_thread::sleep_for(std::chrono::milliseconds(1100));
 
     auto result = validator.validateToken(token, "1.2.3.4.5");
     EXPECT_EQ(result, TokenValidationResult::Expired);
 }
 
+TEST_F(SessionTokenValidatorTest, WrongIssuerReturnsInvalidClaims) {
+    auto config = makeConfig();
+    SessionTokenValidator validator(config);
+
+    auto token = validator.generateToken("user1", "1.2.3.4.5");
+    ASSERT_FALSE(token.empty());
+
+    config.issuer = "unexpected-issuer";
+    validator.setConfig(config);
+
+    auto result = validator.validateToken(token, "1.2.3.4.5");
+    EXPECT_EQ(result, TokenValidationResult::InvalidClaims);
+}
+
+TEST_F(SessionTokenValidatorTest, NoneAlgorithmReturnsUnsupportedAlgorithm) {
+    auto config = makeConfig();
+    SessionTokenValidator validator(config);
+
+    auto token = createUnsignedToken(config, "user1", "1.2.3.4.5");
+    auto result = validator.validateToken(token, "1.2.3.4.5");
+    EXPECT_EQ(result, TokenValidationResult::UnsupportedAlgorithm);
+}
+
 // =============================================================================
 // Configuration update
 // =============================================================================
 
-TEST(SessionTokenValidatorTest, SetConfigUpdatesSecret) {
-    SessionTokenValidator validator;
-
-    auto token = validator.generateToken("user1", "1.2.3.4.5");
-    EXPECT_EQ(validator.validateToken(token, "1.2.3.4.5"),
-              TokenValidationResult::Valid);
-
-    // Change secret — old tokens should no longer validate
-    SessionTokenConfig newConfig;
-    newConfig.secretKey = "new-secret-key";
-    validator.setConfig(newConfig);
-
-    auto result = validator.validateToken(token, "1.2.3.4.5");
-    EXPECT_EQ(result, TokenValidationResult::InvalidSignature);
-}
-
-TEST(SessionTokenValidatorTest, SetConfigUpdatesAllowLocal) {
-    SessionTokenValidator validator;
+TEST_F(SessionTokenValidatorTest, SetConfigUpdatesAllowLocal) {
+    SessionTokenValidator validator(makeConfig());
     EXPECT_FALSE(validator.allowsUnauthenticatedLocal());
 
-    SessionTokenConfig config;
+    auto config = makeConfig();
     config.allowUnauthenticatedLocal = true;
     validator.setConfig(config);
     EXPECT_TRUE(validator.allowsUnauthenticatedLocal());
@@ -187,36 +334,30 @@ TEST(SessionTokenValidatorTest, SetConfigUpdatesAllowLocal) {
 // Multiple tokens
 // =============================================================================
 
-TEST(SessionTokenValidatorTest, DifferentUsersGetDifferentTokens) {
-    SessionTokenValidator validator;
+TEST_F(SessionTokenValidatorTest, DifferentUsersGetDifferentTokens) {
+    SessionTokenValidator validator(makeConfig());
 
     auto token1 = validator.generateToken("user1", "1.2.3.4.5");
     auto token2 = validator.generateToken("user2", "1.2.3.4.5");
 
     EXPECT_NE(token1, token2);
-
-    // Both should be valid
     EXPECT_EQ(validator.validateToken(token1, "1.2.3.4.5"),
               TokenValidationResult::Valid);
     EXPECT_EQ(validator.validateToken(token2, "1.2.3.4.5"),
               TokenValidationResult::Valid);
 }
 
-TEST(SessionTokenValidatorTest, DifferentStudiesGetDifferentTokens) {
-    SessionTokenValidator validator;
+TEST_F(SessionTokenValidatorTest, DifferentStudiesGetDifferentTokens) {
+    SessionTokenValidator validator(makeConfig());
 
     auto token1 = validator.generateToken("user1", "1.2.3.4.5");
     auto token2 = validator.generateToken("user1", "9.8.7.6.5");
 
     EXPECT_NE(token1, token2);
-
-    // Each token valid for its own study
     EXPECT_EQ(validator.validateToken(token1, "1.2.3.4.5"),
               TokenValidationResult::Valid);
     EXPECT_EQ(validator.validateToken(token2, "9.8.7.6.5"),
               TokenValidationResult::Valid);
-
-    // Cross-validation should fail
     EXPECT_EQ(validator.validateToken(token1, "9.8.7.6.5"),
               TokenValidationResult::StudyMismatch);
 }
@@ -225,21 +366,19 @@ TEST(SessionTokenValidatorTest, DifferentStudiesGetDifferentTokens) {
 // Move semantics
 // =============================================================================
 
-TEST(SessionTokenValidatorTest, MoveConstruction) {
-    SessionTokenConfig config;
-    config.secretKey = "move-test";
+TEST_F(SessionTokenValidatorTest, MoveConstruction) {
+    auto config = makeConfig();
     SessionTokenValidator a(config);
     auto token = a.generateToken("user1", "1.2.3.4.5");
 
     SessionTokenValidator b(std::move(a));
     EXPECT_EQ(b.validateToken(token, "1.2.3.4.5"),
               TokenValidationResult::Valid);
-    EXPECT_EQ(b.config().secretKey, "move-test");
+    EXPECT_EQ(b.config().issuer, "dicom-viewer-tests");
 }
 
-TEST(SessionTokenValidatorTest, MoveAssignment) {
-    SessionTokenConfig config;
-    config.secretKey = "move-assign";
+TEST_F(SessionTokenValidatorTest, MoveAssignment) {
+    auto config = makeConfig();
     SessionTokenValidator a(config);
     auto token = a.generateToken("user1", "1.2.3.4.5");
 
@@ -247,7 +386,7 @@ TEST(SessionTokenValidatorTest, MoveAssignment) {
     b = std::move(a);
     EXPECT_EQ(b.validateToken(token, "1.2.3.4.5"),
               TokenValidationResult::Valid);
-    EXPECT_EQ(b.config().secretKey, "move-assign");
+    EXPECT_EQ(b.config().audience, "render-clients");
 }
 
 // =============================================================================
@@ -256,7 +395,7 @@ TEST(SessionTokenValidatorTest, MoveAssignment) {
 
 #include "services/render/render_session_manager.hpp"
 
-TEST(SessionTokenValidatorTest, ManagerTokenForwarding) {
+TEST_F(SessionTokenValidatorTest, ManagerTokenForwarding) {
     RenderSessionManager manager;
 
     auto token = manager.generateSessionToken("user1", "1.2.3.4.5");
@@ -265,12 +404,11 @@ TEST(SessionTokenValidatorTest, ManagerTokenForwarding) {
     auto result = manager.validateSessionToken(token, "1.2.3.4.5");
     EXPECT_EQ(result, TokenValidationResult::Valid);
 
-    // Wrong study should fail
     result = manager.validateSessionToken(token, "9.8.7.6.5");
     EXPECT_EQ(result, TokenValidationResult::StudyMismatch);
 }
 
-TEST(SessionTokenValidatorTest, ManagerTokenValidatorAccessible) {
+TEST_F(SessionTokenValidatorTest, ManagerTokenValidatorAccessible) {
     RenderSessionManager manager;
 
     auto* validator = manager.tokenValidator();

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,7 +9,8 @@
         "spdlog",
         "fmt",
         "nlohmann-json",
-        "gtest"
+        "gtest",
+        "jwt-cpp"
     ],
     "builtin-baseline": "84bab45d415d22042bd0b9081aea57f362da3f35"
 }


### PR DESCRIPTION
## Summary
- replace the render session token validator with RS256 JWT signing and verification
- add JWT issuer/audience/role/organization claims plus PEM-backed key loading with ephemeral fallback
- enforce JWT validation during WebSocket upgrades and rewrite unit coverage around RS256 flows

## Testing
- `cmake -S /Users/raphaelshin/Sources/dicom_viewer -B /Users/raphaelshin/Sources/dicom_viewer/build`
- `cmake --build /Users/raphaelshin/Sources/dicom_viewer/build --target session_token_validator_test websocket_frame_streamer_test -j4`
- `./bin/session_token_validator_test`
- `./bin/websocket_frame_streamer_test`

Closes #496.
