### PR TITLE
feat(server): implement headless server project structure and entry point

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1018,33 +1018,8 @@ if(NOT DICOM_VIEWER_SERVER_ONLY)
         ARCHIVE DESTINATION lib
     )
 else()
-    # Headless server executable (no Qt required)
-    # Full service wiring is implemented in issue #500
-    add_executable(dicom_viewer_server
-        server/src/main.cpp
-    )
-
-    target_include_directories(dicom_viewer_server PRIVATE
-        ${CMAKE_SOURCE_DIR}/include
-    )
-
-    target_link_libraries(dicom_viewer_server PRIVATE
-        spdlog::spdlog
-        fmt::fmt
-        nlohmann_json::nlohmann_json
-        OpenSSL::SSL
-        OpenSSL::Crypto
-    )
-
-    if(TARGET jwt-cpp::jwt-cpp)
-        target_link_libraries(dicom_viewer_server PRIVATE jwt-cpp::jwt-cpp)
-    endif()
-
-    install(TARGETS dicom_viewer_server
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-    )
+    # Headless server build — delegate to server/CMakeLists.txt
+    add_subdirectory(server)
 endif()
 
 # Tests

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1,0 +1,48 @@
+# Server-only build configuration
+# Included by root CMakeLists.txt when DICOM_VIEWER_SERVER_ONLY=ON
+cmake_minimum_required(VERSION 3.20)
+
+# Collect server source files
+set(SERVER_SOURCES
+    src/main.cpp
+    src/api/api_server.cpp
+)
+
+# Headless server executable
+add_executable(dicom_viewer_server ${SERVER_SOURCES})
+
+target_include_directories(dicom_viewer_server PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/include
+    ${PACS_SYSTEM_INCLUDE_DIR}
+)
+
+# Inherit Crow + Asio include paths from render_service
+get_target_property(RENDER_INCLUDES render_service INTERFACE_INCLUDE_DIRECTORIES)
+if(RENDER_INCLUDES)
+    target_include_directories(dicom_viewer_server PRIVATE ${RENDER_INCLUDES})
+endif()
+
+target_link_libraries(dicom_viewer_server PRIVATE
+    render_service
+    pacs_service
+    spdlog::spdlog
+    fmt::fmt
+    nlohmann_json::nlohmann_json
+    OpenSSL::SSL
+    OpenSSL::Crypto
+)
+
+if(TARGET jwt-cpp::jwt-cpp)
+    target_link_libraries(dicom_viewer_server PRIVATE jwt-cpp::jwt-cpp)
+endif()
+
+# VTK module autoinit (server mode: no GUISupportQt)
+vtk_module_autoinit(
+    TARGETS dicom_viewer_server render_service
+    MODULES ${VTK_LIBRARIES}
+)
+
+install(TARGETS dicom_viewer_server
+    RUNTIME DESTINATION bin
+)

