### PR TITLE
feat(rendering): implement GPU Memory Budget Manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -640,6 +640,7 @@ add_library(render_service STATIC
     src/services/render/adaptive_quality_controller.cpp
     src/services/render/dirty_region_tracker.cpp
     src/services/render/session_token_validator.cpp
+    src/services/render/gpu_memory_budget_manager.cpp
 )
 
 # Crow WebSocket framework (header-only)
@@ -654,6 +655,7 @@ target_link_libraries(render_service PUBLIC
     jwt-cpp::jwt-cpp
     OpenSSL::SSL
     OpenSSL::Crypto
+    ${CMAKE_DL_LIBS}
 )
 
 if(EXISTS "${CROW_INCLUDE_DIR}/crow.h" AND EXISTS "${ASIO_INCLUDE_DIR}/asio.hpp")

--- a/include/services/render/gpu_memory_budget_manager.hpp
+++ b/include/services/render/gpu_memory_budget_manager.hpp
@@ -1,0 +1,213 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, kcenon
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file gpu_memory_budget_manager.hpp
+ * @brief GPU memory budget manager with NVML-based monitoring
+ * @details Monitors VRAM usage via NVIDIA NVML API, enforces per-session budgets,
+ *          and prevents server crashes from GPU memory exhaustion. Falls back
+ *          gracefully when NVML is unavailable (e.g., non-NVIDIA or macOS hosts).
+ *
+ * ## Enforcement Tiers
+ * - 85% utilization: reject new session creation
+ * - 90% utilization: auto-degrade quality on all sessions
+ * - 95% utilization: force-terminate LRU idle session
+ *
+ * ## Thread Safety
+ * - All public methods are thread-safe (internal mutex)
+ *
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace dicom_viewer::services {
+
+/**
+ * @brief Session type identifiers for VRAM budget estimation
+ */
+enum class GpuSessionType {
+    CT,       ///< CT session (~2 GB VRAM)
+    Flow4D,   ///< 4D Flow session (~3.5 GB VRAM)
+    Generic   ///< Generic session (~1 GB VRAM)
+};
+
+/**
+ * @brief Enforcement action returned by checkAndEnforce()
+ */
+enum class EnforcementAction {
+    None,              ///< Under budget, no action needed
+    RejectNewSessions, ///< 85%+ utilization: reject new session creation
+    DegradeQuality,    ///< 90%+ utilization: auto-degrade quality on sessions
+    TerminateLRU       ///< 95%+ utilization: terminate least-recently-used session
+};
+
+/**
+ * @brief GPU memory metrics snapshot
+ */
+struct GpuMemoryMetrics {
+    bool available = false;       ///< Whether NVML is functional
+    std::string gpuName;          ///< GPU device name (e.g., "NVIDIA T4")
+    uint64_t totalBytes = 0;      ///< Total VRAM in bytes
+    uint64_t usedBytes = 0;       ///< Used VRAM in bytes
+    uint64_t freeBytes = 0;       ///< Free VRAM in bytes
+    double utilizationPercent = 0; ///< Used / Total as percentage (0-100)
+    uint32_t activeSessionCount = 0; ///< Number of tracked sessions
+};
+
+/**
+ * @brief Configuration for GPU memory budget thresholds
+ */
+struct GpuBudgetConfig {
+    /// Utilization threshold to reject new sessions (percent)
+    double rejectThreshold = 85.0;
+
+    /// Utilization threshold to auto-degrade quality (percent)
+    double degradeThreshold = 90.0;
+
+    /// Utilization threshold to force-terminate LRU session (percent)
+    double terminateThreshold = 95.0;
+
+    /// Estimated VRAM per CT session (bytes)
+    uint64_t ctSessionBudgetBytes = 2ULL * 1024 * 1024 * 1024;
+
+    /// Estimated VRAM per 4D Flow session (bytes)
+    uint64_t flow4dSessionBudgetBytes = 3584ULL * 1024 * 1024;
+
+    /// Estimated VRAM per generic session (bytes)
+    uint64_t genericSessionBudgetBytes = 1ULL * 1024 * 1024 * 1024;
+
+    /// GPU device index to monitor (0 = first GPU)
+    uint32_t deviceIndex = 0;
+};
+
+/**
+ * @brief Callback invoked when enforcement terminates a session
+ * @param sessionId Session that should be terminated
+ */
+using SessionTerminateCallback = std::function<void(const std::string& sessionId)>;
+
+/**
+ * @brief GPU memory budget manager with NVML-based monitoring
+ *
+ * Monitors GPU memory via NVML, tracks per-session budgets, and enforces
+ * utilization thresholds. When NVML is unavailable, all operations succeed
+ * gracefully (no enforcement, metrics report unavailable).
+ *
+ * @trace SRS-FR-REMOTE-010
+ */
+class GpuMemoryBudgetManager {
+public:
+    explicit GpuMemoryBudgetManager(const GpuBudgetConfig& config = {});
+    ~GpuMemoryBudgetManager();
+
+    // Non-copyable, non-movable
+    GpuMemoryBudgetManager(const GpuMemoryBudgetManager&) = delete;
+    GpuMemoryBudgetManager& operator=(const GpuMemoryBudgetManager&) = delete;
+    GpuMemoryBudgetManager(GpuMemoryBudgetManager&&) = delete;
+    GpuMemoryBudgetManager& operator=(GpuMemoryBudgetManager&&) = delete;
+
+    /**
+     * @brief Check if NVML is available and initialized
+     */
+    [[nodiscard]] bool isAvailable() const;
+
+    /**
+     * @brief Pre-check whether a new session can be created
+     * @param type Session type for budget estimation
+     * @return true if budget allows, false if creation should be rejected
+     */
+    [[nodiscard]] bool canCreateSession(GpuSessionType type) const;
+
+    /**
+     * @brief Register a session with the budget tracker
+     * @param sessionId Unique session identifier
+     * @param type Session type for budget estimation
+     */
+    void registerSession(const std::string& sessionId, GpuSessionType type);
+
+    /**
+     * @brief Unregister a session from the budget tracker
+     * @param sessionId Session to remove
+     */
+    void unregisterSession(const std::string& sessionId);
+
+    /**
+     * @brief Update the last-active timestamp for a session
+     * @param sessionId Session that had recent activity
+     */
+    void touchSession(const std::string& sessionId);
+
+    /**
+     * @brief Check GPU utilization and enforce budget thresholds
+     * @return The enforcement action that was triggered (or None)
+     */
+    EnforcementAction checkAndEnforce();
+
+    /**
+     * @brief Get current GPU memory metrics
+     */
+    [[nodiscard]] GpuMemoryMetrics metrics() const;
+
+    /**
+     * @brief Get the estimated VRAM budget for a session type
+     * @param type Session type
+     * @return Estimated VRAM in bytes
+     */
+    [[nodiscard]] uint64_t sessionBudget(GpuSessionType type) const;
+
+    /**
+     * @brief Get the ID of the least-recently-used session
+     * @return Session ID, or empty string if no sessions tracked
+     */
+    [[nodiscard]] std::string lruSessionId() const;
+
+    /**
+     * @brief Set callback invoked when a session is terminated by enforcement
+     */
+    void setTerminateCallback(SessionTerminateCallback callback);
+
+    /**
+     * @brief Get the current configuration
+     */
+    [[nodiscard]] const GpuBudgetConfig& config() const;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace dicom_viewer::services

--- a/server/src/api/api_server.cpp
+++ b/server/src/api/api_server.cpp
@@ -87,6 +87,10 @@ public:
         auth_ = auth;
     }
 
+    void setGpuBudgetManager(services::GpuMemoryBudgetManager* gpuBudget) {
+        gpuBudget_ = gpuBudget;
+    }
+
     void setPacsServices(services::DicomEchoSCU* echo,
                          services::DicomFindSCU* finder,
                          services::DicomMoveSCU* mover) {
@@ -170,7 +174,7 @@ private:
         registerFlowRoutes(app_.get(), sessions_, config_.corsOrigin);
         registerCardiacRoutes(app_.get(), sessions_, config_.corsOrigin);
         registerExportRoutes(app_.get(), sessions_, audit_, config_.exportDir, config_.corsOrigin);
-        registerHealthRoutes(app_.get(), config_.corsOrigin);
+        registerHealthRoutes(app_.get(), gpuBudget_, config_.corsOrigin);
 
         // ---- Catch-all 404 ----
         CROW_CATCHALL_ROUTE((*app_))([this](crow::response& res) {
@@ -193,6 +197,7 @@ private:
     services::DicomEchoSCU* echo_ = nullptr;
     services::DicomFindSCU* finder_ = nullptr;
     services::DicomMoveSCU* mover_ = nullptr;
+    services::GpuMemoryBudgetManager* gpuBudget_ = nullptr;
 };
 
 // ---- ApiServer public interface ----
@@ -216,6 +221,10 @@ uint16_t ApiServer::port() const { return impl_->port(); }
 
 void ApiServer::setAuthProvider(services::AuthProvider* auth) {
     impl_->setAuthProvider(auth);
+}
+
+void ApiServer::setGpuBudgetManager(services::GpuMemoryBudgetManager* gpuBudget) {
+    impl_->setGpuBudgetManager(gpuBudget);
 }
 
 void ApiServer::setPacsServices(services::DicomEchoSCU* echo,

--- a/server/src/api/api_server.hpp
+++ b/server/src/api/api_server.hpp
@@ -78,6 +78,7 @@
 
 namespace dicom_viewer::services {
 class AuthProvider;
+class GpuMemoryBudgetManager;
 class RenderSessionManager;
 class SessionTokenValidator;
 class AuditService;
@@ -151,6 +152,12 @@ public:
      * @note If nullptr, auth routes return 503 Service Unavailable
      */
     void setAuthProvider(services::AuthProvider* auth);
+
+    /**
+     * @brief Inject the GPU memory budget manager for health routes
+     * @param gpuBudget GpuMemoryBudgetManager instance (non-owning, may be nullptr)
+     */
+    void setGpuBudgetManager(services::GpuMemoryBudgetManager* gpuBudget);
 
     /**
      * @brief Inject PACS SCU services for PACS integration routes

--- a/server/src/api/health_routes.cpp
+++ b/server/src/api/health_routes.cpp
@@ -29,6 +29,8 @@
 
 #include "health_routes.hpp"
 
+#include "services/render/gpu_memory_budget_manager.hpp"
+
 #include <nlohmann/json.hpp>
 
 namespace dicom_viewer::server {
@@ -36,19 +38,34 @@ namespace dicom_viewer::server {
 using routes::addCorsHeaders;
 using nlohmann::json;
 
-void registerHealthRoutes(routes::App* app, const std::string& corsOrigin) {
+void registerHealthRoutes(routes::App* app,
+                          services::GpuMemoryBudgetManager* gpuBudget,
+                          const std::string& corsOrigin) {
     // GET /api/v1/health/gpu — GPU memory budget metrics
-    // Stub implementation until GpuBudgetManager is available (#503).
     CROW_ROUTE(*app, "/api/v1/health/gpu")(
-        [corsOrigin](const crow::request& /*req*/, crow::response& res) {
+        [corsOrigin, gpuBudget](const crow::request& /*req*/, crow::response& res) {
             addCorsHeaders(res, corsOrigin);
 
             json resp;
-            resp["available"] = false;
-            resp["budgetMb"]  = 0;
-            resp["usedMb"]    = 0;
-            resp["gpuCount"]  = 0;
-            resp["note"]      = "GPU Budget Manager not yet available (see issue #503)";
+
+            if (gpuBudget) {
+                auto m = gpuBudget->metrics();
+                resp["available"]      = m.available;
+                resp["gpuName"]        = m.gpuName;
+                resp["totalMb"]        = m.totalBytes / (1024 * 1024);
+                resp["usedMb"]         = m.usedBytes / (1024 * 1024);
+                resp["freeMb"]         = m.freeBytes / (1024 * 1024);
+                resp["utilization"]    = m.utilizationPercent;
+                resp["activeSessions"] = m.activeSessionCount;
+            } else {
+                resp["available"]      = false;
+                resp["gpuName"]        = "";
+                resp["totalMb"]        = 0;
+                resp["usedMb"]         = 0;
+                resp["freeMb"]         = 0;
+                resp["utilization"]    = 0.0;
+                resp["activeSessions"] = 0;
+            }
 
             res.code = 200;
             res.body = resp.dump();

--- a/server/src/api/health_routes.hpp
+++ b/server/src/api/health_routes.hpp
@@ -38,9 +38,6 @@
  * |--------|--------------------|--------|
  * | GET    | /api/v1/health/gpu | Public |
  *
- * @note GPU budget metrics are stubbed until GpuBudgetManager is
- *       implemented in issue #503.
- *
  * @author kcenon
  * @since 1.0.0
  */
@@ -51,13 +48,20 @@
 
 #include <string>
 
+namespace dicom_viewer::services {
+class GpuMemoryBudgetManager;
+} // namespace dicom_viewer::services
+
 namespace dicom_viewer::server {
 
 /**
  * @brief Register extended health check routes on the Crow application.
  * @param app        Crow application with JwtMiddleware (non-owning)
+ * @param gpuBudget  GPU memory budget manager (non-owning, may be nullptr)
  * @param corsOrigin CORS allowed-origin header value
  */
-void registerHealthRoutes(routes::App* app, const std::string& corsOrigin);
+void registerHealthRoutes(routes::App* app,
+                          services::GpuMemoryBudgetManager* gpuBudget,
+                          const std::string& corsOrigin);
 
 } // namespace dicom_viewer::server

--- a/src/services/render/gpu_memory_budget_manager.cpp
+++ b/src/services/render/gpu_memory_budget_manager.cpp
@@ -1,0 +1,372 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, kcenon
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "services/render/gpu_memory_budget_manager.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <mutex>
+#include <unordered_map>
+
+#ifdef __linux__
+#include <dlfcn.h>
+#endif
+
+namespace dicom_viewer::services {
+
+// ---------------------------------------------------------------------------
+// NVML type definitions (mirrors nvml.h without requiring the header)
+// ---------------------------------------------------------------------------
+using nvmlReturn_t = unsigned int;
+constexpr nvmlReturn_t NVML_SUCCESS = 0;
+
+struct nvmlMemory_t {
+    uint64_t total;
+    uint64_t free;
+    uint64_t used;
+};
+
+using nvmlDevice_t = void*;
+
+// NVML function pointer types
+using NvmlInit_t = nvmlReturn_t (*)();
+using NvmlShutdown_t = nvmlReturn_t (*)();
+using NvmlDeviceGetHandleByIndex_t = nvmlReturn_t (*)(unsigned int, nvmlDevice_t*);
+using NvmlDeviceGetMemoryInfo_t = nvmlReturn_t (*)(nvmlDevice_t, nvmlMemory_t*);
+using NvmlDeviceGetName_t = nvmlReturn_t (*)(nvmlDevice_t, char*, unsigned int);
+
+// ---------------------------------------------------------------------------
+// NVML dynamic loader
+// ---------------------------------------------------------------------------
+struct NvmlFunctions {
+    NvmlInit_t init = nullptr;
+    NvmlShutdown_t shutdown = nullptr;
+    NvmlDeviceGetHandleByIndex_t getHandleByIndex = nullptr;
+    NvmlDeviceGetMemoryInfo_t getMemoryInfo = nullptr;
+    NvmlDeviceGetName_t getName = nullptr;
+    void* handle = nullptr;
+
+    bool load() {
+#ifdef __linux__
+        handle = dlopen("libnvidia-ml.so.1", RTLD_LAZY);
+        if (!handle) {
+            return false;
+        }
+
+        init = reinterpret_cast<NvmlInit_t>(dlsym(handle, "nvmlInit_v2"));
+        shutdown = reinterpret_cast<NvmlShutdown_t>(dlsym(handle, "nvmlShutdown"));
+        getHandleByIndex = reinterpret_cast<NvmlDeviceGetHandleByIndex_t>(
+            dlsym(handle, "nvmlDeviceGetHandleByIndex_v2"));
+        getMemoryInfo = reinterpret_cast<NvmlDeviceGetMemoryInfo_t>(
+            dlsym(handle, "nvmlDeviceGetMemoryInfo"));
+        getName = reinterpret_cast<NvmlDeviceGetName_t>(
+            dlsym(handle, "nvmlDeviceGetName"));
+
+        if (!init || !shutdown || !getHandleByIndex || !getMemoryInfo || !getName) {
+            unload();
+            return false;
+        }
+
+        if (init() != NVML_SUCCESS) {
+            unload();
+            return false;
+        }
+
+        return true;
+#else
+        return false;
+#endif
+    }
+
+    void unload() {
+#ifdef __linux__
+        if (handle) {
+            if (shutdown) {
+                shutdown();
+            }
+            dlclose(handle);
+            handle = nullptr;
+        }
+#endif
+        init = nullptr;
+        shutdown = nullptr;
+        getHandleByIndex = nullptr;
+        getMemoryInfo = nullptr;
+        getName = nullptr;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Impl
+// ---------------------------------------------------------------------------
+class GpuMemoryBudgetManager::Impl {
+public:
+    struct SessionEntry {
+        GpuSessionType type;
+        std::chrono::steady_clock::time_point lastActive;
+    };
+
+    explicit Impl(const GpuBudgetConfig& config)
+        : config_(config)
+    {
+        available_ = nvml_.load();
+
+        if (available_) {
+            nvmlReturn_t ret = nvml_.getHandleByIndex(config_.deviceIndex, &device_);
+            if (ret != NVML_SUCCESS) {
+                available_ = false;
+                nvml_.unload();
+            }
+        }
+    }
+
+    ~Impl() {
+        if (available_) {
+            nvml_.unload();
+        }
+    }
+
+    bool isAvailable() const {
+        std::lock_guard lock(mutex_);
+        return available_;
+    }
+
+    bool canCreateSession(GpuSessionType type) const {
+        std::lock_guard lock(mutex_);
+
+        if (!available_) {
+            return true; // Permissive when NVML unavailable
+        }
+
+        nvmlMemory_t memInfo{};
+        if (nvml_.getMemoryInfo(device_, &memInfo) != NVML_SUCCESS) {
+            return true;
+        }
+
+        uint64_t budgetNeeded = sessionBudgetLocked(type);
+        uint64_t projectedUsed = memInfo.used + budgetNeeded;
+        double projectedUtil = (static_cast<double>(projectedUsed) / memInfo.total) * 100.0;
+
+        return projectedUtil < config_.rejectThreshold;
+    }
+
+    void registerSession(const std::string& sessionId, GpuSessionType type) {
+        std::lock_guard lock(mutex_);
+
+        SessionEntry entry;
+        entry.type = type;
+        entry.lastActive = std::chrono::steady_clock::now();
+        sessions_[sessionId] = entry;
+    }
+
+    void unregisterSession(const std::string& sessionId) {
+        std::lock_guard lock(mutex_);
+        sessions_.erase(sessionId);
+    }
+
+    void touchSession(const std::string& sessionId) {
+        std::lock_guard lock(mutex_);
+        auto it = sessions_.find(sessionId);
+        if (it != sessions_.end()) {
+            it->second.lastActive = std::chrono::steady_clock::now();
+        }
+    }
+
+    EnforcementAction checkAndEnforce() {
+        std::lock_guard lock(mutex_);
+
+        if (!available_) {
+            return EnforcementAction::None;
+        }
+
+        nvmlMemory_t memInfo{};
+        if (nvml_.getMemoryInfo(device_, &memInfo) != NVML_SUCCESS) {
+            return EnforcementAction::None;
+        }
+
+        double util = (static_cast<double>(memInfo.used) / memInfo.total) * 100.0;
+
+        if (util >= config_.terminateThreshold) {
+            // Terminate LRU idle session
+            auto lru = lruSessionIdLocked();
+            if (!lru.empty() && terminateCallback_) {
+                terminateCallback_(lru);
+                sessions_.erase(lru);
+            }
+            return EnforcementAction::TerminateLRU;
+        }
+
+        if (util >= config_.degradeThreshold) {
+            return EnforcementAction::DegradeQuality;
+        }
+
+        if (util >= config_.rejectThreshold) {
+            return EnforcementAction::RejectNewSessions;
+        }
+
+        return EnforcementAction::None;
+    }
+
+    GpuMemoryMetrics metrics() const {
+        std::lock_guard lock(mutex_);
+
+        GpuMemoryMetrics m;
+        m.available = available_;
+        m.activeSessionCount = static_cast<uint32_t>(sessions_.size());
+
+        if (!available_) {
+            return m;
+        }
+
+        // Query GPU name
+        char name[96] = {};
+        if (nvml_.getName(device_, name, sizeof(name)) == NVML_SUCCESS) {
+            m.gpuName = name;
+        }
+
+        // Query memory info
+        nvmlMemory_t memInfo{};
+        if (nvml_.getMemoryInfo(device_, &memInfo) == NVML_SUCCESS) {
+            m.totalBytes = memInfo.total;
+            m.usedBytes = memInfo.used;
+            m.freeBytes = memInfo.free;
+            m.utilizationPercent =
+                (static_cast<double>(memInfo.used) / memInfo.total) * 100.0;
+        }
+
+        return m;
+    }
+
+    uint64_t sessionBudget(GpuSessionType type) const {
+        std::lock_guard lock(mutex_);
+        return sessionBudgetLocked(type);
+    }
+
+    std::string lruSessionId() const {
+        std::lock_guard lock(mutex_);
+        return lruSessionIdLocked();
+    }
+
+    void setTerminateCallback(SessionTerminateCallback callback) {
+        std::lock_guard lock(mutex_);
+        terminateCallback_ = std::move(callback);
+    }
+
+    const GpuBudgetConfig& config() const { return config_; }
+
+private:
+    uint64_t sessionBudgetLocked(GpuSessionType type) const {
+        switch (type) {
+            case GpuSessionType::CT:      return config_.ctSessionBudgetBytes;
+            case GpuSessionType::Flow4D:  return config_.flow4dSessionBudgetBytes;
+            case GpuSessionType::Generic: return config_.genericSessionBudgetBytes;
+        }
+        return config_.genericSessionBudgetBytes;
+    }
+
+    std::string lruSessionIdLocked() const {
+        if (sessions_.empty()) {
+            return {};
+        }
+
+        auto oldest = sessions_.begin();
+        for (auto it = sessions_.begin(); it != sessions_.end(); ++it) {
+            if (it->second.lastActive < oldest->second.lastActive) {
+                oldest = it;
+            }
+        }
+        return oldest->first;
+    }
+
+    GpuBudgetConfig config_;
+    mutable NvmlFunctions nvml_;
+    mutable nvmlDevice_t device_ = nullptr;
+    bool available_ = false;
+    std::unordered_map<std::string, SessionEntry> sessions_;
+    SessionTerminateCallback terminateCallback_;
+    mutable std::mutex mutex_;
+};
+
+// ---------------------------------------------------------------------------
+// Public API delegation
+// ---------------------------------------------------------------------------
+GpuMemoryBudgetManager::GpuMemoryBudgetManager(const GpuBudgetConfig& config)
+    : impl_(std::make_unique<Impl>(config))
+{
+}
+
+GpuMemoryBudgetManager::~GpuMemoryBudgetManager() = default;
+
+bool GpuMemoryBudgetManager::isAvailable() const {
+    return impl_->isAvailable();
+}
+
+bool GpuMemoryBudgetManager::canCreateSession(GpuSessionType type) const {
+    return impl_->canCreateSession(type);
+}
+
+void GpuMemoryBudgetManager::registerSession(
+    const std::string& sessionId, GpuSessionType type) {
+    impl_->registerSession(sessionId, type);
+}
+
+void GpuMemoryBudgetManager::unregisterSession(const std::string& sessionId) {
+    impl_->unregisterSession(sessionId);
+}
+
+void GpuMemoryBudgetManager::touchSession(const std::string& sessionId) {
+    impl_->touchSession(sessionId);
+}
+
+EnforcementAction GpuMemoryBudgetManager::checkAndEnforce() {
+    return impl_->checkAndEnforce();
+}
+
+GpuMemoryMetrics GpuMemoryBudgetManager::metrics() const {
+    return impl_->metrics();
+}
+
+uint64_t GpuMemoryBudgetManager::sessionBudget(GpuSessionType type) const {
+    return impl_->sessionBudget(type);
+}
+
+std::string GpuMemoryBudgetManager::lruSessionId() const {
+    return impl_->lruSessionId();
+}
+
+void GpuMemoryBudgetManager::setTerminateCallback(
+    SessionTerminateCallback callback) {
+    impl_->setTerminateCallback(std::move(callback));
+}
+
+const GpuBudgetConfig& GpuMemoryBudgetManager::config() const {
+    return impl_->config();
+}
+
+} // namespace dicom_viewer::services

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2156,6 +2156,23 @@ target_include_directories(adaptive_quality_controller_test PRIVATE
 
 gtest_discover_tests(adaptive_quality_controller_test DISCOVERY_TIMEOUT 60)
 
+# Unit tests for GpuMemoryBudgetManager
+add_executable(gpu_memory_budget_manager_test
+    unit/gpu_memory_budget_manager_test.cpp
+)
+
+target_link_libraries(gpu_memory_budget_manager_test PRIVATE
+    render_service
+    GTest::gtest
+    GTest::gtest_main
+)
+
+target_include_directories(gpu_memory_budget_manager_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(gpu_memory_budget_manager_test DISCOVERY_TIMEOUT 60)
+
 # Unit tests for WebSocketFrameStreamer
 add_executable(websocket_frame_streamer_test
     unit/websocket_frame_streamer_test.cpp

--- a/tests/unit/gpu_memory_budget_manager_test.cpp
+++ b/tests/unit/gpu_memory_budget_manager_test.cpp
@@ -1,0 +1,282 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, kcenon
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include "services/render/gpu_memory_budget_manager.hpp"
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+using namespace dicom_viewer::services;
+
+// =============================================================================
+// Default construction and configuration
+// =============================================================================
+
+TEST(GpuMemoryBudgetManagerTest, DefaultConstruction) {
+    GpuMemoryBudgetManager manager;
+    const auto& cfg = manager.config();
+    EXPECT_DOUBLE_EQ(cfg.rejectThreshold, 85.0);
+    EXPECT_DOUBLE_EQ(cfg.degradeThreshold, 90.0);
+    EXPECT_DOUBLE_EQ(cfg.terminateThreshold, 95.0);
+    EXPECT_EQ(cfg.deviceIndex, 0u);
+}
+
+TEST(GpuMemoryBudgetManagerTest, CustomConfig) {
+    GpuBudgetConfig config;
+    config.rejectThreshold = 80.0;
+    config.degradeThreshold = 88.0;
+    config.terminateThreshold = 93.0;
+    config.deviceIndex = 1;
+
+    GpuMemoryBudgetManager manager(config);
+    const auto& cfg = manager.config();
+    EXPECT_DOUBLE_EQ(cfg.rejectThreshold, 80.0);
+    EXPECT_DOUBLE_EQ(cfg.degradeThreshold, 88.0);
+    EXPECT_DOUBLE_EQ(cfg.terminateThreshold, 93.0);
+    EXPECT_EQ(cfg.deviceIndex, 1u);
+}
+
+// =============================================================================
+// Session budget values
+// =============================================================================
+
+TEST(GpuMemoryBudgetManagerTest, SessionBudgetCT) {
+    GpuMemoryBudgetManager manager;
+    uint64_t expected = 2ULL * 1024 * 1024 * 1024; // 2 GB
+    EXPECT_EQ(manager.sessionBudget(GpuSessionType::CT), expected);
+}
+
+TEST(GpuMemoryBudgetManagerTest, SessionBudgetFlow4D) {
+    GpuMemoryBudgetManager manager;
+    uint64_t expected = 3584ULL * 1024 * 1024; // 3.5 GB
+    EXPECT_EQ(manager.sessionBudget(GpuSessionType::Flow4D), expected);
+}
+
+TEST(GpuMemoryBudgetManagerTest, SessionBudgetGeneric) {
+    GpuMemoryBudgetManager manager;
+    uint64_t expected = 1ULL * 1024 * 1024 * 1024; // 1 GB
+    EXPECT_EQ(manager.sessionBudget(GpuSessionType::Generic), expected);
+}
+
+TEST(GpuMemoryBudgetManagerTest, CustomSessionBudget) {
+    GpuBudgetConfig config;
+    config.ctSessionBudgetBytes = 4ULL * 1024 * 1024 * 1024;
+    GpuMemoryBudgetManager manager(config);
+    EXPECT_EQ(manager.sessionBudget(GpuSessionType::CT),
+              4ULL * 1024 * 1024 * 1024);
+}
+
+// =============================================================================
+// Graceful fallback when NVML is unavailable
+// =============================================================================
+
+TEST(GpuMemoryBudgetManagerTest, FallbackAvailability) {
+    GpuMemoryBudgetManager manager;
+    // On macOS and CI (non-NVIDIA), NVML should be unavailable
+#ifndef __linux__
+    EXPECT_FALSE(manager.isAvailable());
+#endif
+    // On any platform: should not crash
+}
+
+TEST(GpuMemoryBudgetManagerTest, FallbackCanCreateSession) {
+    GpuMemoryBudgetManager manager;
+    if (!manager.isAvailable()) {
+        // When NVML unavailable, all session types should be allowed
+        EXPECT_TRUE(manager.canCreateSession(GpuSessionType::CT));
+        EXPECT_TRUE(manager.canCreateSession(GpuSessionType::Flow4D));
+        EXPECT_TRUE(manager.canCreateSession(GpuSessionType::Generic));
+    }
+}
+
+TEST(GpuMemoryBudgetManagerTest, FallbackCheckAndEnforce) {
+    GpuMemoryBudgetManager manager;
+    if (!manager.isAvailable()) {
+        EXPECT_EQ(manager.checkAndEnforce(), EnforcementAction::None);
+    }
+}
+
+TEST(GpuMemoryBudgetManagerTest, FallbackMetrics) {
+    GpuMemoryBudgetManager manager;
+    if (!manager.isAvailable()) {
+        auto m = manager.metrics();
+        EXPECT_FALSE(m.available);
+        EXPECT_EQ(m.totalBytes, 0u);
+        EXPECT_EQ(m.usedBytes, 0u);
+        EXPECT_EQ(m.freeBytes, 0u);
+        EXPECT_DOUBLE_EQ(m.utilizationPercent, 0.0);
+        EXPECT_TRUE(m.gpuName.empty());
+    }
+}
+
+// =============================================================================
+// Session registration and tracking
+// =============================================================================
+
+TEST(GpuMemoryBudgetManagerTest, RegisterSession) {
+    GpuMemoryBudgetManager manager;
+    manager.registerSession("session-1", GpuSessionType::CT);
+
+    auto m = manager.metrics();
+    EXPECT_EQ(m.activeSessionCount, 1u);
+}
+
+TEST(GpuMemoryBudgetManagerTest, UnregisterSession) {
+    GpuMemoryBudgetManager manager;
+    manager.registerSession("session-1", GpuSessionType::CT);
+    manager.registerSession("session-2", GpuSessionType::Flow4D);
+    EXPECT_EQ(manager.metrics().activeSessionCount, 2u);
+
+    manager.unregisterSession("session-1");
+    EXPECT_EQ(manager.metrics().activeSessionCount, 1u);
+}
+
+TEST(GpuMemoryBudgetManagerTest, UnregisterNonexistentSession) {
+    GpuMemoryBudgetManager manager;
+    // Should not crash
+    manager.unregisterSession("nonexistent");
+    EXPECT_EQ(manager.metrics().activeSessionCount, 0u);
+}
+
+TEST(GpuMemoryBudgetManagerTest, MultipleSessions) {
+    GpuMemoryBudgetManager manager;
+    manager.registerSession("s1", GpuSessionType::CT);
+    manager.registerSession("s2", GpuSessionType::Flow4D);
+    manager.registerSession("s3", GpuSessionType::Generic);
+
+    EXPECT_EQ(manager.metrics().activeSessionCount, 3u);
+
+    manager.unregisterSession("s2");
+    EXPECT_EQ(manager.metrics().activeSessionCount, 2u);
+
+    manager.unregisterSession("s1");
+    manager.unregisterSession("s3");
+    EXPECT_EQ(manager.metrics().activeSessionCount, 0u);
+}
+
+// =============================================================================
+// LRU session tracking
+// =============================================================================
+
+TEST(GpuMemoryBudgetManagerTest, LruSessionIdEmpty) {
+    GpuMemoryBudgetManager manager;
+    EXPECT_TRUE(manager.lruSessionId().empty());
+}
+
+TEST(GpuMemoryBudgetManagerTest, LruSessionIdSingleSession) {
+    GpuMemoryBudgetManager manager;
+    manager.registerSession("only-one", GpuSessionType::CT);
+    EXPECT_EQ(manager.lruSessionId(), "only-one");
+}
+
+TEST(GpuMemoryBudgetManagerTest, LruSessionIdOrderedByActivity) {
+    GpuMemoryBudgetManager manager;
+
+    manager.registerSession("old", GpuSessionType::CT);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    manager.registerSession("new", GpuSessionType::CT);
+
+    // "old" was registered first, so it should be LRU
+    EXPECT_EQ(manager.lruSessionId(), "old");
+}
+
+TEST(GpuMemoryBudgetManagerTest, TouchSessionUpdatesLru) {
+    GpuMemoryBudgetManager manager;
+
+    manager.registerSession("first", GpuSessionType::CT);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    manager.registerSession("second", GpuSessionType::CT);
+
+    // Touch "first" to make it recent
+    manager.touchSession("first");
+
+    // Now "second" should be LRU (older last-active time)
+    EXPECT_EQ(manager.lruSessionId(), "second");
+}
+
+// =============================================================================
+// Terminate callback
+// =============================================================================
+
+TEST(GpuMemoryBudgetManagerTest, TerminateCallbackNotCalledWithoutNvml) {
+    GpuMemoryBudgetManager manager;
+    bool called = false;
+    manager.setTerminateCallback([&](const std::string&) {
+        called = true;
+    });
+
+    if (!manager.isAvailable()) {
+        manager.checkAndEnforce();
+        EXPECT_FALSE(called);
+    }
+}
+
+// =============================================================================
+// EnforcementAction enum distinctness
+// =============================================================================
+
+TEST(GpuMemoryBudgetManagerTest, EnforcementActionEnumValues) {
+    EXPECT_NE(static_cast<int>(EnforcementAction::None),
+              static_cast<int>(EnforcementAction::RejectNewSessions));
+    EXPECT_NE(static_cast<int>(EnforcementAction::RejectNewSessions),
+              static_cast<int>(EnforcementAction::DegradeQuality));
+    EXPECT_NE(static_cast<int>(EnforcementAction::DegradeQuality),
+              static_cast<int>(EnforcementAction::TerminateLRU));
+}
+
+// =============================================================================
+// GpuSessionType enum distinctness
+// =============================================================================
+
+TEST(GpuMemoryBudgetManagerTest, GpuSessionTypeEnumValues) {
+    EXPECT_NE(static_cast<int>(GpuSessionType::CT),
+              static_cast<int>(GpuSessionType::Flow4D));
+    EXPECT_NE(static_cast<int>(GpuSessionType::Flow4D),
+              static_cast<int>(GpuSessionType::Generic));
+    EXPECT_NE(static_cast<int>(GpuSessionType::CT),
+              static_cast<int>(GpuSessionType::Generic));
+}
+
+// =============================================================================
+// GpuMemoryMetrics default values
+// =============================================================================
+
+TEST(GpuMemoryBudgetManagerTest, MetricsDefaultValues) {
+    GpuMemoryMetrics m;
+    EXPECT_FALSE(m.available);
+    EXPECT_TRUE(m.gpuName.empty());
+    EXPECT_EQ(m.totalBytes, 0u);
+    EXPECT_EQ(m.usedBytes, 0u);
+    EXPECT_EQ(m.freeBytes, 0u);
+    EXPECT_DOUBLE_EQ(m.utilizationPercent, 0.0);
+    EXPECT_EQ(m.activeSessionCount, 0u);
+}


### PR DESCRIPTION
## Summary
- Implement `GpuMemoryBudgetManager` with dynamic NVML loading for GPU VRAM monitoring
- Enforce three utilization tiers: 85% reject new sessions, 90% degrade quality, 95% terminate LRU
- Track per-session VRAM budgets (CT ~2GB, 4D Flow ~3.5GB, Generic ~1GB)
- Graceful fallback when NVML unavailable (permissive mode on macOS/non-NVIDIA hosts)
- Wire real GPU metrics into `/api/v1/health/gpu` endpoint, replacing the previous stub

Closes #503

## What
| File | Purpose |
|------|---------|
| `include/services/render/gpu_memory_budget_manager.hpp` | Public API: session types, enforcement actions, metrics, budget config |
| `src/services/render/gpu_memory_budget_manager.cpp` | NVML dynamic loading via dlopen, enforcement logic, LRU tracking |
| `tests/unit/gpu_memory_budget_manager_test.cpp` | 20 unit tests: fallback behavior, session tracking, LRU, config |
| `server/src/api/health_routes.*` | `/api/v1/health/gpu` now returns real metrics from budget manager |
| `server/src/api/api_server.*` | `setGpuBudgetManager()` injection point for health routes |
| `CMakeLists.txt` | Add source to render_service, link `${CMAKE_DL_LIBS}` |
| `tests/CMakeLists.txt` | Add test executable |

## Why
GPU memory exhaustion can crash the rendering server when too many concurrent sessions
allocate VRAM. This budget manager provides proactive monitoring and enforcement to
maintain server stability under load.

## How

### NVML Dynamic Loading
- Uses `dlopen("libnvidia-ml.so.1")` + `dlsym()` at runtime, no build-time NVML dependency
- Single binary works on both GPU (Linux + NVIDIA) and non-GPU (macOS) hosts
- Falls back to permissive mode when NVML unavailable

### Enforcement Tiers
| Utilization | Action |
|-------------|--------|
| < 85% | None |
| >= 85% | Reject new session creation |
| >= 90% | Auto-degrade quality on all sessions |
| >= 95% | Force-terminate least-recently-used idle session |

### Architecture
- PImpl pattern consistent with existing render service components
- Thread-safe (internal mutex on all public methods)
- Callback-based session termination (`SessionTerminateCallback`)

## Test Plan
- [x] Unit tests cover fallback behavior, session registration/unregistration, LRU tracking, config
- [ ] CI build and test pass on Ubuntu
- [ ] Integration testing with NVML on GPU-equipped server (future)