### PR TITLE
fix(client): narrow BinaryFrame.imageData to Uint8Array<ArrayBuffer>

### DIFF
--- a/client/src/types/websocket.ts
+++ b/client/src/types/websocket.ts
@@ -29,7 +29,7 @@ export interface BinaryFrame {
   channelId: number
   width: number
   height: number
-  imageData: Uint8Array
+  imageData: Uint8Array<ArrayBuffer>
 }
 
 export interface InputEvent {


### PR DESCRIPTION
## What

Fixes TypeScript 5.9 build errors in `RemoteViewport.tsx` caused by the unparameterised `Uint8Array` type in `BinaryFrame`.

### Change Type
- [x] Bugfix (fixes a build error)

### Affected Components
- `client/src/types/websocket.ts` — `BinaryFrame.imageData` narrowed to `Uint8Array<ArrayBuffer>`

## Why

### Problem Solved

TypeScript 5.x made built-in typed arrays generic: the bare `Uint8Array` now resolves to `Uint8Array<ArrayBufferLike>`. Both `ImageData` and `Blob` constructors require `ArrayBuffer`-backed arrays, causing:

- TS2769: `new ImageData(clamped, w, h)` rejected (line 38)
- TS2322: `new Blob([frame.imageData])` rejected (line 43)

### Related Issues
- Closes #506

### Why `ArrayBuffer` is accurate

WebSocket messages with `binaryType = 'arraybuffer'` always deliver `ArrayBuffer`, never `SharedArrayBuffer`. The narrower type matches the runtime contract.

## How

### Implementation Details

Single-character change: `imageData: Uint8Array` → `imageData: Uint8Array<ArrayBuffer>` in the `BinaryFrame` interface. No runtime change; TypeScript propagates the type downstream, fixing all dependent errors.

### Testing Done
- [x] `npm --prefix client run build` — passes with zero errors (119 modules)
- [x] No logic changes, runtime behavior identical

### Breaking Changes
None — this is a type annotation tightening that matches the existing runtime contract.

### Rollback Plan
Revert this single-line change.