### PR TITLE
feat(client): implement tool panels and dialogs

### DIFF
--- a/client/src/components/dialogs/PacsConfigDialog.tsx
+++ b/client/src/components/dialogs/PacsConfigDialog.tsx
@@ -1,0 +1,252 @@
+// PacsConfigDialog manages PACS server configurations stored in pacsStore.
+// Server configs are managed locally (no server-side persistence endpoint).
+
+import { useState } from 'react'
+import { usePacsStore } from '@/stores/pacsStore'
+import { useUiStore } from '@/stores/uiStore'
+import type { PacsServer } from '@/types/api'
+
+interface ServerForm {
+  name: string
+  aet: string
+  host: string
+  port: string
+  tlsEnabled: boolean
+}
+
+const EMPTY_FORM: ServerForm = {
+  name: '',
+  aet: '',
+  host: '',
+  port: '11112',
+  tlsEnabled: false,
+}
+
+export function PacsConfigDialog() {
+  const isPacsConfigOpen = useUiStore((s) => s.isPacsConfigOpen)
+  const closePacsConfig = useUiStore((s) => s.closePacsConfig)
+  const servers = usePacsStore((s) => s.servers)
+  const setServers = usePacsStore((s) => s.setServers)
+
+  const [form, setForm] = useState<ServerForm>(EMPTY_FORM)
+  const [error, setError] = useState<string | null>(null)
+
+  if (!isPacsConfigOpen) return null
+
+  const handleAdd = () => {
+    const portNum = parseInt(form.port, 10)
+    if (!form.name.trim() || !form.aet.trim() || !form.host.trim()) {
+      setError('Name, AET, and Host are required')
+      return
+    }
+    if (isNaN(portNum) || portNum < 1 || portNum > 65535) {
+      setError('Port must be 1–65535')
+      return
+    }
+
+    const newServer: PacsServer = {
+      id: `${Date.now()}`,
+      name: form.name.trim(),
+      aet: form.aet.trim(),
+      host: form.host.trim(),
+      port: portNum,
+      tlsEnabled: form.tlsEnabled,
+    }
+    setServers([...servers, newServer])
+    setForm(EMPTY_FORM)
+    setError(null)
+  }
+
+  const handleRemove = (id: string) => {
+    setServers(servers.filter((s) => s.id !== id))
+  }
+
+  return (
+    <div style={overlayStyle} onClick={closePacsConfig}>
+      <div style={dialogStyle} onClick={(e) => e.stopPropagation()}>
+        <div style={titleStyle}>PACS Configuration</div>
+
+        {/* Server list */}
+        {servers.length > 0 && (
+          <div style={{ marginBottom: '12px' }}>
+            {servers.map((server) => (
+              <div key={server.id} style={serverRowStyle}>
+                <div style={{ flex: 1 }}>
+                  <span style={{ color: '#e0e0e0', fontSize: '13px' }}>{server.name}</span>
+                  <span style={{ color: '#666', fontSize: '12px', marginLeft: '8px' }}>
+                    {server.aet} @ {server.host}:{server.port}
+                    {server.tlsEnabled && ' (TLS)'}
+                  </span>
+                </div>
+                <button
+                  onClick={() => handleRemove(server.id)}
+                  style={{ ...smallButtonStyle, color: '#ef9a9a' }}
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Add form */}
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' }}>
+          <div style={fieldGroupStyle}>
+            <label style={labelStyle}>Name</label>
+            <input
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              placeholder="Main PACS"
+              style={inputStyle}
+            />
+          </div>
+          <div style={fieldGroupStyle}>
+            <label style={labelStyle}>AE Title</label>
+            <input
+              value={form.aet}
+              onChange={(e) => setForm({ ...form, aet: e.target.value })}
+              placeholder="PACS_AET"
+              style={inputStyle}
+            />
+          </div>
+          <div style={fieldGroupStyle}>
+            <label style={labelStyle}>Host</label>
+            <input
+              value={form.host}
+              onChange={(e) => setForm({ ...form, host: e.target.value })}
+              placeholder="192.168.1.100"
+              style={inputStyle}
+            />
+          </div>
+          <div style={fieldGroupStyle}>
+            <label style={labelStyle}>Port</label>
+            <input
+              type="number"
+              value={form.port}
+              onChange={(e) => setForm({ ...form, port: e.target.value })}
+              placeholder="11112"
+              style={inputStyle}
+            />
+          </div>
+          <div style={{ ...fieldGroupStyle, flexDirection: 'row', alignItems: 'center', gap: '6px' }}>
+            <input
+              type="checkbox"
+              id="pacs-tls"
+              checked={form.tlsEnabled}
+              onChange={(e) => setForm({ ...form, tlsEnabled: e.target.checked })}
+            />
+            <label htmlFor="pacs-tls" style={{ ...labelStyle, cursor: 'pointer' }}>
+              TLS
+            </label>
+          </div>
+        </div>
+
+        {error !== null && (
+          <div style={{ color: '#ef9a9a', fontSize: '12px', marginTop: '6px' }}>{error}</div>
+        )}
+
+        <div style={{ display: 'flex', gap: '8px', marginTop: '12px', justifyContent: 'flex-end' }}>
+          <button onClick={handleAdd} style={primaryButtonStyle}>
+            Add Server
+          </button>
+          <button onClick={closePacsConfig} style={secondaryButtonStyle}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const overlayStyle: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0,0,0,0.6)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 1000,
+}
+
+const dialogStyle: React.CSSProperties = {
+  background: '#1e1e1e',
+  border: '1px solid #333',
+  borderRadius: '6px',
+  padding: '20px',
+  width: '480px',
+  maxWidth: '90vw',
+  maxHeight: '80vh',
+  overflow: 'auto',
+}
+
+const titleStyle: React.CSSProperties = {
+  fontSize: '16px',
+  fontWeight: 600,
+  color: '#e0e0e0',
+  marginBottom: '16px',
+}
+
+const serverRowStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  padding: '6px 8px',
+  background: '#2a2a2a',
+  borderRadius: '3px',
+  marginBottom: '4px',
+}
+
+const fieldGroupStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '4px',
+}
+
+const labelStyle: React.CSSProperties = {
+  fontSize: '11px',
+  color: '#666',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+}
+
+const inputStyle: React.CSSProperties = {
+  background: '#2a2a2a',
+  border: '1px solid #444',
+  borderRadius: '3px',
+  color: '#ccc',
+  fontSize: '13px',
+  padding: '4px 8px',
+  outline: 'none',
+  width: '100%',
+  boxSizing: 'border-box',
+}
+
+const smallButtonStyle: React.CSSProperties = {
+  background: 'transparent',
+  border: '1px solid #444',
+  borderRadius: '3px',
+  color: '#aaa',
+  cursor: 'pointer',
+  fontSize: '12px',
+  padding: '2px 8px',
+}
+
+const primaryButtonStyle: React.CSSProperties = {
+  background: '#1565c0',
+  border: '1px solid #1976d2',
+  borderRadius: '3px',
+  color: '#fff',
+  cursor: 'pointer',
+  fontSize: '13px',
+  padding: '6px 16px',
+}
+
+const secondaryButtonStyle: React.CSSProperties = {
+  background: '#2a2a2a',
+  border: '1px solid #444',
+  borderRadius: '3px',
+  color: '#ccc',
+  cursor: 'pointer',
+  fontSize: '13px',
+  padding: '6px 16px',
+}

--- a/client/src/components/dialogs/SettingsDialog.tsx
+++ b/client/src/components/dialogs/SettingsDialog.tsx
@@ -1,0 +1,140 @@
+// SettingsDialog allows toggling theme, status bar, and toolbar visibility.
+
+import { useUiStore } from '@/stores/uiStore'
+
+export function SettingsDialog() {
+  const isSettingsOpen = useUiStore((s) => s.isSettingsOpen)
+  const closeSettings = useUiStore((s) => s.closeSettings)
+  const theme = useUiStore((s) => s.theme)
+  const setTheme = useUiStore((s) => s.setTheme)
+  const isStatusBarVisible = useUiStore((s) => s.isStatusBarVisible)
+  const setStatusBarVisible = useUiStore((s) => s.setStatusBarVisible)
+  const isToolBarVisible = useUiStore((s) => s.isToolBarVisible)
+  const setToolBarVisible = useUiStore((s) => s.setToolBarVisible)
+
+  if (!isSettingsOpen) return null
+
+  return (
+    <div style={overlayStyle} onClick={closeSettings}>
+      <div style={dialogStyle} onClick={(e) => e.stopPropagation()}>
+        <div style={titleStyle}>Settings</div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          {/* Theme */}
+          <div style={rowStyle}>
+            <span style={rowLabelStyle}>Theme</span>
+            <div style={{ display: 'flex', gap: '4px' }}>
+              <button
+                onClick={() => setTheme('dark')}
+                style={{
+                  ...chipStyle,
+                  background: theme === 'dark' ? '#1565c0' : '#2a2a2a',
+                  color: theme === 'dark' ? '#fff' : '#aaa',
+                }}
+              >
+                Dark
+              </button>
+              <button
+                onClick={() => setTheme('light')}
+                style={{
+                  ...chipStyle,
+                  background: theme === 'light' ? '#1565c0' : '#2a2a2a',
+                  color: theme === 'light' ? '#fff' : '#aaa',
+                }}
+              >
+                Light
+              </button>
+            </div>
+          </div>
+
+          {/* Status bar */}
+          <div style={rowStyle}>
+            <label htmlFor="settings-statusbar" style={rowLabelStyle}>
+              Status bar
+            </label>
+            <input
+              id="settings-statusbar"
+              type="checkbox"
+              checked={isStatusBarVisible}
+              onChange={(e) => setStatusBarVisible(e.target.checked)}
+            />
+          </div>
+
+          {/* Toolbar */}
+          <div style={rowStyle}>
+            <label htmlFor="settings-toolbar" style={rowLabelStyle}>
+              Toolbar
+            </label>
+            <input
+              id="settings-toolbar"
+              type="checkbox"
+              checked={isToolBarVisible}
+              onChange={(e) => setToolBarVisible(e.target.checked)}
+            />
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '20px' }}>
+          <button onClick={closeSettings} style={closeButtonStyle}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const overlayStyle: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0,0,0,0.6)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 1000,
+}
+
+const dialogStyle: React.CSSProperties = {
+  background: '#1e1e1e',
+  border: '1px solid #333',
+  borderRadius: '6px',
+  padding: '20px',
+  width: '360px',
+  maxWidth: '90vw',
+}
+
+const titleStyle: React.CSSProperties = {
+  fontSize: '16px',
+  fontWeight: 600,
+  color: '#e0e0e0',
+  marginBottom: '16px',
+}
+
+const rowStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+}
+
+const rowLabelStyle: React.CSSProperties = {
+  fontSize: '13px',
+  color: '#ccc',
+}
+
+const chipStyle: React.CSSProperties = {
+  border: '1px solid #444',
+  borderRadius: '3px',
+  cursor: 'pointer',
+  fontSize: '12px',
+  padding: '4px 12px',
+}
+
+const closeButtonStyle: React.CSSProperties = {
+  background: '#2a2a2a',
+  border: '1px solid #444',
+  borderRadius: '3px',
+  color: '#ccc',
+  cursor: 'pointer',
+  fontSize: '13px',
+  padding: '6px 16px',
+}

