### PR TITLE
feat(client): implement core viewport components

### DIFF
--- a/client/src/components/viewport/MeasurementOverlay.tsx
+++ b/client/src/components/viewport/MeasurementOverlay.tsx
@@ -1,0 +1,142 @@
+// MeasurementOverlay renders SVG annotations for measurements associated
+// with a given channelId. Positioned absolutely over the canvas.
+
+import { useMeasurementStore } from '@/stores/measurementStore'
+import type { Measurement } from '@/types/models'
+
+interface Props {
+  channelId: number
+  width: number
+  height: number
+}
+
+function renderMeasurement(m: Measurement) {
+  const { points } = m
+
+  switch (m.type) {
+    case 'length': {
+      if (points.length < 2) return null
+      const [p0, p1] = points as [{ x: number; y: number }, { x: number; y: number }]
+      const mx = (p0.x + p1.x) / 2
+      const my = (p0.y + p1.y) / 2
+      return (
+        <g key={m.id} stroke="#ffeb3b" strokeWidth={1.5} fill="none">
+          <line x1={p0.x} y1={p0.y} x2={p1.x} y2={p1.y} />
+          {m.value !== undefined && (
+            <text x={mx} y={my - 4} fill="#ffeb3b" fontSize={12} stroke="none">
+              {m.value.toFixed(2)} {m.unit ?? ''}
+            </text>
+          )}
+        </g>
+      )
+    }
+
+    case 'angle': {
+      if (points.length < 3) return null
+      const [a, b, c] = points as [
+        { x: number; y: number },
+        { x: number; y: number },
+        { x: number; y: number }
+      ]
+      return (
+        <g key={m.id} stroke="#4fc3f7" strokeWidth={1.5} fill="none">
+          <line x1={a.x} y1={a.y} x2={b.x} y2={b.y} />
+          <line x1={b.x} y1={b.y} x2={c.x} y2={c.y} />
+          {m.value !== undefined && (
+            <text x={b.x + 4} y={b.y - 4} fill="#4fc3f7" fontSize={12} stroke="none">
+              {m.value.toFixed(1)}°
+            </text>
+          )}
+        </g>
+      )
+    }
+
+    case 'ellipse': {
+      if (points.length < 2) return null
+      const [start, end] = points as [{ x: number; y: number }, { x: number; y: number }]
+      const cx = (start.x + end.x) / 2
+      const cy = (start.y + end.y) / 2
+      const rx = Math.abs(end.x - start.x) / 2
+      const ry = Math.abs(end.y - start.y) / 2
+      return (
+        <g key={m.id} stroke="#a5d6a7" strokeWidth={1.5} fill="none">
+          <ellipse cx={cx} cy={cy} rx={rx} ry={ry} />
+          {m.value !== undefined && (
+            <text x={cx} y={cy - ry - 4} fill="#a5d6a7" fontSize={12} stroke="none">
+              {m.value.toFixed(2)} {m.unit ?? ''}
+            </text>
+          )}
+        </g>
+      )
+    }
+
+    case 'rectangle': {
+      if (points.length < 2) return null
+      const [tl, br] = points as [{ x: number; y: number }, { x: number; y: number }]
+      const w = br.x - tl.x
+      const h = br.y - tl.y
+      return (
+        <g key={m.id} stroke="#ce93d8" strokeWidth={1.5} fill="none">
+          <rect x={tl.x} y={tl.y} width={w} height={h} />
+          {m.value !== undefined && (
+            <text x={tl.x} y={tl.y - 4} fill="#ce93d8" fontSize={12} stroke="none">
+              {m.value.toFixed(2)} {m.unit ?? ''}
+            </text>
+          )}
+        </g>
+      )
+    }
+
+    case 'arrow': {
+      if (points.length < 2) return null
+      const [from, to] = points as [{ x: number; y: number }, { x: number; y: number }]
+      const angle = Math.atan2(to.y - from.y, to.x - from.x)
+      const arrowLen = 10
+      const arrowAngle = Math.PI / 6
+      const ax1 = to.x - arrowLen * Math.cos(angle - arrowAngle)
+      const ay1 = to.y - arrowLen * Math.sin(angle - arrowAngle)
+      const ax2 = to.x - arrowLen * Math.cos(angle + arrowAngle)
+      const ay2 = to.y - arrowLen * Math.sin(angle + arrowAngle)
+      return (
+        <g key={m.id} stroke="#ff8a65" strokeWidth={1.5} fill="none">
+          <line x1={from.x} y1={from.y} x2={to.x} y2={to.y} />
+          <polyline points={`${ax1},${ay1} ${to.x},${to.y} ${ax2},${ay2}`} />
+          {m.label !== undefined && (
+            <text x={to.x + 4} y={to.y} fill="#ff8a65" fontSize={12} stroke="none">
+              {m.label}
+            </text>
+          )}
+        </g>
+      )
+    }
+
+    default:
+      return null
+  }
+}
+
+export function MeasurementOverlay({ channelId, width, height }: Props) {
+  const measurements = useMeasurementStore((s) =>
+    s.measurements.filter((m) => m.channelId === channelId)
+  )
+
+  if (measurements.length === 0) return null
+
+  return (
+    <svg
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        pointerEvents: 'none',
+        overflow: 'visible',
+      }}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+    >
+      {measurements.map(renderMeasurement)}
+    </svg>
+  )
+}

