### PR TITLE
feat(ui): implement MeasurementPanel for measurement lifecycle management (#551)

### DIFF
--- a/client/src/components/layout/SidePanel.tsx
+++ b/client/src/components/layout/SidePanel.tsx
@@ -6,6 +6,7 @@ import { SegmentationPanel } from '@/components/panels/SegmentationPanel'
 import { FlowToolPanel } from '@/components/panels/FlowToolPanel'
 import { OverlayControlPanel } from '@/components/panels/OverlayControlPanel'
 import { ReportPanel } from '@/components/panels/ReportPanel'
+import { MeasurementPanel } from '@/components/panels/MeasurementPanel'
 
 type ActivePanel = NonNullable<ReturnType<typeof useUiStore.getState>['activePanel']>
 
@@ -25,12 +26,7 @@ function ActivePanelContent({ activePanel }: { activePanel: ActivePanel }) {
     case 'flow': return <FlowToolPanel />
     case 'overlay': return <OverlayControlPanel />
     case 'report': return <ReportPanel />
-    case 'measurement':
-      return (
-        <div style={{ color: '#555', fontSize: '12px', textAlign: 'center', marginTop: '8px' }}>
-          Use the viewport tools to add measurements
-        </div>
-      )
+    case 'measurement': return <MeasurementPanel />
   }
 }
 

