### PR TITLE
feat(client): implement app layout and navigation components

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,6 @@
 import { useSessionStore } from '@/stores/sessionStore'
 import { AuthProvider } from '@/components/auth/AuthProvider'
+import { AppLayout } from '@/components/layout/AppLayout'
 
 function App() {
   const connectionStatus = useSessionStore((s) => s.connectionStatus)
@@ -7,7 +8,7 @@ function App() {
   return (
     <AuthProvider>
       <div data-testid="app-root" data-status={connectionStatus}>
-        {/* Layout components will be added in issue #520 */}
+        <AppLayout />
       </div>
     </AuthProvider>
   )

--- a/client/src/components/layout/AppLayout.tsx
+++ b/client/src/components/layout/AppLayout.tsx
@@ -1,0 +1,36 @@
+// AppLayout is the main application shell: TopBar + (SidePanel | ViewportGrid) + StatusBar.
+
+import { useUiStore } from '@/stores/uiStore'
+import { TopBar } from './TopBar'
+import { SidePanel } from './SidePanel'
+import { StatusBar } from './StatusBar'
+import { ViewportGrid } from '@/components/viewport/ViewportGrid'
+
+export function AppLayout() {
+  const isStatusBarVisible = useUiStore((s) => s.isStatusBarVisible)
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100vw',
+        height: '100vh',
+        background: '#111',
+        overflow: 'hidden',
+      }}
+    >
+      <TopBar />
+
+      {/* Main content: sidebar + viewport area */}
+      <div style={{ display: 'flex', flex: 1, overflow: 'hidden', minHeight: 0 }}>
+        <SidePanel />
+        <div style={{ flex: 1, overflow: 'hidden', minWidth: 0 }}>
+          <ViewportGrid />
+        </div>
+      </div>
+
+      {isStatusBarVisible && <StatusBar />}
+    </div>
+  )
+}

--- a/client/src/components/layout/SidePanel.tsx
+++ b/client/src/components/layout/SidePanel.tsx
@@ -1,0 +1,92 @@
+// SidePanel is a collapsible dock housing tabbed tool panels.
+// Actual panel content (PatientBrowser, SegmentationPanel, etc.) will be
+// added in issue #521. Placeholder tabs are rendered here.
+
+import { useUiStore } from '@/stores/uiStore'
+import type { ReactNode } from 'react'
+
+type ActivePanel = NonNullable<ReturnType<typeof useUiStore.getState>['activePanel']>
+
+const PANEL_TABS: { id: ActivePanel; label: string }[] = [
+  { id: 'patientBrowser', label: 'Patients' },
+  { id: 'segmentation', label: 'Seg' },
+  { id: 'measurement', label: 'Measure' },
+  { id: 'flow', label: 'Flow' },
+  { id: 'overlay', label: 'Overlay' },
+  { id: 'report', label: 'Report' },
+]
+
+interface Props {
+  children?: ReactNode
+}
+
+export function SidePanel({ children }: Props) {
+  const isSidePanelOpen = useUiStore((s) => s.isSidePanelOpen)
+  const activePanel = useUiStore((s) => s.activePanel)
+  const setActivePanel = useUiStore((s) => s.setActivePanel)
+
+  if (!isSidePanelOpen) return null
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: '240px',
+        flexShrink: 0,
+        background: '#1e1e1e',
+        borderRight: '1px solid #333',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Tab bar */}
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '1px',
+          padding: '4px',
+          background: '#1a1a1a',
+          borderBottom: '1px solid #333',
+          flexShrink: 0,
+        }}
+      >
+        {PANEL_TABS.map(({ id, label }) => (
+          <button
+            key={id}
+            onClick={() => setActivePanel(id)}
+            style={{
+              background: activePanel === id ? '#1565c0' : '#2a2a2a',
+              border: '1px solid #444',
+              borderRadius: '3px',
+              color: activePanel === id ? '#fff' : '#aaa',
+              cursor: 'pointer',
+              fontSize: '11px',
+              padding: '3px 6px',
+              lineHeight: 1,
+            }}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Panel content area */}
+      <div
+        style={{
+          flex: 1,
+          overflow: 'auto',
+          padding: '8px',
+          color: '#888',
+          fontSize: '13px',
+        }}
+      >
+        {children ?? (
+          <div style={{ textAlign: 'center', marginTop: '24px', color: '#555' }}>
+            {activePanel !== null ? activePanel : 'Select a panel'}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/layout/StatusBar.tsx
+++ b/client/src/components/layout/StatusBar.tsx
@@ -1,0 +1,54 @@
+// StatusBar displays real-time connection status and quality metrics from sessionStore.
+
+import { useSessionStore } from '@/stores/sessionStore'
+
+const STATUS_COLOR: Record<string, string> = {
+  connected: '#4caf50',
+  connecting: '#ff9800',
+  disconnected: '#9e9e9e',
+  error: '#f44336',
+}
+
+export function StatusBar() {
+  const connectionStatus = useSessionStore((s) => s.connectionStatus)
+  const metrics = useSessionStore((s) => s.metrics)
+
+  const color = STATUS_COLOR[connectionStatus] ?? '#9e9e9e'
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '16px',
+        height: '24px',
+        padding: '0 12px',
+        background: '#1a1a1a',
+        borderTop: '1px solid #333',
+        fontSize: '12px',
+        color: '#aaa',
+        userSelect: 'none',
+        flexShrink: 0,
+      }}
+    >
+      <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+        <span
+          style={{
+            display: 'inline-block',
+            width: '8px',
+            height: '8px',
+            borderRadius: '50%',
+            background: color,
+          }}
+        />
+        <span style={{ color }}>{connectionStatus}</span>
+      </span>
+      <span>{metrics.fps.toFixed(0)} FPS</span>
+      <span>{metrics.latencyMs.toFixed(0)} ms</span>
+      <span>{(metrics.bandwidthKbps / 1024).toFixed(1)} Mbps</span>
+      {metrics.droppedFrames > 0 && (
+        <span style={{ color: '#f44336' }}>{metrics.droppedFrames} dropped</span>
+      )}
+    </div>
+  )
+}

--- a/client/src/components/layout/TopBar.tsx
+++ b/client/src/components/layout/TopBar.tsx
@@ -1,0 +1,94 @@
+// TopBar renders the application header: title, viewport layout selector,
+// sidebar toggle, and user info with logout.
+
+import { useUiStore } from '@/stores/uiStore'
+import { useViewportStore } from '@/stores/viewportStore'
+import { useAuthStore } from '@/stores/authStore'
+import type { ViewportLayout } from '@/types/models'
+
+const LAYOUTS: ViewportLayout[] = ['1x1', '1x2', '2x2', '2x3', '3x3']
+
+export function TopBar() {
+  const layout = useViewportStore((s) => s.layout)
+  const setLayout = useViewportStore((s) => s.setLayout)
+  const isSidePanelOpen = useUiStore((s) => s.isSidePanelOpen)
+  const toggleSidePanel = useUiStore((s) => s.toggleSidePanel)
+  const user = useAuthStore((s) => s.user)
+  const logout = useAuthStore((s) => s.logout)
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        height: '40px',
+        padding: '0 12px',
+        background: '#212121',
+        borderBottom: '1px solid #333',
+        flexShrink: 0,
+      }}
+    >
+      {/* Sidebar toggle */}
+      <button
+        onClick={toggleSidePanel}
+        title={isSidePanelOpen ? 'Collapse sidebar' : 'Expand sidebar'}
+        style={buttonStyle}
+        aria-pressed={isSidePanelOpen}
+      >
+        {isSidePanelOpen ? '◀' : '▶'}
+      </button>
+
+      {/* App title */}
+      <span
+        style={{ fontWeight: 600, fontSize: '14px', color: '#e0e0e0', marginRight: '8px' }}
+      >
+        DICOM Viewer
+      </span>
+
+      {/* Viewport layout selector */}
+      <span style={{ fontSize: '12px', color: '#888', marginRight: '4px' }}>Layout:</span>
+      {LAYOUTS.map((l) => (
+        <button
+          key={l}
+          onClick={() => setLayout(l)}
+          style={{
+            ...buttonStyle,
+            background: layout === l ? '#1565c0' : '#2a2a2a',
+            color: layout === l ? '#fff' : '#aaa',
+            minWidth: '36px',
+          }}
+        >
+          {l}
+        </button>
+      ))}
+
+      {/* Spacer */}
+      <div style={{ flex: 1 }} />
+
+      {/* User info */}
+      {user !== null && (
+        <span style={{ fontSize: '12px', color: '#aaa' }}>
+          {user.username}
+          <span style={{ color: '#666', marginLeft: '4px' }}>({user.role})</span>
+        </span>
+      )}
+
+      <button onClick={logout} style={{ ...buttonStyle, color: '#ef9a9a' }}>
+        Logout
+      </button>
+    </div>
+  )
+}
+
+const buttonStyle: React.CSSProperties = {
+  background: '#2a2a2a',
+  border: '1px solid #444',
+  borderRadius: '3px',
+  color: '#ccc',
+  cursor: 'pointer',
+  fontSize: '12px',
+  padding: '2px 8px',
+  height: '24px',
+  lineHeight: 1,
+}