--- a/client/src/components/viewport/RemoteViewport.tsx
+++ b/client/src/components/viewport/RemoteViewport.tsx
@@ -1,0 +1,177 @@
+// RemoteViewport renders binary frames from WebSocket onto a canvas element.
+// RGBA frames: ImageData -> createImageBitmap (GPU upload off main thread)
+// JPEG/PNG frames: Blob -> createImageBitmap (decoded off main thread)
+// Rendering is decoupled from network delivery via requestAnimationFrame.
+
+import { useEffect, useRef, useCallback } from 'react'
+import { wsManager } from '@/api/wsManager'
+import { FrameType } from '@/types/websocket'
+import type { BinaryFrame } from '@/types/websocket'
+import type { InputEvent } from '@/types/websocket'
+
+interface Props {
+  channelId: number
+  isActive: boolean
+  onClick: () => void
+}
+
+export function RemoteViewport({ channelId, isActive, onClick }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  // Latest decoded bitmap, consumed by the rAF loop
+  const bitmapRef = useRef<ImageBitmap | null>(null)
+  const pendingBitmapRef = useRef<ImageBitmap | null>(null)
+  const rafIdRef = useRef<number>(0)
+  // Track canvas size for input coordinate normalisation
+  const canvasSizeRef = useRef<{ width: number; height: number }>({ width: 0, height: 0 })
+
+  // Decode an incoming frame into an ImageBitmap off the main thread
+  const handleFrame = useCallback(async (frame: BinaryFrame) => {
+    let bitmap: ImageBitmap
+
+    if (frame.frameType === FrameType.RGBA) {
+      // Raw RGBA: wrap in ImageData then createImageBitmap
+      const clamped = new Uint8ClampedArray(
+        frame.imageData.buffer,
+        frame.imageData.byteOffset,
+        frame.imageData.byteLength
+      )
+      const imgData = new ImageData(clamped, frame.width, frame.height)
+      bitmap = await createImageBitmap(imgData)
+    } else {
+      // JPEG or PNG: wrap in Blob, browser decodes in a worker
+      const mime = frame.frameType === FrameType.JPEG ? 'image/jpeg' : 'image/png'
+      const blob = new Blob([frame.imageData], { type: mime })
+      bitmap = await createImageBitmap(blob)
+    }
+
+    // Swap: discard any pending bitmap that was never rendered
+    pendingBitmapRef.current?.close()
+    pendingBitmapRef.current = bitmap
+  }, [])
+
+  // rAF loop: draw the latest bitmap each frame
+  const renderLoop = useCallback(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const pending = pendingBitmapRef.current
+    if (pending !== null) {
+      const ctx = canvas.getContext('2d')
+      if (ctx) {
+        // Resize canvas to match frame dimensions if needed
+        if (canvas.width !== pending.width || canvas.height !== pending.height) {
+          canvas.width = pending.width
+          canvas.height = pending.height
+          canvasSizeRef.current = { width: pending.width, height: pending.height }
+        }
+        ctx.drawImage(pending, 0, 0)
+
+        // Release previous bitmap after draw
+        bitmapRef.current?.close()
+        bitmapRef.current = pending
+        pendingBitmapRef.current = null
+      }
+    }
+
+    rafIdRef.current = requestAnimationFrame(renderLoop)
+  }, [])
+
+  // Subscribe to frames for this channel
+  useEffect(() => {
+    const unsubscribe = wsManager.onFrame(channelId, (frame) => {
+      void handleFrame(frame)
+    })
+    return unsubscribe
+  }, [channelId, handleFrame])
+
+  // Start/stop rAF loop
+  useEffect(() => {
+    rafIdRef.current = requestAnimationFrame(renderLoop)
+    return () => {
+      cancelAnimationFrame(rafIdRef.current)
+      bitmapRef.current?.close()
+      bitmapRef.current = null
+      pendingBitmapRef.current?.close()
+      pendingBitmapRef.current = null
+    }
+  }, [renderLoop])
+
+  // Forward mouse/keyboard input events to the server
+  const buildInputEvent = useCallback(
+    (base: Omit<InputEvent, 'channelId'>): InputEvent => ({
+      ...base,
+      channelId,
+    }),
+    [channelId]
+  )
+
+  const getModifiers = (e: React.MouseEvent | React.KeyboardEvent | React.WheelEvent) => ({
+    ctrl: e.ctrlKey,
+    shift: e.shiftKey,
+    alt: e.altKey,
+    meta: e.metaKey,
+  })
+
+  const getCanvasCoords = (e: React.MouseEvent) => {
+    const rect = canvasRef.current?.getBoundingClientRect()
+    if (!rect) return { x: 0, y: 0 }
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top }
+  }
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    onClick()
+    const { x, y } = getCanvasCoords(e)
+    wsManager.sendInputEvent(buildInputEvent({ type: 'mousedown', x, y, button: e.button, modifiers: getModifiers(e) }))
+  }
+
+  const handleMouseUp = (e: React.MouseEvent) => {
+    const { x, y } = getCanvasCoords(e)
+    wsManager.sendInputEvent(buildInputEvent({ type: 'mouseup', x, y, button: e.button, modifiers: getModifiers(e) }))
+  }
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (e.buttons === 0) return
+    const { x, y } = getCanvasCoords(e)
+    wsManager.sendInputEvent(buildInputEvent({ type: 'mousemove', x, y, modifiers: getModifiers(e) }))
+  }
+
+  const handleWheel = (e: React.WheelEvent) => {
+    const { x, y } = getCanvasCoords(e)
+    wsManager.sendInputEvent(buildInputEvent({ type: 'wheel', x, y, deltaX: e.deltaX, deltaY: e.deltaY, modifiers: getModifiers(e) }))
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    wsManager.sendInputEvent(buildInputEvent({ type: 'keydown', key: e.key, modifiers: getModifiers(e) }))
+  }
+
+  const handleKeyUp = (e: React.KeyboardEvent) => {
+    wsManager.sendInputEvent(buildInputEvent({ type: 'keyup', key: e.key, modifiers: getModifiers(e) }))
+  }
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        background: '#000',
+        outline: isActive ? '2px solid #2196f3' : '1px solid #333',
+        boxSizing: 'border-box',
+        cursor: 'crosshair',
+        overflow: 'hidden',
+      }}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      onKeyUp={handleKeyUp}
+    >
+      <canvas
+        ref={canvasRef}
+        style={{ display: 'block', width: '100%', height: '100%', objectFit: 'contain' }}
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+        onMouseMove={handleMouseMove}
+        onWheel={handleWheel}
+      />
+    </div>
+  )
+}