--- a/client/src/components/layout/AppLayout.tsx
+++ b/client/src/components/layout/AppLayout.tsx
@@ -1,10 +1,13 @@
 // AppLayout is the main application shell: TopBar + (SidePanel | ViewportGrid) + StatusBar.
+// Modal dialogs are rendered here so they overlay the entire UI.
 
 import { useUiStore } from '@/stores/uiStore'
 import { TopBar } from './TopBar'
 import { SidePanel } from './SidePanel'
 import { StatusBar } from './StatusBar'
 import { ViewportGrid } from '@/components/viewport/ViewportGrid'
+import { PacsConfigDialog } from '@/components/dialogs/PacsConfigDialog'
+import { SettingsDialog } from '@/components/dialogs/SettingsDialog'
 
 export function AppLayout() {
   const isStatusBarVisible = useUiStore((s) => s.isStatusBarVisible)
@@ -31,6 +34,10 @@ export function AppLayout() {
       </div>
 
       {isStatusBarVisible && <StatusBar />}
+
+      {/* Modal dialogs */}
+      <PacsConfigDialog />
+      <SettingsDialog />
     </div>
   )
 }

--- a/client/src/components/layout/SidePanel.tsx
+++ b/client/src/components/layout/SidePanel.tsx
@@ -1,9 +1,11 @@
 // SidePanel is a collapsible dock housing tabbed tool panels.