### PR DESCRIPTION
## What

### Summary
Implements the application shell components:
- `AppLayout.tsx` — main window shell composed of TopBar, SidePanel, ViewportGrid, and StatusBar
- `TopBar.tsx` — viewport layout selector (1x1/1x2/2x2/2x3/3x3), sidebar toggle, user info with logout
- `SidePanel.tsx` — collapsible left dock with tabbed panel navigation (Patients, Seg, Measure, Flow, Overlay, Report)
- `StatusBar.tsx` — connection status indicator with FPS, latency, and bandwidth metrics
- Updated `App.tsx` to render `AppLayout` inside `AuthProvider`

### Change Type
- [x] Feature (new functionality)

### Affected Components
- `client/src/components/layout/AppLayout.tsx` (new)
- `client/src/components/layout/TopBar.tsx` (new)
- `client/src/components/layout/SidePanel.tsx` (new)
- `client/src/components/layout/StatusBar.tsx` (new)
- `client/src/App.tsx` (updated)

## Why

### Problem Solved
The application had no layout shell — authenticated users saw an empty div. This PR adds the complete navigation structure required to host tool panels and the viewport grid.

### Related Issues
Closes #520
Part of #506

## How

### Implementation Details
- `AppLayout` uses `flex-direction: column` for vertical stacking, inner content row uses `flex` with `minHeight: 0` / `minWidth: 0` to prevent flex overflow
- `SidePanel` tab state driven by `useUiStore.activePanel`; actual panel content (PatientBrowser etc.) is a placeholder pending issue #521
- `StatusBar` reads `connectionStatus` and `QualityMetrics` from `useSessionStore`
- `TopBar` layout selector dispatches to `useViewportStore.setLayout`

### Testing Done
- [x] TypeScript type check (`npm run typecheck`) — passes with zero errors

### Breaking Changes
None — `App.tsx` change wires in new AppLayout; structure is additive.