--- a/client/src/components/viewport/ViewportGrid.tsx
+++ b/client/src/components/viewport/ViewportGrid.tsx
@@ -1,0 +1,64 @@
+// ViewportGrid renders a CSS grid of RemoteViewport + MeasurementOverlay pairs.
+// Layout is driven by useViewportStore; each viewport slot maps to a channel.
+
+import { useViewportStore } from '@/stores/viewportStore'
+import { RemoteViewport } from './RemoteViewport'
+import { MeasurementOverlay } from './MeasurementOverlay'
+import type { ViewportLayout } from '@/types/models'
+
+function layoutToColumns(layout: ViewportLayout): number {
+  switch (layout) {
+    case '1x1': return 1
+    case '1x2': return 2
+    case '2x2': return 2
+    case '2x3': return 3
+    case '3x3': return 3
+  }
+}
+
+// Canvas dimensions for the SVG viewBox (must stay in sync with actual frame size).
+// We use a fixed logical coordinate space matching common DICOM display resolutions.
+const OVERLAY_WIDTH = 512
+const OVERLAY_HEIGHT = 512
+
+export function ViewportGrid() {
+  const layout = useViewportStore((s) => s.layout)
+  const channels = useViewportStore((s) => s.channels)
+  const activeViewportIndex = useViewportStore((s) => s.activeViewportIndex)
+  const setActiveViewport = useViewportStore((s) => s.setActiveViewport)
+
+  const cols = layoutToColumns(layout)
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: `repeat(${cols}, 1fr)`,
+        gridAutoRows: '1fr',
+        width: '100%',
+        height: '100%',
+        gap: '2px',
+        background: '#111',
+        boxSizing: 'border-box',
+      }}
+    >
+      {channels.map((ch) => (
+        <div
+          key={ch.channelId}
+          style={{ position: 'relative', minWidth: 0, minHeight: 0 }}
+        >
+          <RemoteViewport
+            channelId={ch.channelId}
+            isActive={ch.viewportIndex === activeViewportIndex}
+            onClick={() => setActiveViewport(ch.viewportIndex)}
+          />
+          <MeasurementOverlay
+            channelId={ch.channelId}
+            width={OVERLAY_WIDTH}
+            height={OVERLAY_HEIGHT}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## What

### Summary
Implements the three core viewport components for DICOM image display:
- `RemoteViewport.tsx` — canvas-based renderer using `createImageBitmap` + `requestAnimationFrame` loop with full mouse/keyboard input forwarding
- `MeasurementOverlay.tsx` — SVG annotation layer for all measurement types (length, angle, ellipse, rectangle, arrow)
- `ViewportGrid.tsx` — CSS Grid layout manager supporting 1x1, 1x2, 2x2, 2x3, 3x3 viewport arrangements

### Change Type
- [x] Feature (new functionality)

### Affected Components
- `client/src/components/viewport/RemoteViewport.tsx` (new)
- `client/src/components/viewport/MeasurementOverlay.tsx` (new)
- `client/src/components/viewport/ViewportGrid.tsx` (new)

## Why

### Problem Solved
The viewport is the primary UI surface for DICOM image display. Without these components, no medical imaging data can be rendered in the browser client.

### Related Issues
Closes #519
Part of #506

## How

### Implementation Details
- **RemoteViewport**: decouples network delivery from rendering — `wsManager.onFrame` decodes bitmaps asynchronously via `createImageBitmap`, latest bitmap is consumed by the rAF loop. Supports RGBA (raw `ImageData`), JPEG, and PNG frame types. Active viewport highlighted with a blue outline.
- **MeasurementOverlay**: filtered by `channelId` from `useMeasurementStore`, rendered as `pointer-events: none` SVG so mouse events fall through to the canvas. `preserveAspectRatio="none"` matches SVG coordinates to CSS layout.
- **ViewportGrid**: `grid-template-columns: repeat(cols, 1fr)` driven by `useViewportStore.layout`; channels rendered in index order.

### Testing Done
- [x] TypeScript type check (`npm run typecheck`) — passes with zero errors

### Breaking Changes
None — new files only, no existing code modified.