--- a/client/src/components/panels/MeasurementPanel.tsx
+++ b/client/src/components/panels/MeasurementPanel.tsx
@@ -1,0 +1,246 @@
+// MeasurementPanel provides tool selection, measurement list, and lifecycle controls.
+
+import { useState } from 'react'
+import { useMeasurementStore } from '@/stores/measurementStore'
+import type { MeasurementTool, Measurement } from '@/types/models'
+
+const TOOLS: { id: Exclude<MeasurementTool, 'none'>; label: string; color: string }[] = [
+  { id: 'length', label: 'Length', color: '#ffeb3b' },
+  { id: 'angle', label: 'Angle', color: '#4fc3f7' },
+  { id: 'ellipse', label: 'Ellipse', color: '#a5d6a7' },
+  { id: 'rectangle', label: 'Rect', color: '#ce93d8' },
+  { id: 'arrow', label: 'Arrow', color: '#ff8a65' },
+]
+
+const TOOL_COLORS: Record<string, string> = {
+  length: '#ffeb3b',
+  angle: '#4fc3f7',
+  ellipse: '#a5d6a7',
+  rectangle: '#ce93d8',
+  arrow: '#ff8a65',
+}
+
+function formatValue(m: Measurement): string {
+  if (m.type === 'arrow') return m.label ?? ''
+  if (m.value === undefined) return ''
+  if (m.type === 'angle') return `${m.value.toFixed(1)}\u00B0`
+  return `${m.value.toFixed(2)} ${m.unit ?? ''}`
+}
+
+function MeasurementRow({ m }: { m: Measurement }) {
+  const selectedId = useMeasurementStore((s) => s.selectedMeasurementId)
+  const selectMeasurement = useMeasurementStore((s) => s.selectMeasurement)
+  const updateMeasurement = useMeasurementStore((s) => s.updateMeasurement)
+  const removeMeasurement = useMeasurementStore((s) => s.removeMeasurement)
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(m.label ?? '')
+
+  const isSelected = selectedId === m.id
+  const color = TOOL_COLORS[m.type] ?? '#aaa'
+
+  const commitLabel = () => {
+    updateMeasurement(m.id, { label: draft || undefined })
+    setEditing(false)
+  }
+
+  return (
+    <div
+      onClick={() => selectMeasurement(isSelected ? null : m.id)}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '6px',
+        padding: '4px 4px',
+        borderBottom: '1px solid #2a2a2a',
+        background: isSelected ? '#2a3a4a' : 'transparent',
+        cursor: 'pointer',
+        borderRadius: '2px',
+      }}
+    >
+      {/* Type color indicator */}
+      <div
+        style={{
+          width: '10px',
+          height: '10px',
+          borderRadius: '2px',
+          background: color,
+          flexShrink: 0,
+        }}
+      />
+
+      {/* Value */}
+      <span
+        style={{
+          flex: 1,
+          fontSize: '12px',
+          color: '#ccc',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {formatValue(m) || m.type}
+      </span>
+
+      {/* Editable label */}
+      {editing ? (
+        <input
+          autoFocus
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commitLabel}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') commitLabel()
+            if (e.key === 'Escape') setEditing(false)
+          }}
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            width: '60px',
+            fontSize: '11px',
+            background: '#1a1a1a',
+            border: '1px solid #555',
+            borderRadius: '2px',
+            color: '#ccc',
+            padding: '1px 3px',
+          }}
+        />
+      ) : (
+        <span
+          onDoubleClick={(e) => {
+            e.stopPropagation()
+            setDraft(m.label ?? '')
+            setEditing(true)
+          }}
+          style={{
+            fontSize: '11px',
+            color: '#777',
+            maxWidth: '60px',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+          title="Double-click to edit label"
+        >
+          {m.label || '—'}
+        </span>
+      )}
+
+      {/* Delete */}
+      <button
+        onClick={(e) => {
+          e.stopPropagation()
+          removeMeasurement(m.id)
+        }}
+        style={{ ...chipStyle, padding: '1px 5px', color: '#ef9a9a' }}
+      >
+        ✕
+      </button>
+    </div>
+  )
+}
+
+export function MeasurementPanel() {
+  const activeTool = useMeasurementStore((s) => s.activeTool)
+  const setActiveTool = useMeasurementStore((s) => s.setActiveTool)
+  const measurements = useMeasurementStore((s) => s.measurements)
+  const clearAll = useMeasurementStore((s) => s.clearAll)
+  const [confirmClear, setConfirmClear] = useState(false)
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+      {/* Tool selector */}
+      <div>
+        <div style={sectionLabel}>Tool</div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginTop: '4px' }}>
+          {TOOLS.map(({ id, label, color }) => (
+            <button
+              key={id}
+              onClick={() => setActiveTool(activeTool === id ? 'none' : id)}
+              style={{
+                ...chipStyle,
+                background: activeTool === id ? color : '#2a2a2a',
+                color: activeTool === id ? '#000' : '#aaa',
+                borderColor: activeTool === id ? color : '#444',
+              }}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Measurement list */}
+      <div>
+        <div style={sectionLabel}>Measurements ({measurements.length})</div>
+        <div style={{ marginTop: '4px' }}>
+          {measurements.map((m) => (
+            <MeasurementRow key={m.id} m={m} />
+          ))}
+          {measurements.length === 0 && (
+            <div style={{ color: '#555', fontSize: '12px', textAlign: 'center', marginTop: '8px' }}>
+              No measurements. Select a tool and click on the viewport.
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Clear All */}
+      {measurements.length > 0 && (
+        confirmClear ? (
+          <div style={{ display: 'flex', gap: '4px' }}>
+            <button
+              onClick={() => {
+                clearAll()
+                setConfirmClear(false)
+              }}
+              style={{ ...actionButtonStyle, color: '#ef9a9a', flex: 1 }}
+            >
+              Confirm
+            </button>
+            <button
+              onClick={() => setConfirmClear(false)}
+              style={{ ...actionButtonStyle, flex: 1 }}
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={() => setConfirmClear(true)}
+            style={actionButtonStyle}
+          >
+            Clear All
+          </button>
+        )
+      )}
+    </div>
+  )
+}
+
+const sectionLabel: React.CSSProperties = {
+  fontSize: '11px',
+  color: '#666',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+}
+
+const chipStyle: React.CSSProperties = {
+  background: '#2a2a2a',
+  border: '1px solid #444',
+  borderRadius: '3px',
+  color: '#aaa',
+  cursor: 'pointer',
+  fontSize: '12px',
+  padding: '3px 8px',
+}
+
+const actionButtonStyle: React.CSSProperties = {
+  background: '#2a2a2a',
+  border: '1px solid #444',
+  borderRadius: '3px',
+  color: '#ccc',
+  cursor: 'pointer',
+  fontSize: '12px',
+  padding: '4px 8px',
+  width: '100%',
+}

--- a/client/src/components/viewport/MeasurementOverlay.tsx
+++ b/client/src/components/viewport/MeasurementOverlay.tsx
@@ -10,8 +10,9 @@ interface Props {
   height: number
 }
 
-function renderMeasurement(m: Measurement) {
+function renderMeasurement(m: Measurement, isSelected: boolean) {
   const { points } = m
+  const sw = isSelected ? 3 : 1.5
 
   switch (m.type) {
     case 'length': {
@@ -20,7 +21,7 @@ function renderMeasurement(m: Measurement) {
       const mx = (p0.x + p1.x) / 2
       const my = (p0.y + p1.y) / 2
       return (
-        <g key={m.id} stroke="#ffeb3b" strokeWidth={1.5} fill="none">
+        <g key={m.id} stroke="#ffeb3b" strokeWidth={sw} fill="none">
           <line x1={p0.x} y1={p0.y} x2={p1.x} y2={p1.y} />
           {m.value !== undefined && (
             <text x={mx} y={my - 4} fill="#ffeb3b" fontSize={12} stroke="none">
@@ -39,7 +40,7 @@ function renderMeasurement(m: Measurement) {
         { x: number; y: number }
       ]
       return (
-        <g key={m.id} stroke="#4fc3f7" strokeWidth={1.5} fill="none">
+        <g key={m.id} stroke="#4fc3f7" strokeWidth={sw} fill="none">
           <line x1={a.x} y1={a.y} x2={b.x} y2={b.y} />
           <line x1={b.x} y1={b.y} x2={c.x} y2={c.y} />
           {m.value !== undefined && (
@@ -59,7 +60,7 @@ function renderMeasurement(m: Measurement) {
       const rx = Math.abs(end.x - start.x) / 2
       const ry = Math.abs(end.y - start.y) / 2
       return (
-        <g key={m.id} stroke="#a5d6a7" strokeWidth={1.5} fill="none">
+        <g key={m.id} stroke="#a5d6a7" strokeWidth={sw} fill="none">
           <ellipse cx={cx} cy={cy} rx={rx} ry={ry} />
           {m.value !== undefined && (
             <text x={cx} y={cy - ry - 4} fill="#a5d6a7" fontSize={12} stroke="none">
@@ -76,7 +77,7 @@ function renderMeasurement(m: Measurement) {
       const w = br.x - tl.x
       const h = br.y - tl.y
       return (
-        <g key={m.id} stroke="#ce93d8" strokeWidth={1.5} fill="none">
+        <g key={m.id} stroke="#ce93d8" strokeWidth={sw} fill="none">
           <rect x={tl.x} y={tl.y} width={w} height={h} />
           {m.value !== undefined && (
             <text x={tl.x} y={tl.y - 4} fill="#ce93d8" fontSize={12} stroke="none">
@@ -98,7 +99,7 @@ function renderMeasurement(m: Measurement) {
       const ax2 = to.x - arrowLen * Math.cos(angle + arrowAngle)
       const ay2 = to.y - arrowLen * Math.sin(angle + arrowAngle)
       return (
-        <g key={m.id} stroke="#ff8a65" strokeWidth={1.5} fill="none">
+        <g key={m.id} stroke="#ff8a65" strokeWidth={sw} fill="none">
           <line x1={from.x} y1={from.y} x2={to.x} y2={to.y} />
           <polyline points={`${ax1},${ay1} ${to.x},${to.y} ${ax2},${ay2}`} />
           {m.label !== undefined && (
@@ -119,6 +120,7 @@ export function MeasurementOverlay({ channelId, width, height }: Props) {
   const measurements = useMeasurementStore((s) =>
     s.measurements.filter((m) => m.channelId === channelId)
   )
+  const selectedId = useMeasurementStore((s) => s.selectedMeasurementId)
 
   if (measurements.length === 0) return null
 
@@ -136,7 +138,7 @@ export function MeasurementOverlay({ channelId, width, height }: Props) {
       viewBox={`0 0 ${width} ${height}`}
       preserveAspectRatio="none"
     >
-      {measurements.map(renderMeasurement)}
+      {measurements.map((m) => renderMeasurement(m, m.id === selectedId))}
     </svg>
   )
 }


### PR DESCRIPTION
## Summary
- Implement `MeasurementPanel` component with tool selector bar (length, angle, ellipse, rect, arrow) and scrollable measurement list
- Replace static placeholder text in SidePanel "Measure" tab with interactive measurement management UI
- Add selection highlight in `MeasurementOverlay` for selected measurements (thicker stroke)

## Related Issues
Closes #551

## What Changed
| File | Change |
|------|--------|
| `client/src/components/panels/MeasurementPanel.tsx` | New: full measurement lifecycle panel |
| `client/src/components/layout/SidePanel.tsx` | Replace static text with MeasurementPanel |
| `client/src/components/viewport/MeasurementOverlay.tsx` | Add selection highlight (strokeWidth=3) |

## Test plan
- [ ] Verify MeasurementPanel renders in SidePanel "Measure" tab
- [ ] Verify 5 tool buttons with correct color coding
- [ ] Verify measurement list displays type, value, unit
- [ ] Verify click-to-select highlights measurement in overlay
- [ ] Verify delete and "Clear All" functionality
- [ ] Verify inline label editing via double-click
- [ ] Verify empty state message when no measurements exist