-// Actual panel content (PatientBrowser, SegmentationPanel, etc.) will be
-// added in issue #521. Placeholder tabs are rendered here.
 
 import { useUiStore } from '@/stores/uiStore'
-import type { ReactNode } from 'react'
+import { PatientBrowser } from '@/components/panels/PatientBrowser'
+import { SegmentationPanel } from '@/components/panels/SegmentationPanel'
+import { FlowToolPanel } from '@/components/panels/FlowToolPanel'
+import { OverlayControlPanel } from '@/components/panels/OverlayControlPanel'
+import { ReportPanel } from '@/components/panels/ReportPanel'
 
 type ActivePanel = NonNullable<ReturnType<typeof useUiStore.getState>['activePanel']>
 
@@ -16,11 +18,23 @@ const PANEL_TABS: { id: ActivePanel; label: string }[] = [
   { id: 'report', label: 'Report' },
 ]
 
-interface Props {
-  children?: ReactNode
+function ActivePanelContent({ activePanel }: { activePanel: ActivePanel }) {
+  switch (activePanel) {
+    case 'patientBrowser': return <PatientBrowser />
+    case 'segmentation': return <SegmentationPanel />
+    case 'flow': return <FlowToolPanel />
+    case 'overlay': return <OverlayControlPanel />
+    case 'report': return <ReportPanel />
+    case 'measurement':
+      return (
+        <div style={{ color: '#555', fontSize: '12px', textAlign: 'center', marginTop: '8px' }}>
+          Use the viewport tools to add measurements
+        </div>
+      )
+  }
 }
 
-export function SidePanel({ children }: Props) {
+export function SidePanel() {
   const isSidePanelOpen = useUiStore((s) => s.isSidePanelOpen)
   const activePanel = useUiStore((s) => s.activePanel)
   const setActivePanel = useUiStore((s) => s.setActivePanel)
@@ -81,9 +95,11 @@ export function SidePanel({ children }: Props) {
           fontSize: '13px',
         }}
       >
-        {children ?? (
+        {activePanel !== null ? (
+          <ActivePanelContent activePanel={activePanel} />
+        ) : (
           <div style={{ textAlign: 'center', marginTop: '24px', color: '#555' }}>
-            {activePanel !== null ? activePanel : 'Select a panel'}
+            Select a panel
           </div>
         )}
       </div>

--- a/client/src/components/layout/TopBar.tsx
+++ b/client/src/components/layout/TopBar.tsx
@@ -13,6 +13,8 @@ export function TopBar() {
   const setLayout = useViewportStore((s) => s.setLayout)
   const isSidePanelOpen = useUiStore((s) => s.isSidePanelOpen)
   const toggleSidePanel = useUiStore((s) => s.toggleSidePanel)
+  const openPacsConfig = useUiStore((s) => s.openPacsConfig)
+  const openSettings = useUiStore((s) => s.openSettings)
   const user = useAuthStore((s) => s.user)
   const logout = useAuthStore((s) => s.logout)
 
@@ -65,6 +67,14 @@ export function TopBar() {
 
       {/* Spacer */}
       <div style={{ flex: 1 }} />
+
+      {/* Config / Settings */}
+      <button onClick={openPacsConfig} style={buttonStyle} title="PACS Configuration">
+        PACS
+      </button>
+      <button onClick={openSettings} style={buttonStyle} title="Settings">
+        ⚙
+      </button>
 
       {/* User info */}
       {user !== null && (

--- a/client/src/components/panels/FlowToolPanel.tsx
+++ b/client/src/components/panels/FlowToolPanel.tsx
@@ -1,0 +1,107 @@
+// FlowToolPanel controls 4D Flow MRI phase playback and displays quantification data.
+
+import { useFlowStore } from '@/stores/flowStore'
+
+export function FlowToolPanel() {
+  const phaseIndex = useFlowStore((s) => s.phaseIndex)
+  const totalPhases = useFlowStore((s) => s.totalPhases)
+  const isPlaying = useFlowStore((s) => s.isPlaying)
+  const playbackFps = useFlowStore((s) => s.playbackFps)
+  const quantificationData = useFlowStore((s) => s.quantificationData)
+  const setPhaseIndex = useFlowStore((s) => s.setPhaseIndex)
+  const setPlaying = useFlowStore((s) => s.setPlaying)
+  const setPlaybackFps = useFlowStore((s) => s.setPlaybackFps)
+  const nextPhase = useFlowStore((s) => s.nextPhase)
+  const prevPhase = useFlowStore((s) => s.prevPhase)
+
+  if (totalPhases === 0) {
+    return (
+      <div style={{ color: '#555', fontSize: '12px', textAlign: 'center', marginTop: '8px' }}>
+        No 4D Flow study loaded
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+      {/* Phase scrubber */}
+      <div>
+        <div style={sectionLabel}>
+          Phase {phaseIndex + 1} / {totalPhases}
+        </div>
+        <input
+          type="range"
+          min={0}
+          max={totalPhases - 1}
+          value={phaseIndex}
+          onChange={(e) => setPhaseIndex(Number(e.target.value))}
+          style={{ width: '100%', marginTop: '4px' }}
+        />
+      </div>
+
+      {/* Playback controls */}
+      <div style={{ display: 'flex', gap: '4px', justifyContent: 'center' }}>
+        <button onClick={prevPhase} style={controlButtonStyle}>◀</button>
+        <button
+          onClick={() => setPlaying(!isPlaying)}
+          style={{ ...controlButtonStyle, minWidth: '64px', background: isPlaying ? '#1565c0' : '#2a2a2a' }}
+        >
+          {isPlaying ? '⏸ Pause' : '▶ Play'}
+        </button>
+        <button onClick={nextPhase} style={controlButtonStyle}>▶</button>
+      </div>
+
+      {/* FPS control */}
+      <div>
+        <div style={sectionLabel}>Playback speed: {playbackFps} FPS</div>
+        <input
+          type="range"
+          min={1}
+          max={30}
+          value={playbackFps}
+          onChange={(e) => setPlaybackFps(Number(e.target.value))}
+          style={{ width: '100%', marginTop: '4px' }}
+        />
+      </div>
+
+      {/* Quantification data */}
+      {quantificationData !== null && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          <div style={sectionLabel}>Flow Metrics</div>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '12px' }}>
+            <tbody>
+              {([
+                ['Forward', `${quantificationData.forwardFlowMl.toFixed(1)} mL`],
+                ['Reverse', `${quantificationData.reverseFlowMl.toFixed(1)} mL`],
+                ['Net flow', `${quantificationData.netFlowMl.toFixed(1)} mL`],
+                ['Peak vel.', `${(quantificationData.peakVelocityMs * 100).toFixed(1)} cm/s`],
+              ] as [string, string][]).map(([key, val]) => (
+                <tr key={key}>
+                  <td style={{ color: '#666', paddingRight: '8px', paddingBottom: '2px' }}>{key}</td>
+                  <td style={{ color: '#ccc' }}>{val}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const sectionLabel: React.CSSProperties = {
+  fontSize: '11px',
+  color: '#666',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+}
+
+const controlButtonStyle: React.CSSProperties = {
+  background: '#2a2a2a',
+  border: '1px solid #444',
+  borderRadius: '3px',
+  color: '#ccc',
+  cursor: 'pointer',
+  fontSize: '13px',
+  padding: '4px 10px',
+}

--- a/client/src/components/panels/OverlayControlPanel.tsx
+++ b/client/src/components/panels/OverlayControlPanel.tsx
@@ -1,0 +1,82 @@
+// OverlayControlPanel controls segmentation label overlay visibility and opacity.
+
+import { useSegmentationStore } from '@/stores/segmentationStore'
+
+function colorToCss(rgba: [number, number, number, number]): string {
+  return `rgba(${rgba[0]},${rgba[1]},${rgba[2]},${rgba[3] / 255})`
+}
+
+export function OverlayControlPanel() {
+  const labels = useSegmentationStore((s) => s.labels)
+  const updateLabel = useSegmentationStore((s) => s.updateLabel)
+
+  if (labels.length === 0) {
+    return (
+      <div style={{ color: '#555', fontSize: '12px', textAlign: 'center', marginTop: '8px' }}>
+        No segmentation labels
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <div style={sectionLabel}>Overlay Visibility &amp; Opacity</div>
+      {labels.map((label) => (
+        <div key={label.id} style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+            {/* Color swatch */}
+            <div
+              style={{
+                width: '12px',
+                height: '12px',
+                borderRadius: '2px',
+                background: colorToCss(label.color),
+                flexShrink: 0,
+              }}
+            />
+            {/* Visibility toggle */}
+            <input
+              type="checkbox"
+              checked={label.visible}
+              onChange={(e) => updateLabel(label.id, { visible: e.target.checked })}
+              style={{ flexShrink: 0 }}
+            />
+            <span
+              style={{
+                flex: 1,
+                fontSize: '12px',
+                color: label.visible ? '#ccc' : '#555',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {label.name}
+            </span>
+            <span style={{ fontSize: '11px', color: '#666', flexShrink: 0 }}>
+              {Math.round(label.opacity * 100)}%
+            </span>
+          </div>
+          {/* Opacity slider */}
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.05}
+            value={label.opacity}
+            disabled={!label.visible}
+            onChange={(e) => updateLabel(label.id, { opacity: Number(e.target.value) })}
+            style={{ width: '100%', opacity: label.visible ? 1 : 0.3 }}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+const sectionLabel: React.CSSProperties = {
+  fontSize: '11px',
+  color: '#666',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+}

--- a/client/src/components/panels/PatientBrowser.tsx
+++ b/client/src/components/panels/PatientBrowser.tsx
@@ -1,0 +1,152 @@
+// PatientBrowser shows a local study list and PACS query interface.
+// Local studies are fetched via useStudies(); PACS results are stored in pacsStore.
+
+import { useState } from 'react'
+import { useStudies, usePacsQuery } from '@/api/endpoints'
+import { useStudyStore } from '@/stores/studyStore'
+import { usePacsStore } from '@/stores/pacsStore'
+import type { PacsQueryParams } from '@/types/api'
+
+const rowStyle: React.CSSProperties = {
+  padding: '6px 8px',
+  borderRadius: '3px',
+  cursor: 'pointer',
+  fontSize: '12px',
+  userSelect: 'none',
+}
+
+export function PatientBrowser() {
+  const [patientName, setPatientName] = useState('')
+  const [patientId, setPatientId] = useState('')
+
+  const { data: studies, isLoading } = useStudies()
+
+  const pacsQueryMutation = usePacsQuery()
+  const pacsServers = usePacsStore((s) => s.servers)
+  const queryResults = usePacsStore((s) => s.queryResults)
+  const isQuerying = usePacsStore((s) => s.isQuerying)
+  const setQueryResults = usePacsStore((s) => s.setQueryResults)
+  const setQuerying = usePacsStore((s) => s.setQuerying)
+  const setQueryError = usePacsStore((s) => s.setQueryError)
+  const clearQueryResults = usePacsStore((s) => s.clearQueryResults)
+
+  const selectedStudyUid = useStudyStore((s) => s.selectedStudyUid)
+  const selectStudy = useStudyStore((s) => s.selectStudy)
+
+  const firstServer = pacsServers[0]
+
+  const handleSearch = () => {
+    if (firstServer === undefined) return
+    setQuerying(true)
+
+    const params: PacsQueryParams = { serverId: firstServer.id }
+    if (patientName.trim()) params.patientName = patientName.trim()
+    if (patientId.trim()) params.patientId = patientId.trim()
+
+    pacsQueryMutation.mutate(params, {
+      onSuccess: (result) => {
+        setQueryResults(result.studies)
+      },
+      onError: (err) => {
+        setQueryError(err instanceof Error ? err.message : 'PACS query failed')
+      },
+    })
+  }
+
+  const displayStudies = queryResults.length > 0 ? queryResults : (studies ?? [])
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+      {/* PACS search form — only when a server is configured */}
+      {firstServer !== undefined && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          <input
+            placeholder="Patient name"
+            value={patientName}
+            onChange={(e) => setPatientName(e.target.value)}
+            style={inputStyle}
+          />
+          <input
+            placeholder="Patient ID"
+            value={patientId}
+            onChange={(e) => setPatientId(e.target.value)}
+            style={inputStyle}
+          />
+          <div style={{ display: 'flex', gap: '4px' }}>
+            <button
+              onClick={handleSearch}
+              disabled={isQuerying}
+              style={{ ...actionButtonStyle, flex: 1 }}
+            >
+              {isQuerying ? 'Searching…' : 'Search PACS'}
+            </button>
+            {queryResults.length > 0 && (
+              <button onClick={clearQueryResults} style={actionButtonStyle}>
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Study list */}
+      {isLoading && (
+        <div style={{ color: '#666', fontSize: '12px', textAlign: 'center' }}>
+          Loading…
+        </div>
+      )}
+
+      {displayStudies.map((study) => {
+        const isActive = study.studyInstanceUid === selectedStudyUid
+        return (
+          <div
+            key={study.studyInstanceUid}
+            onClick={() => selectStudy(study.studyInstanceUid)}
+            style={{
+              ...rowStyle,
+              background: isActive ? '#1565c0' : '#2a2a2a',
+            }}
+          >
+            <div style={{ color: '#e0e0e0', fontWeight: 500 }}>
+              {study.patientName || '—'}
+            </div>
+            <div style={{ color: '#aaa', marginTop: '2px' }}>
+              {study.studyDate} &mdash; {study.studyDescription || 'No description'}
+            </div>
+            <div style={{ color: '#666', marginTop: '2px' }}>
+              {study.modalities.join(', ')} &bull; {study.seriesCount} series
+            </div>
+          </div>
+        )
+      })}
+
+      {displayStudies.length === 0 && !isLoading && (
+        <div style={{ color: '#555', fontSize: '12px', textAlign: 'center', marginTop: '8px' }}>
+          No studies
+        </div>
+      )}
+    </div>
+  )
+}
+
+const inputStyle: React.CSSProperties = {
+  background: '#2a2a2a',
+  border: '1px solid #444',
+  borderRadius: '3px',
+  color: '#ccc',
+  fontSize: '12px',
+  padding: '4px 6px',
+  outline: 'none',
+  width: '100%',
+  boxSizing: 'border-box',
+}
+
+const actionButtonStyle: React.CSSProperties = {
+  background: '#2a2a2a',
+  border: '1px solid #444',
+  borderRadius: '3px',
+  color: '#ccc',
+  cursor: 'pointer',
+  fontSize: '12px',
+  padding: '4px 8px',
+}

--- a/client/src/components/panels/ReportPanel.tsx
+++ b/client/src/components/panels/ReportPanel.tsx
@@ -1,0 +1,108 @@
+// ReportPanel triggers PDF/CSV export for the currently selected study via REST API.
+
+import { useExportReport, useExportCsv } from '@/api/endpoints'
+import { useStudyStore } from '@/stores/studyStore'
+
+export function ReportPanel() {
+  const selectedStudyUid = useStudyStore((s) => s.selectedStudyUid)
+  const exportReport = useExportReport()
+  const exportCsv = useExportCsv()
+
+  const downloadBlob = (blob: Blob, filename: string) => {
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const handleExportPdf = () => {
+    if (selectedStudyUid === null) return
+    exportReport.mutate(
+      { studyInstanceUid: selectedStudyUid, format: 'pdf', includeImages: true },
+      {
+        onSuccess: (blob) => downloadBlob(blob, `report-${selectedStudyUid}.pdf`),
+      }
+    )
+  }
+
+  const handleExportDocx = () => {
+    if (selectedStudyUid === null) return
+    exportReport.mutate(
+      { studyInstanceUid: selectedStudyUid, format: 'docx', includeImages: false },
+      {
+        onSuccess: (blob) => downloadBlob(blob, `report-${selectedStudyUid}.docx`),
+      }
+    )
+  }
+
+  const handleExportCsv = () => {
+    if (selectedStudyUid === null) return
+    exportCsv.mutate(
+      { studyInstanceUid: selectedStudyUid, metrics: ['flow', 'measurements'] },
+      {
+        onSuccess: (blob) => downloadBlob(blob, `metrics-${selectedStudyUid}.csv`),
+      }
+    )
+  }
+
+  if (selectedStudyUid === null) {
+    return (
+      <div style={{ color: '#555', fontSize: '12px', textAlign: 'center', marginTop: '8px' }}>
+        Select a study to export
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <div style={sectionLabel}>Export</div>
+      <button
+        onClick={handleExportPdf}
+        disabled={exportReport.isPending}
+        style={buttonStyle}
+      >
+        {exportReport.isPending ? 'Generating…' : 'Download PDF Report'}
+      </button>
+      <button
+        onClick={handleExportDocx}
+        disabled={exportReport.isPending}
+        style={buttonStyle}
+      >
+        Download DOCX Report
+      </button>
+      <button
+        onClick={handleExportCsv}
+        disabled={exportCsv.isPending}
+        style={buttonStyle}
+      >
+        {exportCsv.isPending ? 'Exporting…' : 'Export Metrics CSV'}
+      </button>
+      {exportReport.isError && (
+        <div style={{ color: '#ef9a9a', fontSize: '12px' }}>
+          Export failed: {exportReport.error instanceof Error ? exportReport.error.message : 'Unknown error'}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const sectionLabel: React.CSSProperties = {
+  fontSize: '11px',
+  color: '#666',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+}
+
+const buttonStyle: React.CSSProperties = {
+  background: '#2a2a2a',
+  border: '1px solid #444',
+  borderRadius: '3px',
+  color: '#ccc',
+  cursor: 'pointer',
+  fontSize: '12px',
+  padding: '6px 8px',
+  textAlign: 'left',
+  width: '100%',
+}

--- a/client/src/components/panels/SegmentationPanel.tsx
+++ b/client/src/components/panels/SegmentationPanel.tsx
@@ -1,0 +1,201 @@
+// SegmentationPanel provides brush/eraser tool controls and segmentation label management.
+
+import { useSegmentationStore } from '@/stores/segmentationStore'
+import type { SegmentationTool } from '@/types/models'
+
+const TOOLS: { id: SegmentationTool; label: string }[] = [
+  { id: 'brush', label: 'Brush' },
+  { id: 'eraser', label: 'Eraser' },
+  { id: 'levelTracing', label: 'Trace' },
+  { id: 'scissors', label: 'Scissors' },
+  { id: 'hollow', label: 'Hollow' },
+]
+
+const LABEL_COLORS: [number, number, number, number][] = [
+  [255, 82, 82, 255],
+  [82, 255, 82, 255],
+  [82, 82, 255, 255],
+  [255, 255, 82, 255],
+  [255, 82, 255, 255],
+]
+
+function colorToCss(rgba: [number, number, number, number]): string {
+  return `rgba(${rgba[0]},${rgba[1]},${rgba[2]},${rgba[3] / 255})`
+}
+
+export function SegmentationPanel() {
+  const activeTool = useSegmentationStore((s) => s.activeTool)
+  const setActiveTool = useSegmentationStore((s) => s.setActiveTool)
+  const brushSize = useSegmentationStore((s) => s.brushSize)
+  const setBrushSize = useSegmentationStore((s) => s.setBrushSize)
+  const undoDepth = useSegmentationStore((s) => s.undoDepth)
+  const undo = useSegmentationStore((s) => s.undo)
+  const labels = useSegmentationStore((s) => s.labels)
+  const activeLabelId = useSegmentationStore((s) => s.activeLabelId)
+  const setActiveLabelId = useSegmentationStore((s) => s.setActiveLabelId)
+  const addLabel = useSegmentationStore((s) => s.addLabel)
+  const removeLabel = useSegmentationStore((s) => s.removeLabel)
+  const updateLabel = useSegmentationStore((s) => s.updateLabel)
+
+  const handleAddLabel = () => {
+    const colorEntry = LABEL_COLORS[labels.length % LABEL_COLORS.length]
+    if (colorEntry === undefined) return
+    addLabel({
+      id: Date.now(),
+      name: `Label ${labels.length + 1}`,
+      color: colorEntry,
+      visible: true,
+      opacity: 0.5,
+    })
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+      {/* Tool selector */}
+      <div>
+        <div style={sectionLabel}>Tool</div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginTop: '4px' }}>
+          {TOOLS.map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setActiveTool(id)}
+              style={{
+                ...chipStyle,
+                background: activeTool === id ? '#1565c0' : '#2a2a2a',
+                color: activeTool === id ? '#fff' : '#aaa',
+              }}
+            >
+              {label}
+            </button>
+          ))}
+          <button
+            onClick={() => setActiveTool('none')}
+            style={{
+              ...chipStyle,
+              background: activeTool === 'none' ? '#424242' : '#2a2a2a',
+              color: '#aaa',
+            }}
+          >
+            None
+          </button>
+        </div>
+      </div>
+
+      {/* Brush size */}
+      <div>
+        <div style={sectionLabel}>Brush size: {brushSize}px</div>
+        <input
+          type="range"
+          min={1}
+          max={100}
+          value={brushSize}
+          onChange={(e) => setBrushSize(Number(e.target.value))}
+          style={{ width: '100%', marginTop: '4px' }}
+        />
+      </div>
+
+      {/* Undo */}
+      <button
+        onClick={undo}
+        disabled={undoDepth === 0}
+        style={{ ...actionButtonStyle, opacity: undoDepth === 0 ? 0.4 : 1 }}
+      >
+        Undo ({undoDepth})
+      </button>
+
+      {/* Labels */}
+      <div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: '4px',
+          }}
+        >
+          <span style={sectionLabel}>Labels</span>
+          <button onClick={handleAddLabel} style={chipStyle}>
+            + Add
+          </button>
+        </div>
+        {labels.map((label) => (
+          <div
+            key={label.id}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '6px',
+              padding: '4px 0',
+              borderBottom: '1px solid #2a2a2a',
+            }}
+          >
+            {/* Color swatch / active indicator */}
+            <div
+              onClick={() => setActiveLabelId(label.id)}
+              style={{
+                width: '16px',
+                height: '16px',
+                borderRadius: '3px',
+                background: colorToCss(label.color),
+                border: activeLabelId === label.id ? '2px solid #fff' : '2px solid transparent',
+                cursor: 'pointer',
+                flexShrink: 0,
+              }}
+            />
+            {/* Visibility toggle */}
+            <input
+              type="checkbox"
+              checked={label.visible}
+              onChange={(e) => updateLabel(label.id, { visible: e.target.checked })}
+              style={{ flexShrink: 0 }}
+            />
+            {/* Label name */}
+            <span style={{ flex: 1, fontSize: '12px', color: '#ccc', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {label.name}
+            </span>
+            {/* Remove */}
+            <button
+              onClick={() => removeLabel(label.id)}
+              style={{ ...chipStyle, padding: '1px 5px', color: '#ef9a9a' }}
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+        {labels.length === 0 && (
+          <div style={{ color: '#555', fontSize: '12px', textAlign: 'center', marginTop: '4px' }}>
+            No labels
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const sectionLabel: React.CSSProperties = {
+  fontSize: '11px',
+  color: '#666',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+}
+
+const chipStyle: React.CSSProperties = {
+  background: '#2a2a2a',
+  border: '1px solid #444',
+  borderRadius: '3px',
+  color: '#aaa',
+  cursor: 'pointer',
+  fontSize: '12px',
+  padding: '3px 8px',
+}
+
+const actionButtonStyle: React.CSSProperties = {
+  background: '#2a2a2a',
+  border: '1px solid #444',
+  borderRadius: '3px',
+  color: '#ccc',
+  cursor: 'pointer',
+  fontSize: '12px',
+  padding: '4px 8px',
+  width: '100%',
+}

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -16,12 +16,18 @@ interface UiState {
   activePanel: ActivePanel
   isStatusBarVisible: boolean
   isToolBarVisible: boolean
+  isPacsConfigOpen: boolean
+  isSettingsOpen: boolean
   setTheme: (theme: Theme) => void
   setSidePanelOpen: (open: boolean) => void
   setActivePanel: (panel: ActivePanel) => void
   toggleSidePanel: () => void
   setStatusBarVisible: (visible: boolean) => void
   setToolBarVisible: (visible: boolean) => void
+  openPacsConfig: () => void
+  closePacsConfig: () => void
+  openSettings: () => void
+  closeSettings: () => void
 }
 
 export const useUiStore = create<UiState>((set) => ({
@@ -30,6 +36,8 @@ export const useUiStore = create<UiState>((set) => ({
   activePanel: 'patientBrowser',
   isStatusBarVisible: true,
   isToolBarVisible: true,
+  isPacsConfigOpen: false,
+  isSettingsOpen: false,
 
   setTheme: (theme) => set({ theme }),
 
@@ -44,4 +52,9 @@ export const useUiStore = create<UiState>((set) => ({
   setStatusBarVisible: (isStatusBarVisible) => set({ isStatusBarVisible }),
 
   setToolBarVisible: (isToolBarVisible) => set({ isToolBarVisible }),
+
+  openPacsConfig: () => set({ isPacsConfigOpen: true }),
+  closePacsConfig: () => set({ isPacsConfigOpen: false }),
+  openSettings: () => set({ isSettingsOpen: true }),
+  closeSettings: () => set({ isSettingsOpen: false }),
 }))


### PR DESCRIPTION
## What

### Summary
Completes the React client UI (Phase 2.4 split 4/4) by implementing all side panel tool components and modal dialogs:
- **PatientBrowser** — local study list with PACS query interface (patient name/ID search)
- **SegmentationPanel** — brush/eraser/trace/scissors/hollow tools, brush size slider, undo, segmentation label management (add/remove/visibility)
- **FlowToolPanel** — 4D Flow MRI phase scrubber, play/pause, FPS control, quantification metrics display
- **OverlayControlPanel** — per-label visibility toggle and opacity slider for segmentation overlays
- **ReportPanel** — PDF/DOCX/CSV export triggers via REST API (`/export/report`, `/export/csv`)
- **PacsConfigDialog** — add/remove PACS server configurations (name, AET, host, port, TLS); persisted in `pacsStore`
- **SettingsDialog** — theme (dark/light), status bar, and toolbar visibility toggles
- Updated `SidePanel` to render actual panel components based on active tab
- Updated `TopBar` with PACS Config and Settings buttons
- Updated `AppLayout` to render modal dialogs at root level
- Added `isPacsConfigOpen`/`isSettingsOpen` states to `uiStore`

### Change Type
- [x] Feature (new functionality)

### Affected Components
- `client/src/components/panels/` (5 new files)
- `client/src/components/dialogs/` (2 new files)
- `client/src/components/layout/SidePanel.tsx` (updated)
- `client/src/components/layout/TopBar.tsx` (updated)
- `client/src/components/layout/AppLayout.tsx` (updated)
- `client/src/stores/uiStore.ts` (updated)

## Why

### Problem Solved
Tool panels give clinicians access to study data (PatientBrowser), segmentation tools, 4D Flow analysis, report generation, and PACS configuration. This PR completes Phase 2.4 of the React client migration.

### Related Issues
Closes #521
Part of #506

## How

### Implementation Details
- All panels communicate with the server via REST API hooks (`useStudies`, `usePacsQuery`, `useExportReport`, `useExportCsv`)
- `ReportPanel` uses `URL.createObjectURL` for blob downloads — no server-side temp file needed
- `PacsConfigDialog` manages PACS servers in `pacsStore` (local state) since no server-side CRUD endpoint exists
- Modal dialogs use `position: fixed; inset: 0` overlay pattern with click-outside-to-close
- `SidePanel` uses a switch-based `ActivePanelContent` component to avoid conditional import complexity
- TypeScript `noUncheckedIndexedAccess` handled throughout (`pacsServers[0]` guarded with `=== undefined`)

### Testing Done
- [x] TypeScript type check (`npm run typecheck`) — passes with zero errors

### Breaking Changes
None — `uiStore` additions are backward-compatible (new optional fields with defaults).

## Epic Closure Note
With #521 merged, all sub-issues of #506 will be completed:
- #518 Authentication ✓
- #519 Viewport components ✓
- #520 Layout shell ✓
- #521 Tool panels & dialogs (this PR)