--- a/server/src/api/api_server.cpp
+++ b/server/src/api/api_server.cpp
@@ -1,0 +1,203 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, kcenon
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "api_server.hpp"
+#include "jwt_middleware.hpp"
+
+#include "services/render/render_session_manager.hpp"
+#include "services/render/session_token_validator.hpp"
+#include "services/audit_service.hpp"
+
+#define CROW_DISABLE_STATIC_DIR
+#include <crow.h>
+#include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+
+namespace dicom_viewer::server {
+
+using App = crow::App<JwtMiddleware>;
+
+class ApiServer::Impl {
+public:
+    explicit Impl(const ApiServerConfig& cfg)
+        : config_(cfg)
+        , app_(std::make_unique<App>())
+        , running_(false)
+    {}
+
+    ~Impl() { stop(); }
+
+    void setServices(services::RenderSessionManager* sessions,
+                     services::SessionTokenValidator* validator,
+                     services::AuditService* audit) {
+        sessions_ = sessions;
+        validator_ = validator;
+        audit_ = audit;
+        app_->get_middleware<JwtMiddleware>().validator = validator;
+    }
+
+    bool start() {
+        if (running_) return true;
+        registerRoutes();
+        app_->loglevel(crow::LogLevel::Warning);
+        app_->concurrency(config_.concurrency);
+
+        // Start in background thread
+        serverThread_ = std::thread([this] {
+            running_ = true;
+            app_->port(config_.port).run();
+            running_ = false;
+        });
+
+        // Wait briefly for server to bind
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        spdlog::info("REST API server started on port {}", config_.port);
+        return true;
+    }
+
+    void stop() {
+        if (app_) {
+            app_->stop();
+        }
+        if (serverThread_.joinable()) {
+            serverThread_.join();
+        }
+        running_ = false;
+    }
+
+    [[nodiscard]] bool isRunning() const { return running_; }
+    [[nodiscard]] uint16_t port() const { return config_.port; }
+
+private:
+    void addCorsHeaders(crow::response& res) {
+        res.add_header("Access-Control-Allow-Origin", config_.corsOrigin);
+        res.add_header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+        res.add_header("Access-Control-Allow-Headers", "Authorization, Content-Type");
+        res.add_header("Content-Type", "application/json");
+    }
+
+    void registerRoutes() {
+        // ---- CORS preflight ----
+        CROW_ROUTE((*app_), "/api/<path>").methods(crow::HTTPMethod::Options)(
+            [this](const crow::request& /*req*/, crow::response& res,
+                   const std::string& /*path*/) {
+                addCorsHeaders(res);
+                res.code = 204;
+                res.end();
+            });
+
+        // ---- Health check (public) ----
+        CROW_ROUTE((*app_), "/api/v1/health")(
+            [this](const crow::request& /*req*/, crow::response& res) {
+                nlohmann::json body;
+                body["status"] = "ok";
+                body["version"] = config_.serverVersion;
+                body["activeSessions"] = sessions_ ? sessions_->activeSessionCount() : 0;
+
+                addCorsHeaders(res);
+                res.code = 200;
+                res.body = body.dump();
+                res.end();
+            });
+
+        // ---- List sessions (authenticated) ----
+        CROW_ROUTE((*app_), "/api/v1/sessions")(
+            [this](const crow::request& req, crow::response& res) {
+                auto& ctx = app_->get_context<JwtMiddleware>(req);
+                if (!ctx.authenticated) {
+                    res.code = 401;
+                    res.body = R"({"error":"unauthorized"})";
+                    res.end();
+                    return;
+                }
+
+                nlohmann::json body;
+                if (sessions_) {
+                    auto ids = sessions_->activeSessionIds();
+                    body["sessions"] = ids;
+                    body["count"] = ids.size();
+                } else {
+                    body["sessions"] = nlohmann::json::array();
+                    body["count"] = 0;
+                }
+
+                addCorsHeaders(res);
+                res.code = 200;
+                res.body = body.dump();
+                res.end();
+            });
+
+        // ---- Catch-all 404 ----
+        CROW_CATCHALL_ROUTE((*app_))([this](crow::response& res) {
+            addCorsHeaders(res);
+            res.code = 404;
+            res.body = R"({"error":"not_found"})";
+            res.end();
+        });
+    }
+
+    ApiServerConfig config_;
+    std::unique_ptr<App> app_;
+    std::atomic<bool> running_;
+    std::thread serverThread_;
+
+    services::RenderSessionManager* sessions_ = nullptr;
+    services::SessionTokenValidator* validator_ = nullptr;
+    services::AuditService* audit_ = nullptr;
+};
+
+// ---- ApiServer public interface ----
+
+ApiServer::ApiServer(const ApiServerConfig& config)
+    : impl_(std::make_unique<Impl>(config))
+{}
+
+ApiServer::~ApiServer() = default;
+
+void ApiServer::setServices(services::RenderSessionManager* sessions,
+                             services::SessionTokenValidator* validator,
+                             services::AuditService* audit) {
+    impl_->setServices(sessions, validator, audit);
+}
+
+bool ApiServer::start() { return impl_->start(); }
+void ApiServer::stop() { impl_->stop(); }
+bool ApiServer::isRunning() const { return impl_->isRunning(); }
+uint16_t ApiServer::port() const { return impl_->port(); }
+
+void ApiServer::registerRoutes() {
+    // Routes are registered inside Impl::start()
+}
+
+} // namespace dicom_viewer::server

