### PR TITLE
refactor(build): add DICOM_VIEWER_SERVER_ONLY CMake build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,21 +37,24 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 # Options
 option(BUILD_TESTS "Build unit tests" ON)
 option(BUILD_DOCS "Build documentation" OFF)
+option(DICOM_VIEWER_SERVER_ONLY "Build headless server without Qt UI" OFF)
 
 # Find required packages
-find_package(Qt6 REQUIRED COMPONENTS
-    Core
-    Concurrent
-    Widgets
-    Gui
-    OpenGL
-    OpenGLWidgets
-    PrintSupport
-    Test
-    WebSockets
-)
+if(NOT DICOM_VIEWER_SERVER_ONLY)
+    find_package(Qt6 REQUIRED COMPONENTS
+        Core
+        Concurrent
+        Widgets
+        Gui
+        OpenGL
+        OpenGLWidgets
+        PrintSupport
+        Test
+        WebSockets
+    )
+endif()
 
-find_package(VTK REQUIRED COMPONENTS
+set(VTK_REQUIRED_COMPONENTS
     CommonCore
     CommonDataModel
     CommonExecutionModel
@@ -61,7 +64,6 @@ find_package(VTK REQUIRED COMPONENTS
     FiltersGeneral
     FiltersGeometry
     FiltersSources
-    GUISupportQt
     ImagingCore
     InteractionStyle
     InteractionWidgets
@@ -71,6 +73,10 @@ find_package(VTK REQUIRED COMPONENTS
     RenderingOpenGL2
     RenderingVolumeOpenGL2
 )
+if(NOT DICOM_VIEWER_SERVER_ONLY)
+    list(APPEND VTK_REQUIRED_COMPONENTS GUISupportQt)
+endif()
+find_package(VTK REQUIRED COMPONENTS ${VTK_REQUIRED_COMPONENTS})
 
 find_package(ITK REQUIRED COMPONENTS
     ITKCommon
@@ -540,9 +546,11 @@ include_directories(
 )
 
 # Qt automatic processing
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTORCC ON)
-set(CMAKE_AUTOUIC ON)
+if(NOT DICOM_VIEWER_SERVER_ONLY)
+    set(CMAKE_AUTOMOC ON)
+    set(CMAKE_AUTORCC ON)
+    set(CMAKE_AUTOUIC ON)
+endif()
 
 # Find FFTW for ITK's FFT operations (required by N4 bias correction and other filters)
 find_library(FFTW3_LIBRARY fftw3)
@@ -768,8 +776,11 @@ target_link_libraries(pacs_service PUBLIC
     pacs::services
     spdlog::spdlog
     fmt::fmt
-    Qt6::Core
 )
+
+if(NOT DICOM_VIEWER_SERVER_ONLY)
+    target_link_libraries(pacs_service PUBLIC Qt6::Core)
+endif()
 
 if(TARGET pacs::encoding)
     target_link_libraries(pacs_service PUBLIC pacs::encoding)
@@ -844,13 +855,18 @@ target_link_libraries(export_service PUBLIC
     measurement_service
     segmentation_service
     pacs_service
-    Qt6::Core
-    Qt6::Widgets
-    Qt6::Gui
-    Qt6::PrintSupport
     nlohmann_json::nlohmann_json
     ${VTK_LIBRARIES}
 )
+
+if(NOT DICOM_VIEWER_SERVER_ONLY)
+    target_link_libraries(export_service PUBLIC
+        Qt6::Core
+        Qt6::Widgets
+        Qt6::Gui
+        Qt6::PrintSupport
+    )
+endif()
 
 # Flow analysis service (4D Flow MRI)
 add_library(flow_service STATIC
@@ -904,96 +920,132 @@ target_link_libraries(cardiac_service PUBLIC
     ${VTK_LIBRARIES}
 )
 
-# UI library
-add_library(dicom_viewer_ui STATIC
-    src/ui/main_window.cpp
-    src/ui/widgets/viewport_widget.cpp
-    src/ui/widgets/viewport_layout_manager.cpp
-    src/ui/widgets/mpr_widget.cpp
-    src/ui/widgets/mpr_view_widget.cpp
-    src/ui/widgets/dr_viewer.cpp
-    src/ui/widgets/phase_slider_widget.cpp
-    src/ui/widgets/sp_mode_toggle.cpp
-    src/ui/panels/patient_browser.cpp
-    src/ui/panels/tools_panel.cpp
-    src/ui/panels/statistics_panel.cpp
-    src/ui/panels/segmentation_panel.cpp
-    src/ui/panels/overlay_control_panel.cpp
-    src/ui/panels/flow_tool_panel.cpp
-    src/ui/display_3d_controller.cpp
-    src/ui/dialogs/settings_dialog.cpp
-    src/ui/dialogs/pacs_config_dialog.cpp
-    src/ui/dialogs/quantification_window.cpp
-    src/ui/dialogs/mask_wizard.cpp
-    src/ui/dialogs/video_export_dialog.cpp
-    src/ui/mask_wizard_controller.cpp
-    src/ui/drop_handler.cpp
-    src/ui/widgets/flow_graph_widget.cpp
-    src/ui/widgets/workflow_tab_bar.cpp
-    src/ui/panels/workflow_panel.cpp
-    src/ui/panels/report_panel.cpp
-    src/ui/intro_page.cpp
-    src/ui/widgets/remote_viewport_widget.cpp
-    # Headers with Q_OBJECT for AUTOMOC
-    include/ui/main_window.hpp
-    include/ui/intro_page.hpp
-    include/ui/viewport_widget.hpp
-    include/ui/viewport_layout_manager.hpp
-    include/ui/mpr_view_widget.hpp
-    include/ui/dr_viewer.hpp
-    include/ui/widgets/phase_slider_widget.hpp
-    include/ui/widgets/sp_mode_toggle.hpp
-    include/ui/panels/patient_browser.hpp
-    include/ui/panels/tools_panel.hpp
-    include/ui/panels/statistics_panel.hpp
-    include/ui/panels/segmentation_panel.hpp
-    include/ui/panels/overlay_control_panel.hpp
-    include/ui/panels/flow_tool_panel.hpp
-    include/ui/dialogs/settings_dialog.hpp
-    include/ui/dialogs/pacs_config_dialog.hpp
-    include/ui/quantification_window.hpp
-    include/ui/dialogs/mask_wizard.hpp
-    include/ui/dialogs/video_export_dialog.hpp
-    include/ui/mask_wizard_controller.hpp
-    include/ui/drop_handler.hpp
-    include/ui/widgets/flow_graph_widget.hpp
-    include/ui/widgets/workflow_tab_bar.hpp
-    include/ui/panels/workflow_panel.hpp
-    include/ui/panels/report_panel.hpp
-    include/ui/widgets/remote_viewport_widget.hpp
-)
+if(NOT DICOM_VIEWER_SERVER_ONLY)
+    # UI library
+    add_library(dicom_viewer_ui STATIC
+        src/ui/main_window.cpp
+        src/ui/widgets/viewport_widget.cpp
+        src/ui/widgets/viewport_layout_manager.cpp
+        src/ui/widgets/mpr_widget.cpp
+        src/ui/widgets/mpr_view_widget.cpp
+        src/ui/widgets/dr_viewer.cpp
+        src/ui/widgets/phase_slider_widget.cpp
+        src/ui/widgets/sp_mode_toggle.cpp
+        src/ui/panels/patient_browser.cpp
+        src/ui/panels/tools_panel.cpp
+        src/ui/panels/statistics_panel.cpp
+        src/ui/panels/segmentation_panel.cpp
+        src/ui/panels/overlay_control_panel.cpp
+        src/ui/panels/flow_tool_panel.cpp
+        src/ui/display_3d_controller.cpp
+        src/ui/dialogs/settings_dialog.cpp
+        src/ui/dialogs/pacs_config_dialog.cpp
+        src/ui/dialogs/quantification_window.cpp
+        src/ui/dialogs/mask_wizard.cpp
+        src/ui/dialogs/video_export_dialog.cpp
+        src/ui/mask_wizard_controller.cpp
+        src/ui/drop_handler.cpp
+        src/ui/widgets/flow_graph_widget.cpp
+        src/ui/widgets/workflow_tab_bar.cpp
+        src/ui/panels/workflow_panel.cpp
+        src/ui/panels/report_panel.cpp
+        src/ui/intro_page.cpp
+        src/ui/widgets/remote_viewport_widget.cpp
+        # Headers with Q_OBJECT for AUTOMOC
+        include/ui/main_window.hpp
+        include/ui/intro_page.hpp
+        include/ui/viewport_widget.hpp
+        include/ui/viewport_layout_manager.hpp
+        include/ui/mpr_view_widget.hpp
+        include/ui/dr_viewer.hpp
+        include/ui/widgets/phase_slider_widget.hpp
+        include/ui/widgets/sp_mode_toggle.hpp
+        include/ui/panels/patient_browser.hpp
+        include/ui/panels/tools_panel.hpp
+        include/ui/panels/statistics_panel.hpp
+        include/ui/panels/segmentation_panel.hpp
+        include/ui/panels/overlay_control_panel.hpp
+        include/ui/panels/flow_tool_panel.hpp
+        include/ui/dialogs/settings_dialog.hpp
+        include/ui/dialogs/pacs_config_dialog.hpp
+        include/ui/quantification_window.hpp
+        include/ui/dialogs/mask_wizard.hpp
+        include/ui/dialogs/video_export_dialog.hpp
+        include/ui/mask_wizard_controller.hpp
+        include/ui/drop_handler.hpp
+        include/ui/widgets/flow_graph_widget.hpp
+        include/ui/widgets/workflow_tab_bar.hpp
+        include/ui/panels/workflow_panel.hpp
+        include/ui/panels/report_panel.hpp
+        include/ui/widgets/remote_viewport_widget.hpp
+    )
 
-target_link_libraries(dicom_viewer_ui PUBLIC
-    render_service
-    measurement_service
-    segmentation_service
-    pacs_service
-    export_service
-    flow_service
-    Qt6::Core
-    Qt6::Concurrent
-    Qt6::Widgets
-    Qt6::Gui
-    Qt6::OpenGL
-    Qt6::OpenGLWidgets
-    Qt6::WebSockets
-    VTK::GUISupportQt
-)
+    target_link_libraries(dicom_viewer_ui PUBLIC
+        render_service
+        measurement_service
+        segmentation_service
+        pacs_service
+        export_service
+        flow_service
+        Qt6::Core
+        Qt6::Concurrent
+        Qt6::Widgets
+        Qt6::Gui
+        Qt6::OpenGL
+        Qt6::OpenGLWidgets
+        Qt6::WebSockets
+        VTK::GUISupportQt
+    )
 
-# Main application
-add_executable(dicom_viewer
-    src/app/main.cpp
-)
+    # Desktop application
+    add_executable(dicom_viewer
+        src/app/main.cpp
+    )
 
-target_link_libraries(dicom_viewer PRIVATE
-    dicom_viewer_ui
-)
+    target_link_libraries(dicom_viewer PRIVATE
+        dicom_viewer_ui
+    )
 
-# VTK module autoinit
-vtk_module_autoinit(
-    TARGETS dicom_viewer dicom_viewer_ui render_service
-    MODULES ${VTK_LIBRARIES}
-)
+    # VTK module autoinit (desktop mode: includes GUISupportQt targets)
+    vtk_module_autoinit(
+        TARGETS dicom_viewer dicom_viewer_ui render_service
+        MODULES ${VTK_LIBRARIES}
+    )
+
+    install(TARGETS dicom_viewer
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+    )
+else()
+    # Headless server executable (no Qt required)
+    # Full service wiring is implemented in issue #500
+    add_executable(dicom_viewer_server
+        server/src/main.cpp
+    )
+
+    target_include_directories(dicom_viewer_server PRIVATE
+        ${CMAKE_SOURCE_DIR}/include
+    )
+
+    target_link_libraries(dicom_viewer_server PRIVATE
+        spdlog::spdlog
+        fmt::fmt
+        nlohmann_json::nlohmann_json
+        OpenSSL::SSL
+        OpenSSL::Crypto
+    )
+
+    if(TARGET jwt-cpp::jwt-cpp)
+        target_link_libraries(dicom_viewer_server PRIVATE jwt-cpp::jwt-cpp)
+    endif()
+
+    install(TARGETS dicom_viewer_server
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+    )
+endif()
 
 # Tests
 if(BUILD_TESTS)
@@ -1001,19 +1053,13 @@ if(BUILD_TESTS)
     add_subdirectory(tests)
 endif()
 
-# Install rules
-install(TARGETS dicom_viewer
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-)
-
 # Build configuration summary
 message(STATUS "")
 message(STATUS "=== dicom_viewer Build Configuration ===")
 message(STATUS "Version: ${PROJECT_VERSION}")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "C++ Standard: ${CMAKE_CXX_STANDARD}")
+message(STATUS "Build mode: ${DICOM_VIEWER_SERVER_ONLY}")
 message(STATUS "")
 message(STATUS "DICOM Network Library:")
 message(STATUS "  pacs_system: Found and enabled")

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -1,0 +1,27 @@
+// Headless DICOM Viewer Server
+// Full implementation: see issue #500 (feat(server): create headless server project structure)
+//
+// This stub validates that the server-only build target compiles correctly
+// without Qt dependencies.
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+int main(int argc, char* argv[]) {
+    for (int i = 1; i < argc; ++i) {
+        if (std::string(argv[i]) == "--help" || std::string(argv[i]) == "-h") {
+            std::cout << "dicom_viewer_server [OPTIONS]\n"
+                      << "  --port <port>          REST API port (default: 8080)\n"
+                      << "  --ws-port <port>       WebSocket port (default: 8081)\n"
+                      << "  --config <path>        Path to deployment.yaml\n"
+                      << "  --max-sessions <n>     Maximum concurrent sessions\n"
+                      << "  --log-level <level>    Log level (trace/debug/info/warn/error)\n"
+                      << "  --help                 Show this help message\n";
+            return EXIT_SUCCESS;
+        }
+    }
+
+    std::cerr << "dicom_viewer_server: full implementation pending (issue #500)\n";
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
## What

Adds `DICOM_VIEWER_SERVER_ONLY` CMake option to enable building the headless rendering server without Qt6 dependencies.

### Change Type
- [x] Refactor (no functional changes)

### Affected Components
- `CMakeLists.txt` - conditional guards for Qt6, VTK GUISupportQt, AUTOMOC/AUTORCC/AUTOUIC
- `server/src/main.cpp` - stub entry point (full implementation in #500)

## Why

### Related Issues
- Closes #495
- Part of #492 (Phase 0.3)

### Motivation
Enables the headless server build path (`-DDICOM_VIEWER_SERVER_ONLY=ON`) that avoids requiring Qt6. This is a prerequisite for #500 (server project structure) and the Docker containerization effort.

## Where

### Changes Summary
| Section | Change |
|---------|--------|
| `find_package(Qt6)` | Wrapped in `if(NOT DICOM_VIEWER_SERVER_ONLY)` |
| VTK components | `GUISupportQt` conditionally included via `VTK_REQUIRED_COMPONENTS` list |
| `CMAKE_AUTOMOC/AUTORCC/AUTOUIC` | Guarded with `if(NOT DICOM_VIEWER_SERVER_ONLY)` |
| `pacs_service` Qt6::Core | Conditional link |
| `export_service` Qt6 links | Conditional link block |
| `dicom_viewer_ui` + `dicom_viewer` | Wrapped in `if(NOT DICOM_VIEWER_SERVER_ONLY)` |
| `dicom_viewer_server` target | Added in `else()` block with stub `server/src/main.cpp` |

## How

### Key Design Decisions
- Default `DICOM_VIEWER_SERVER_ONLY=OFF` preserves full desktop build with zero regressions
- VTK components list built via variable + conditional `list(APPEND ...)` to avoid duplicating the full component list
- Server stub executable links only Qt-free libraries (spdlog, fmt, nlohmann_json, OpenSSL, jwt-cpp)
- Full service wiring (render_service, pacs_service) deferred to #500 after Qt cleanup in #493/#494

### Test Plan
1. Default build: `cmake .. && cmake --build .` — `dicom_viewer` desktop app produces as before
2. Server build: `cmake .. -DDICOM_VIEWER_SERVER_ONLY=ON` — configures without Qt errors
3. Server help: `./bin/dicom_viewer_server --help` — shows CLI options

### Breaking Changes
None — `DICOM_VIEWER_SERVER_ONLY` defaults to OFF.