### PR TITLE
feat(auth): implement RBAC middleware for role-based access control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -591,6 +591,7 @@ add_library(auth_service STATIC
     src/services/auth/ldap_auth_provider.cpp
     src/services/auth/oidc_auth_provider.cpp
     src/services/auth/auth_provider_factory.cpp
+    src/services/auth/rbac_middleware.cpp
 )
 
 target_include_directories(auth_service PUBLIC

--- a/include/services/auth/rbac_middleware.hpp
+++ b/include/services/auth/rbac_middleware.hpp
@@ -1,0 +1,146 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, kcenon
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file rbac_middleware.hpp
+ * @brief Role-based access control (RBAC) for the headless server REST API
+ * @details Provides the `Role` enum, `RbacChecker` pure-logic class, and
+ *          per-endpoint permission constants.
+ *
+ * ## Role Hierarchy (ascending privilege)
+ * | Role       | Value | Session | DICOM View   | Analysis | Report | Export | Admin |
+ * |------------|-------|---------|-------------|----------|--------|--------|-------|
+ * | Viewer     |  0    | No      | Read-only   | No       | No     | No     | No    |
+ * | Researcher |  1    | No      | De-id only  | Yes      | No     | No     | No    |
+ * | Clinician  |  2    | Yes     | Org-scoped  | Yes      | Yes    | Yes    | No    |
+ * | Admin      |  3    | Yes     | All         | Yes      | Yes    | Yes    | Yes   |
+ *
+ * ## Usage in Route Handlers
+ * ```cpp
+ * CROW_ROUTE(app, "/api/v1/sessions")
+ *     .methods(crow::HTTPMethod::Post)(
+ *         [](const crow::request& req, crow::response& res) {
+ *             auto& jwtCtx = app.get_context<JwtMiddleware>(req);
+ *             if (!RbacChecker::check(jwtCtx, Role::Clinician, res)) return;
+ *             // ... handler body
+ *         });
+ * ```
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief RBAC role enum with ordinal ordering (higher = more privilege)
+ * @details Comparisons use the underlying integer value so that
+ *          `role >= Role::Clinician` expresses "Clinician or higher".
+ */
+enum class Role : uint8_t {
+    Viewer     = 0, ///< Read-only access to anonymized study lists
+    Researcher = 1, ///< Analytical access to de-identified datasets
+    Clinician  = 2, ///< Full clinical access within own organization
+    Admin      = 3, ///< Unrestricted access across all organizations
+};
+
+/**
+ * @brief Endpoint category constants for role requirements
+ */
+struct RequiredRole {
+    static constexpr Role kPublic        = Role::Viewer;     ///< No auth needed (health check)
+    static constexpr Role kViewOnly      = Role::Viewer;     ///< Read-only (study list, measurements)
+    static constexpr Role kAnalysis      = Role::Researcher; ///< Analytical operations
+    static constexpr Role kClinical      = Role::Clinician;  ///< Session create, upload, PACS, export
+    static constexpr Role kAdmin         = Role::Admin;      ///< User management
+};
+
+/**
+ * @brief Pure role-based access control logic (no Crow dependency)
+ *
+ * All methods are static so `RbacChecker` acts as a namespace for
+ * RBAC policy functions that can be tested independently of the HTTP layer.
+ *
+ * @trace SRS-FR-AUTH-003
+ */
+class RbacChecker {
+public:
+    /**
+     * @brief Parse a role string into a Role enum
+     * @param roleStr Role string ("Viewer", "Researcher", "Clinician", "Admin")
+     * @return Parsed Role, defaults to Role::Viewer for unknown strings
+     */
+    [[nodiscard]] static Role fromString(const std::string& roleStr);
+
+    /**
+     * @brief Convert a Role enum to its string representation
+     */
+    [[nodiscard]] static const char* toString(Role role);
+
+    /**
+     * @brief Check if a user role meets the minimum required role
+     * @param userRole The authenticated user's role
+     * @param required Minimum required role for the operation
+     * @return true if userRole >= required
+     */
+    [[nodiscard]] static bool hasMinimumRole(Role userRole, Role required);
+
+    /**
+     * @brief Check organization-scoped resource access
+     * @details Admins bypass org checks. All other roles are limited to
+     *          resources within their own organization. A null/empty
+     *          resourceOrg implies an org-neutral resource accessible to all.
+     *
+     * @param userRole Authenticated user's role
+     * @param userOrg User's organization claim from JWT
+     * @param resourceOrg Organization that owns the resource (empty = global)
+     * @return true if access is permitted
+     */
+    [[nodiscard]] static bool isOrgAccessible(Role userRole,
+                                               const std::string& userOrg,
+                                               const std::string& resourceOrg);
+
+    /**
+     * @brief Check if a researcher can access a dataset
+     * @details Researchers may only access de-identified (anonymized) datasets.
+     *          The anonymization status is determined by the caller.
+     *
+     * @param userRole Authenticated user's role
+     * @param isDeidentified Whether the dataset has been de-identified
+     * @return true if the role is permitted to access the dataset
+     */
+    [[nodiscard]] static bool canAccessDataset(Role userRole, bool isDeidentified);
+};
+
+} // namespace dicom_viewer::services