--- a/server/src/api/api_server.hpp
+++ b/server/src/api/api_server.hpp
@@ -1,0 +1,136 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, kcenon
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file api_server.hpp
+ * @brief Crow-based REST API server for the headless DICOM viewer server
+ * @details Bootstraps a Crow application with JWT middleware, CORS headers,
+ *          and the initial set of API routes (health check, session management
+ *          stub). Full route implementation is added in issue #501.
+ *
+ * ## Routes (Phase 1.1)
+ * | Method | Path                  | Auth | Description          |
+ * |--------|-----------------------|------|----------------------|
+ * | GET    | /api/v1/health        | No   | Health check         |
+ * | GET    | /api/v1/sessions      | Yes  | List active sessions |
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace dicom_viewer::services {
+class RenderSessionManager;
+class SessionTokenValidator;
+class AuditService;
+} // namespace dicom_viewer::services
+
+namespace dicom_viewer::server {
+
+/**
+ * @brief Configuration for the REST API server
+ */
+struct ApiServerConfig {
+    /// HTTP listen port (default: 8080)
+    uint16_t port = 8080;
+
+    /// Number of Crow worker threads
+    uint16_t concurrency = 4;
+
+    /// CORS allowed origins (empty = allow all)
+    std::string corsOrigin = "*";
+
+    /// Server version string included in responses
+    std::string serverVersion = "0.3.0";
+};
+
+/**
+ * @brief Crow REST API server with JWT middleware and CORS support
+ *
+ * Manages the lifecycle of the Crow HTTP server for the headless
+ * DICOM rendering backend. Routes are registered in registerRoutes()
+ * using service pointers injected via setServices().
+ *
+ * @trace SRS-FR-SERVER-001
+ */
+class ApiServer {
+public:
+    explicit ApiServer(const ApiServerConfig& config = {});
+    ~ApiServer();
+
+    // Non-copyable, non-movable (owns Crow app and background thread)
+    ApiServer(const ApiServer&) = delete;
+    ApiServer& operator=(const ApiServer&) = delete;
+    ApiServer(ApiServer&&) = delete;
+    ApiServer& operator=(ApiServer&&) = delete;
+
+    /**
+     * @brief Inject service dependencies used by route handlers
+     * @param sessions Render session manager (non-owning)
+     * @param validator JWT token validator (non-owning, may be nullptr)
+     * @param audit ATNA audit service (non-owning, may be nullptr)
+     */
+    void setServices(services::RenderSessionManager* sessions,
+                     services::SessionTokenValidator* validator,
+                     services::AuditService* audit);
+
+    /**
+     * @brief Start the HTTP server (non-blocking — runs in background thread)
+     * @return true if server started successfully
+     */
+    bool start();
+
+    /**
+     * @brief Stop the HTTP server and release its thread
+     */
+    void stop();
+
+    /**
+     * @brief Check if the server is running
+     */
+    [[nodiscard]] bool isRunning() const;
+
+    /**
+     * @brief Get the actual port the server is listening on
+     */
+    [[nodiscard]] uint16_t port() const;
+
+private:
+    void registerRoutes();
+
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::server

--- a/server/src/api/jwt_middleware.hpp
+++ b/server/src/api/jwt_middleware.hpp
@@ -1,0 +1,137 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, kcenon
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file jwt_middleware.hpp
+ * @brief Crow middleware for JWT Bearer token validation on REST API routes
+ * @details Extracts the Bearer token from the Authorization header and
+ *          validates it using SessionTokenValidator. Attaches decoded payload
+ *          to the Crow context for downstream route handlers.
+ *
+ * ## Usage
+ * Routes that require authentication should be defined on a Crow app
+ * configured with JwtMiddleware. Unauthenticated routes (e.g., /health)
+ * can bypass validation by checking context().skip = true before
+ * calling next().
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include "services/render/session_token_validator.hpp"
+
+#include <crow.h>
+#include <spdlog/spdlog.h>
+
+#include <optional>
+#include <string>
+
+namespace dicom_viewer::server {
+
+/**
+ * @brief JWT validation result attached to Crow request context
+ */
+struct JwtContext {
+    bool authenticated = false;
+    std::string userId;
+    std::string role;
+    std::string organization;
+
+    /// Skip validation for this request (set by route handlers before middleware)
+    bool skip = false;
+};
+
+/**
+ * @brief Crow middleware that validates JWT Bearer tokens
+ *
+ * Validates the Authorization: Bearer <token> header on each request.
+ * Sets JwtContext::authenticated = true on success.
+ * Returns 401 Unauthorized on invalid or missing tokens for protected routes.
+ *
+ * Public paths (health check, static docs) set skip = true to bypass validation.
+ */
+struct JwtMiddleware {
+    struct context : JwtContext {};
+
+    /**
+     * @brief Pointer to the token validator (must outlive this middleware)
+     * Set before registering routes.
+     */
+    services::SessionTokenValidator* validator = nullptr;
+
+    void before_handle(crow::request& req, crow::response& res, context& ctx) {
+        // Health check and other public endpoints skip validation
+        if (req.url == "/api/v1/health" || req.url == "/") {
+            ctx.skip = true;
+            return;
+        }
+
+        if (!validator) {
+            // No validator configured — allow all (development mode)
+            ctx.authenticated = true;
+            ctx.userId = "anonymous";
+            ctx.role = "Viewer";
+            return;
+        }
+
+        const std::string authHeader = req.get_header_value("Authorization");
+        if (authHeader.substr(0, 7) != "Bearer ") {
+            res.code = 401;
+            res.body = R"({"error":"missing_token","message":"Authorization: Bearer <token> required"})";
+            res.end();
+            return;
+        }
+
+        const std::string token = authHeader.substr(7);
+        services::TokenPayload payload;
+        const auto result = validator->validateToken(token, payload);
+
+        if (result != services::TokenValidationResult::Valid) {
+            spdlog::warn("JWT validation failed: token={:.8}... result={}",
+                         token, static_cast<int>(result));
+            res.code = 401;
+            res.body = R"({"error":"invalid_token","message":"Token validation failed"})";
+            res.end();
+            return;
+        }
+
+        ctx.authenticated = true;
+        ctx.userId = payload.userId;
+        ctx.role = payload.role;
+        ctx.organization = payload.organization;
+    }
+
+    void after_handle(crow::request& /*req*/, crow::response& /*res*/, context& /*ctx*/) {
+        // No post-processing needed
+    }
+};
+
+} // namespace dicom_viewer::server

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -1,27 +1,316 @@
-// Headless DICOM Viewer Server
-// Full implementation: see issue #500 (feat(server): create headless server project structure)
+// BSD 3-Clause License
 //
-// This stub validates that the server-only build target compiles correctly
-// without Qt dependencies.
+// Copyright (c) 2021-2025, kcenon
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+/**
+ * @file main.cpp
+ * @brief Headless DICOM Viewer Server entry point
+ * @details Bootstraps all services without Qt:
+ *   1. CLI argument parsing
+ *   2. spdlog initialization (console + file)
+ *   3. VTK EGL off-screen rendering validation
+ *   4. Service instantiation (RenderSessionManager, WebSocketFrameStreamer)
+ *   5. Frame + input callback wiring
+ *   6. REST API server (ApiServer) on port 8080
+ *   7. WebSocket server (WebSocketFrameStreamer) on port 8081
+ *   8. SIGTERM/SIGINT graceful shutdown
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#include "api/api_server.hpp"
+
+#include "services/render/render_session_manager.hpp"
+#include "services/render/websocket_frame_streamer.hpp"
+#include "services/render/frame_encoder.hpp"
+#include "services/render/input_event_dispatcher.hpp"
+#include "services/render/offscreen_render_context.hpp"
+#include "services/render/session_token_validator.hpp"
+#include "services/audit_service.hpp"
+
+#include <spdlog/spdlog.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/sinks/rotating_file_sink.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <csignal>
 #include <cstdlib>
+#include <filesystem>
 #include <iostream>
+#include <mutex>
 #include <string>
+#include <thread>
 
-int main(int argc, char* argv[]) {
+// ---- CLI argument structure ----
+
+struct ServerArgs {
+    uint16_t restPort = 8080;
+    uint16_t wsPort = 8081;
+    std::string configPath;
+    uint32_t maxSessions = 8;
+    std::string logLevel = "info";
+    bool helpRequested = false;
+};
+
+// ---- Signal handling ----
+
+static std::atomic<bool> g_shutdown{false};
+static std::mutex g_shutdownMutex;
+static std::condition_variable g_shutdownCv;
+
+static void signalHandler(int /*signum*/) {
+    g_shutdown = true;
+    g_shutdownCv.notify_all();
+}
+
+// ---- Helpers ----
+
+static void printHelp(const char* programName) {
+    std::cout << "Usage: " << programName << " [OPTIONS]\n\n"
+              << "Options:\n"
+              << "  --port <port>          REST API listen port (default: 8080)\n"
+              << "  --ws-port <port>       WebSocket listen port (default: 8081)\n"
+              << "  --config <path>        Path to deployment.yaml\n"
+              << "  --max-sessions <n>     Maximum concurrent render sessions (default: 8)\n"
+              << "  --log-level <level>    Log level: trace|debug|info|warn|error (default: info)\n"
+              << "  --help, -h             Show this help message\n\n"
+              << "Examples:\n"
+              << "  " << programName << " --port 8080 --ws-port 8081\n"
+              << "  " << programName << " --config /etc/dicom_viewer/deployment.yaml\n";
+}
+
+static ServerArgs parseArgs(int argc, char* argv[]) {
+    ServerArgs args;
     for (int i = 1; i < argc; ++i) {
-        if (std::string(argv[i]) == "--help" || std::string(argv[i]) == "-h") {
-            std::cout << "dicom_viewer_server [OPTIONS]\n"
-                      << "  --port <port>          REST API port (default: 8080)\n"
-                      << "  --ws-port <port>       WebSocket port (default: 8081)\n"
-                      << "  --config <path>        Path to deployment.yaml\n"
-                      << "  --max-sessions <n>     Maximum concurrent sessions\n"
-                      << "  --log-level <level>    Log level (trace/debug/info/warn/error)\n"
-                      << "  --help                 Show this help message\n";
-            return EXIT_SUCCESS;
+        std::string arg = argv[i];
+        auto nextArg = [&]() -> std::string {
+            if (i + 1 < argc) return argv[++i];
+            std::cerr << "Error: " << arg << " requires an argument\n";
+            std::exit(EXIT_FAILURE);
+        };
+
+        if (arg == "--help" || arg == "-h") {
+            args.helpRequested = true;
+        } else if (arg == "--port") {
+            args.restPort = static_cast<uint16_t>(std::stoi(nextArg()));
+        } else if (arg == "--ws-port") {
+            args.wsPort = static_cast<uint16_t>(std::stoi(nextArg()));
+        } else if (arg == "--config") {
+            args.configPath = nextArg();
+        } else if (arg == "--max-sessions") {
+            args.maxSessions = static_cast<uint32_t>(std::stoi(nextArg()));
+        } else if (arg == "--log-level") {
+            args.logLevel = nextArg();
+        } else {
+            std::cerr << "Warning: unknown argument '" << arg << "'\n";
         }
     }
+    return args;
+}
 
-    std::cerr << "dicom_viewer_server: full implementation pending (issue #500)\n";
-    return EXIT_FAILURE;
+static spdlog::level::level_enum parseSpdlogLevel(const std::string& level) {
+    if (level == "trace")  return spdlog::level::trace;
+    if (level == "debug")  return spdlog::level::debug;
+    if (level == "warn")   return spdlog::level::warn;
+    if (level == "error")  return spdlog::level::err;
+    return spdlog::level::info;  // default
+}
+
+static void initializeLogging(const std::string& logLevel) {
+    const auto level = parseSpdlogLevel(logLevel);
+
+    // Console sink
+    auto consoleSink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+    consoleSink->set_level(level);
+
+    // Rotating file sink (10 MB per file, 3 rotations)
+    const std::filesystem::path logDir = std::filesystem::temp_directory_path() / "dicom_viewer_server";
+    std::filesystem::create_directories(logDir);
+    auto fileSink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
+        (logDir / "server.log").string(), 10 * 1024 * 1024, 3);
+    fileSink->set_level(level);
+
+    auto logger = std::make_shared<spdlog::logger>(
+        "server", spdlog::sinks_init_list{consoleSink, fileSink});
+    logger->set_level(level);
+    logger->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%l%$] [%t] %v");
+    spdlog::set_default_logger(logger);
+    spdlog::flush_on(spdlog::level::warn);
+}
+
+static bool validateVtkHeadless() {
+    // Set VTK headless environment variable for EGL/OSMesa selection
+#if defined(__linux__)
+    ::setenv("VTK_DEFAULT_RENDER_WINDOW_HEADLESS", "1", /*overwrite=*/0);
+#endif
+
+    // Attempt to create a minimal off-screen context to validate the backend
+    try {
+        dicom_viewer::services::OffscreenRenderContext ctx;
+        ctx.initialize(64, 64);
+        if (!ctx.isInitialized()) {
+            spdlog::warn("VTK off-screen context failed to initialize — "
+                         "rendering may not work in this environment");
+            return false;
+        }
+        spdlog::info("VTK off-screen rendering validated (supportsOpenGL={})",
+                     ctx.supportsOpenGL());
+        return true;
+    } catch (const std::exception& ex) {
+        spdlog::warn("VTK off-screen validation threw: {}", ex.what());
+        return false;
+    }
+}
+
+// ---- Main ----
+
+int main(int argc, char* argv[]) {
+    const ServerArgs args = parseArgs(argc, argv);
+
+    if (args.helpRequested) {
+        printHelp(argv[0]);
+        return EXIT_SUCCESS;
+    }
+
+    // 1. Logging
+    initializeLogging(args.logLevel);
+    spdlog::info("dicom_viewer_server starting (REST:{} WS:{} maxSessions:{})",
+                 args.restPort, args.wsPort, args.maxSessions);
+
+    // 2. VTK headless validation (non-fatal — warn and continue)
+    validateVtkHeadless();
+
+    // 3. Service instantiation
+
+    // JWT token validator (ephemeral keys for dev, key files for production)
+    dicom_viewer::services::SessionTokenConfig tokenCfg;
+    tokenCfg.allowEphemeralKeys = true;
+    if (!args.configPath.empty()) {
+        // TODO: load JWT key paths from deployment.yaml (#508)
+        spdlog::info("Config path provided: {} (deployment.yaml loader pending #508)",
+                     args.configPath);
+    }
+    auto tokenValidator = std::make_unique<dicom_viewer::services::SessionTokenValidator>(tokenCfg);
+
+    // Audit service (disabled by default — enable via deployment.yaml)
+    auto auditService = std::make_unique<dicom_viewer::services::AuditService>();
+
+    // Frame encoder
+    auto frameEncoder = std::make_unique<dicom_viewer::services::FrameEncoder>();
+
+    // Input event dispatcher
+    auto inputDispatcher = std::make_unique<dicom_viewer::services::InputEventDispatcher>();
+
+    // Render session manager
+    dicom_viewer::services::RenderSessionManagerConfig sessionCfg;
+    sessionCfg.maxSessions = args.maxSessions;
+    auto sessionManager = std::make_unique<dicom_viewer::services::RenderSessionManager>(sessionCfg);
+
+    // WebSocket frame streamer
+    auto wsStreamer = std::make_unique<dicom_viewer::services::WebSocketFrameStreamer>();
+    wsStreamer->setTokenValidator(tokenValidator.get());
+    wsStreamer->setAuditService(auditService.get());
+
+    // 4. Wire frame callback pipeline:
+    //    RenderSessionManager → FrameEncoder → WebSocketFrameStreamer
+    sessionManager->setFrameReadyCallback(
+        [&wsStreamer, &frameEncoder, frameSeq = uint32_t{0}]
+        (const std::string& sessionId,
+         const std::vector<uint8_t>& rgbaFrame,
+         uint32_t width, uint32_t height) mutable {
+            if (!wsStreamer->hasClients(sessionId)) return;
+            const auto encoded = frameEncoder->encode(
+                rgbaFrame.data(), width, height,
+                dicom_viewer::services::EncodeFormat::Jpeg, 85);
+            if (!encoded.empty()) {
+                wsStreamer->pushFrame(sessionId, encoded, width, height, ++frameSeq);
+            }
+        });
+
+    // 5. Wire input callback pipeline:
+    //    WebSocketFrameStreamer → InputEventDispatcher → (VTK via RenderSession)
+    wsStreamer->setInputEventCallback(
+        [&inputDispatcher, &sessionManager](const dicom_viewer::services::InputEvent& event) {
+            sessionManager->touchSession(event.sessionId);
+            inputDispatcher->enqueue(event);
+            // Dispatch to VTK interactor via RenderSession
+            auto* session = sessionManager->getSession(event.sessionId);
+            if (session) {
+                sessionManager->notifyInteractionStart(event.sessionId);
+            }
+        });
+
+    // 6. REST API server
+    dicom_viewer::server::ApiServerConfig apiCfg;
+    apiCfg.port = args.restPort;
+    auto apiServer = std::make_unique<dicom_viewer::server::ApiServer>(apiCfg);
+    apiServer->setServices(sessionManager.get(), tokenValidator.get(), auditService.get());
+
+    if (!apiServer->start()) {
+        spdlog::error("Failed to start REST API server on port {}", args.restPort);
+        return EXIT_FAILURE;
+    }
+
+    // 7. WebSocket server
+    dicom_viewer::services::WebSocketStreamConfig wsCfg;
+    wsCfg.port = args.wsPort;
+    if (!wsStreamer->start(wsCfg)) {
+        spdlog::error("Failed to start WebSocket server on port {}", args.wsPort);
+        apiServer->stop();
+        return EXIT_FAILURE;
+    }
+
+    // 8. Start render loop
+    sessionManager->startRenderLoop();
+
+    spdlog::info("Server ready — REST API: http://0.0.0.0:{}/api/v1/health",
+                 args.restPort);
+    spdlog::info("              WebSocket: ws://0.0.0.0:{}/render/{{session_id}}",
+                 args.wsPort);
+
+    // 9. Signal handling for graceful shutdown
+    std::signal(SIGTERM, signalHandler);
+    std::signal(SIGINT,  signalHandler);
+
+    {
+        std::unique_lock<std::mutex> lock(g_shutdownMutex);
+        g_shutdownCv.wait(lock, [] { return g_shutdown.load(); });
+    }
+
+    // 10. Graceful shutdown
+    spdlog::info("Shutdown signal received — stopping services");
+
+    sessionManager->stopRenderLoop();
+    wsStreamer->stop();
+    apiServer->stop();
+
+    spdlog::info("dicom_viewer_server stopped cleanly");
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## What

Implements the headless DICOM viewer server project structure and entry point (Phase 1.1-1.2).

### Change Type
- [x] Feature (new functionality)

### Affected Components
- `server/CMakeLists.txt` - server-only build target with render_service, pacs_service
- `server/src/main.cpp` - full headless entry point with service wiring and graceful shutdown
- `server/src/api/api_server.hpp/cpp` - Crow REST API server with JWT middleware
- `server/src/api/jwt_middleware.hpp` - Crow middleware for JWT Bearer validation
- `CMakeLists.txt` - server block replaced with `add_subdirectory(server)`

## Why

### Related Issues
- Closes #500
- Part of #492 (Phase 1.1-1.2)

### Motivation
Creates the foundational server bootstrap layer required for Docker-based headless deployment. Routes full implementation will be added in #501.

## Where

### Files Changed
| File | Change |
|------|--------|
| `server/CMakeLists.txt` | New — server-only build config |
| `server/src/main.cpp` | Full implementation (replaced stub) |
| `server/src/api/api_server.hpp` | New — Crow app bootstrap interface |
| `server/src/api/api_server.cpp` | New — route registration, CORS, lifecycle |
| `server/src/api/jwt_middleware.hpp` | New — Crow JWT validation middleware |
| `CMakeLists.txt` | Simplified server block to `add_subdirectory(server)` |

### Architecture
```
main.cpp
  ├── initializeLogging()      — spdlog (console + rotating file)
  ├── validateVtkHeadless()    — OffscreenRenderContext probe
  ├── SessionTokenValidator    — RS256 JWT (ephemeral keys for dev)
  ├── AuditService             — ATNA audit (disabled by default)
  ├── RenderSessionManager     — per-client render lifecycle
  ├── FrameEncoder             — RGBA → JPEG compression
  ├── InputEventDispatcher     — VTK input event queuing
  ├── WebSocketFrameStreamer   — Crow WS on port 8081
  ├── ApiServer                — Crow REST on port 8080
  │     └── GET /api/v1/health (public)
  │     └── GET /api/v1/sessions (JWT-protected)
  └── SIGTERM/SIGINT handler   — graceful shutdown sequence
```

## How

### Callback Pipelines
- **Frame path**: `RenderSessionManager` → `FrameEncoder::encode(JPEG)` → `WebSocketFrameStreamer::pushFrame()`
- **Input path**: `WebSocketFrameStreamer::setInputEventCallback` → `InputEventDispatcher::enqueue()`

### Test Plan
1. Server-only build: `cmake .. -DDICOM_VIEWER_SERVER_ONLY=ON && cmake --build .`
2. Help: `./bin/dicom_viewer_server --help` — shows all CLI options
3. Health: start server, `curl http://localhost:8080/api/v1/health` — returns `{"status":"ok",...}`
4. Signal: `kill -SIGTERM <pid>` — server stops cleanly

### Breaking Changes
None — server build is opt-in via `DICOM_VIEWER_SERVER_ONLY=ON`.

### Dependencies
- Depends on #495 (merged — SERVER_ONLY build option) ✓
- Depends on #496 (merged — RS256 JWT) ✓