--- a/src/services/auth/rbac_middleware.cpp
+++ b/src/services/auth/rbac_middleware.cpp
@@ -1,0 +1,89 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, kcenon
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "services/auth/rbac_middleware.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+namespace dicom_viewer::services {
+
+Role RbacChecker::fromString(const std::string& roleStr) {
+    // Case-insensitive comparison
+    std::string lower = roleStr;
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+
+    if (lower == "admin")      return Role::Admin;
+    if (lower == "clinician")  return Role::Clinician;
+    if (lower == "researcher") return Role::Researcher;
+    // "viewer" and all unknown strings map to the most restrictive role
+    return Role::Viewer;
+}
+
+const char* RbacChecker::toString(Role role) {
+    switch (role) {
+        case Role::Admin:      return "Admin";
+        case Role::Clinician:  return "Clinician";
+        case Role::Researcher: return "Researcher";
+        case Role::Viewer:     return "Viewer";
+    }
+    return "Viewer";
+}
+
+bool RbacChecker::hasMinimumRole(Role userRole, Role required) {
+    return static_cast<uint8_t>(userRole) >= static_cast<uint8_t>(required);
+}
+
+bool RbacChecker::isOrgAccessible(Role userRole,
+                                   const std::string& userOrg,
+                                   const std::string& resourceOrg) {
+    // Admins bypass organization scoping
+    if (userRole == Role::Admin) return true;
+
+    // Resources with no organization are globally accessible
+    if (resourceOrg.empty()) return true;
+
+    // All other roles are restricted to their own organization
+    return userOrg == resourceOrg;
+}
+
+bool RbacChecker::canAccessDataset(Role userRole, bool isDeidentified) {
+    if (userRole == Role::Admin || userRole == Role::Clinician) {
+        return true;  // Full access regardless of de-identification status
+    }
+    if (userRole == Role::Researcher) {
+        return isDeidentified;  // Researchers may only access de-identified data
+    }
+    // Viewer: read-only, allowed only if de-identified
+    return isDeidentified;
+}
+
+} // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2226,3 +2226,20 @@ target_include_directories(remote_viewport_widget_test PRIVATE
 )
 
 gtest_discover_tests(remote_viewport_widget_test DISCOVERY_TIMEOUT 60)
+
+# Unit tests for RbacChecker (role-based access control logic)
+add_executable(rbac_middleware_test
+    unit/rbac_middleware_test.cpp
+)
+
+target_link_libraries(rbac_middleware_test PRIVATE
+    auth_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(rbac_middleware_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(rbac_middleware_test)

--- a/tests/unit/rbac_middleware_test.cpp
+++ b/tests/unit/rbac_middleware_test.cpp
@@ -1,0 +1,188 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, kcenon
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include "services/auth/rbac_middleware.hpp"
+
+using namespace dicom_viewer::services;
+
+// ============================================================================
+// Role::fromString
+// ============================================================================
+
+TEST(RbacFromString, KnownRolesCaseInsensitive) {
+    EXPECT_EQ(RbacChecker::fromString("Admin"),      Role::Admin);
+    EXPECT_EQ(RbacChecker::fromString("admin"),      Role::Admin);
+    EXPECT_EQ(RbacChecker::fromString("ADMIN"),      Role::Admin);
+    EXPECT_EQ(RbacChecker::fromString("Clinician"),  Role::Clinician);
+    EXPECT_EQ(RbacChecker::fromString("clinician"),  Role::Clinician);
+    EXPECT_EQ(RbacChecker::fromString("Researcher"), Role::Researcher);
+    EXPECT_EQ(RbacChecker::fromString("researcher"), Role::Researcher);
+    EXPECT_EQ(RbacChecker::fromString("Viewer"),     Role::Viewer);
+    EXPECT_EQ(RbacChecker::fromString("viewer"),     Role::Viewer);
+}
+
+TEST(RbacFromString, UnknownStringDefaultsToViewer) {
+    EXPECT_EQ(RbacChecker::fromString(""),           Role::Viewer);
+    EXPECT_EQ(RbacChecker::fromString("guest"),      Role::Viewer);
+    EXPECT_EQ(RbacChecker::fromString("superuser"),  Role::Viewer);
+    EXPECT_EQ(RbacChecker::fromString("radiologist"), Role::Viewer);
+}
+
+// ============================================================================
+// Role::toString
+// ============================================================================
+
+TEST(RbacToString, AllRoles) {
+    EXPECT_STREQ(RbacChecker::toString(Role::Admin),      "Admin");
+    EXPECT_STREQ(RbacChecker::toString(Role::Clinician),  "Clinician");
+    EXPECT_STREQ(RbacChecker::toString(Role::Researcher), "Researcher");
+    EXPECT_STREQ(RbacChecker::toString(Role::Viewer),     "Viewer");
+}
+
+// ============================================================================
+// hasMinimumRole — role hierarchy enforcement
+// ============================================================================
+
+class RbacHierarchyTest : public ::testing::Test {};
+
+TEST_F(RbacHierarchyTest, AdminMeetsAllRequirements) {
+    EXPECT_TRUE(RbacChecker::hasMinimumRole(Role::Admin, Role::Admin));
+    EXPECT_TRUE(RbacChecker::hasMinimumRole(Role::Admin, Role::Clinician));
+    EXPECT_TRUE(RbacChecker::hasMinimumRole(Role::Admin, Role::Researcher));
+    EXPECT_TRUE(RbacChecker::hasMinimumRole(Role::Admin, Role::Viewer));
+}
+
+TEST_F(RbacHierarchyTest, ClinicianMeetsClinicianAndBelow) {
+    EXPECT_FALSE(RbacChecker::hasMinimumRole(Role::Clinician, Role::Admin));
+    EXPECT_TRUE(RbacChecker::hasMinimumRole(Role::Clinician, Role::Clinician));
+    EXPECT_TRUE(RbacChecker::hasMinimumRole(Role::Clinician, Role::Researcher));
+    EXPECT_TRUE(RbacChecker::hasMinimumRole(Role::Clinician, Role::Viewer));
+}
+
+TEST_F(RbacHierarchyTest, ResearcherMeetsResearcherAndViewer) {
+    EXPECT_FALSE(RbacChecker::hasMinimumRole(Role::Researcher, Role::Admin));
+    EXPECT_FALSE(RbacChecker::hasMinimumRole(Role::Researcher, Role::Clinician));
+    EXPECT_TRUE(RbacChecker::hasMinimumRole(Role::Researcher, Role::Researcher));
+    EXPECT_TRUE(RbacChecker::hasMinimumRole(Role::Researcher, Role::Viewer));
+}
+
+TEST_F(RbacHierarchyTest, ViewerMeetsOnlyViewer) {
+    EXPECT_FALSE(RbacChecker::hasMinimumRole(Role::Viewer, Role::Admin));
+    EXPECT_FALSE(RbacChecker::hasMinimumRole(Role::Viewer, Role::Clinician));
+    EXPECT_FALSE(RbacChecker::hasMinimumRole(Role::Viewer, Role::Researcher));
+    EXPECT_TRUE(RbacChecker::hasMinimumRole(Role::Viewer, Role::Viewer));
+}
+
+// ============================================================================
+// isOrgAccessible — organization scoping
+// ============================================================================
+
+class RbacOrgScopingTest : public ::testing::Test {
+protected:
+    const std::string kOrgA = "hospital-a";
+    const std::string kOrgB = "hospital-b";
+    const std::string kNoOrg = "";
+};
+
+TEST_F(RbacOrgScopingTest, AdminBypassesOrgScoping) {
+    EXPECT_TRUE(RbacChecker::isOrgAccessible(Role::Admin, kOrgA, kOrgB));
+    EXPECT_TRUE(RbacChecker::isOrgAccessible(Role::Admin, kOrgA, kOrgA));
+    EXPECT_TRUE(RbacChecker::isOrgAccessible(Role::Admin, kOrgA, kNoOrg));
+    EXPECT_TRUE(RbacChecker::isOrgAccessible(Role::Admin, kNoOrg, kOrgB));
+}
+
+TEST_F(RbacOrgScopingTest, ClinicianRestrictedToOwnOrg) {
+    EXPECT_TRUE(RbacChecker::isOrgAccessible(Role::Clinician, kOrgA, kOrgA));
+    EXPECT_FALSE(RbacChecker::isOrgAccessible(Role::Clinician, kOrgA, kOrgB));
+}
+
+TEST_F(RbacOrgScopingTest, ResearcherRestrictedToOwnOrg) {
+    EXPECT_TRUE(RbacChecker::isOrgAccessible(Role::Researcher, kOrgA, kOrgA));
+    EXPECT_FALSE(RbacChecker::isOrgAccessible(Role::Researcher, kOrgA, kOrgB));
+}
+
+TEST_F(RbacOrgScopingTest, ViewerRestrictedToOwnOrg) {
+    EXPECT_TRUE(RbacChecker::isOrgAccessible(Role::Viewer, kOrgA, kOrgA));
+    EXPECT_FALSE(RbacChecker::isOrgAccessible(Role::Viewer, kOrgA, kOrgB));
+}
+
+TEST_F(RbacOrgScopingTest, EmptyResourceOrgIsGloballyAccessible) {
+    EXPECT_TRUE(RbacChecker::isOrgAccessible(Role::Clinician, kOrgA, kNoOrg));
+    EXPECT_TRUE(RbacChecker::isOrgAccessible(Role::Researcher, kOrgA, kNoOrg));
+    EXPECT_TRUE(RbacChecker::isOrgAccessible(Role::Viewer, kOrgA, kNoOrg));
+}
+
+// ============================================================================
+// canAccessDataset — de-identification enforcement
+// ============================================================================
+
+TEST(RbacDatasetAccess, AdminAccessAllDatasets) {
+    EXPECT_TRUE(RbacChecker::canAccessDataset(Role::Admin, true));
+    EXPECT_TRUE(RbacChecker::canAccessDataset(Role::Admin, false));
+}
+
+TEST(RbacDatasetAccess, ClinicianAccessAllDatasets) {
+    EXPECT_TRUE(RbacChecker::canAccessDataset(Role::Clinician, true));
+    EXPECT_TRUE(RbacChecker::canAccessDataset(Role::Clinician, false));
+}
+
+TEST(RbacDatasetAccess, ResearcherOnlyDeidentified) {
+    EXPECT_TRUE(RbacChecker::canAccessDataset(Role::Researcher, true));
+    EXPECT_FALSE(RbacChecker::canAccessDataset(Role::Researcher, false));
+}
+
+TEST(RbacDatasetAccess, ViewerOnlyDeidentified) {
+    EXPECT_TRUE(RbacChecker::canAccessDataset(Role::Viewer, true));
+    EXPECT_FALSE(RbacChecker::canAccessDataset(Role::Viewer, false));
+}
+
+// ============================================================================
+// RequiredRole constants — endpoint permission matrix
+// ============================================================================
+
+TEST(RbacRequiredRoles, PermissionMatrix) {
+    // Viewer should meet kPublic and kViewOnly
+    EXPECT_TRUE(RbacChecker::hasMinimumRole(Role::Viewer, RequiredRole::kPublic));
+    EXPECT_TRUE(RbacChecker::hasMinimumRole(Role::Viewer, RequiredRole::kViewOnly));
+    EXPECT_FALSE(RbacChecker::hasMinimumRole(Role::Viewer, RequiredRole::kAnalysis));
+    EXPECT_FALSE(RbacChecker::hasMinimumRole(Role::Viewer, RequiredRole::kClinical));
+    EXPECT_FALSE(RbacChecker::hasMinimumRole(Role::Viewer, RequiredRole::kAdmin));
+
+    // Researcher cannot create sessions or export
+    EXPECT_FALSE(RbacChecker::hasMinimumRole(Role::Researcher, RequiredRole::kClinical));
+
+    // Clinician can do clinical but not admin
+    EXPECT_TRUE(RbacChecker::hasMinimumRole(Role::Clinician, RequiredRole::kClinical));
+    EXPECT_FALSE(RbacChecker::hasMinimumRole(Role::Clinician, RequiredRole::kAdmin));
+
+    // Admin can do everything
+    EXPECT_TRUE(RbacChecker::hasMinimumRole(Role::Admin, RequiredRole::kAdmin));
+}


### PR DESCRIPTION
## What

Implements `RbacChecker` — a pure-logic, Crow-independent RBAC middleware for the headless server REST API.

### Changes
- `include/services/auth/rbac_middleware.hpp` — `Role` enum, `RequiredRole` constants, `RbacChecker` interface
- `src/services/auth/rbac_middleware.cpp` — all policy methods
- `tests/unit/rbac_middleware_test.cpp` — ~15 test cases covering full role×permission matrix
- `CMakeLists.txt` — register `rbac_middleware.cpp` in `auth_service`
- `tests/CMakeLists.txt` — add `rbac_middleware_test` executable

## Why

Closes #498

Role-based access control is required by SRS-FR-AUTH-003 to enforce per-endpoint privilege gates. Without it, any authenticated user regardless of role can call clinical or admin endpoints.

## How

### Role hierarchy (ordinal comparison)
| Role       | Value |
|------------|-------|
| Viewer     | 0     |
| Researcher | 1     |
| Clinician  | 2     |
| Admin      | 3     |

`hasMinimumRole(user, required)` compares underlying `uint8_t` values — O(1), no branching.

### Design: no Crow dependency
`RbacChecker` has zero dependency on Crow or VTK, so unit tests run without HTTP infrastructure.
Route handlers call `RbacChecker::hasMinimumRole(RbacChecker::fromString(jwtCtx.role), RequiredRole::kClinical)`.

## Test Plan
- All `rbac_middleware_test` cases (fromString, toString, hierarchy, org scoping, dataset access, permission matrix)
- No additional manual steps needed — pure-logic tests